### PR TITLE
fix: improve Git tree message clarity

### DIFF
--- a/application/services/RealtimeGuardService.js
+++ b/application/services/RealtimeGuardService.js
@@ -294,7 +294,11 @@ class RealtimeGuardService {
     this.lastDirtyTreeNotification = 0;
     this.removeDirtyTreeMarker();
     this.appendDebugLog(`DIRTY_TREE_CLEAR|${state.stagedCount}|${state.workingCount}|${state.uniqueCount}`);
-    this.notify('Git tree is clean. You can continue.', 'info');
+    const totalFiles = state.uniqueCount || 0;
+    const message = totalFiles > 0
+      ? `Git tree within limits (${totalFiles} files, thresholds OK). You can continue.`
+      : 'Git tree is clean. You can continue.';
+    this.notify(message, 'info');
   }
 
   persistDirtyTreeState(state, limits, notifiedAt, active = true) {


### PR DESCRIPTION
## Summary

Improves the 'Git tree is clean' notification message to be more informative.

### Problem
When git tree has files but they're within thresholds, the message 'Git tree is clean' was confusing because there ARE files modified.

### Solution
Now shows:
- **0 files**: 'Git tree is clean. You can continue.'
- **N files (within limits)**: 'Git tree within limits (N files, thresholds OK). You can continue.'

Fixes #8 from TEST_PLAN.md