### PR TITLE
Release: Git tree message clarity fix

### DIFF
--- a/application/services/RealtimeGuardService.js
+++ b/application/services/RealtimeGuardService.js
@@ -294,7 +294,11 @@ class RealtimeGuardService {
     this.lastDirtyTreeNotification = 0;
     this.removeDirtyTreeMarker();
     this.appendDebugLog(`DIRTY_TREE_CLEAR|${state.stagedCount}|${state.workingCount}|${state.uniqueCount}`);
-    this.notify('Git tree is clean. You can continue.', 'info');
+    const totalFiles = state.uniqueCount || 0;
+    const message = totalFiles > 0
+      ? `Git tree within limits (${totalFiles} files, thresholds OK). You can continue.`
+      : 'Git tree is clean. You can continue.';
+    this.notify(message, 'info');
   }
 
   persistDirtyTreeState(state, limits, notifiedAt, active = true) {


### PR DESCRIPTION
## Summary

Merge develop into main with fix #8.

### Fix:
- **#8**: Improved 'Git tree is clean' message to show file count when within thresholds

### Message change:
- 0 files: 'Git tree is clean. You can continue.'
- N files (within limits): 'Git tree within limits (N files, thresholds OK). You can continue.'