### PR TITLE
feat: improve evidence system and rename .claude to .ast-intelligence

### DIFF
--- a/.AI_EVIDENCE.json
+++ b/.AI_EVIDENCE.json
@@ -1,34 +1,119 @@
 {
-  "timestamp": "2025-12-16T07:00:43+01:00",
-  "session_id": "feature-e2e-branch-wrapper",
-  "action": "feature_e2e_branch_wrapper",
-  "work_type": "documentation",
-  "platforms": ["backend"],
+  "timestamp": "2025-12-16T08:27:17+01:00",
+  "session_id": "feature-test-plan-fixes",
+  "action": "feature_test_plan_fixes",
+  "work_type": "code",
+  "platforms": [
+    "backend"
+  ],
   "files_modified": [],
-  "infra_modified": [],
+  "infra_modified": [
+    ".AI_EVIDENCE.json",
+    ".audit_tmp/health-status.json",
+    ".gitignore",
+    "README.md",
+    "application/services/IntelligentCommitAnalyzer.js",
+    "bin/install.js",
+    "bin/update-evidence.sh",
+    "hooks/getSkillRulesPath.ts",
+    "hooks/git-status-monitor.ts",
+    "hooks/post-tool-use-tracker.sh",
+    "hooks/skill-activation-prompt.sh",
+    "hooks/skill-activation-prompt.ts",
+    "infrastructure/hooks/pre-tool-use-intelligent-enforcer.sh",
+    "infrastructure/mcp/ast-intelligence-automation.js",
+    "infrastructure/shell/validators/validate-ai-protocol.sh"
+  ],
   "rules_read": [
     {
       "file": "rulesgold.mdc",
       "verified": true,
-      "summary": "IDE Rules: ### ANTES de implementar CUALQUIER cosa (aplicables en todas las tecnologías):;### Reglas de Arquitectura:;### Seguridad y Validación:;### Performance y Escalabilidad:;### Testing y Calidad:;### Observabilidad y Debugging:;### Arquitectura y Diseño:;### Control de Versiones y Colaboración:;### i18n y Accesibilidad:;### Error Handling:; | AST: No AST rules for "
+      "summary": "IDE Rules: ### ANTES de implementar CUALQUIER cosa (aplicables en todas las tecnologías):;### Reglas de Arquitectura:;### Seguridad y Validación:;### Performance y Escalabilidad:;### Testing y Calidad:;### Observabilidad y Debugging:;### Arquitectura y Diseño:;### Control de Versiones y Colaboración:;### i18n y Accesibilidad:;### Error Handling:; | AST: Files: 109, Rules:   ruleId: string;,types.any,debug.console,security.secret,security.sql.raw,performance.pagination,performance.nplus1,architecture.layering,architecture.layering,ios.force_unwrapping"
     },
     {
       "file": "rulesbackend.mdc",
       "verified": true,
-      "summary": "IDE Rules: ### ANTES de implementar CUALQUIER cosa (aplicables en todas las tecnologías):;### Reglas de Arquitectura:;### Seguridad y Validación:;### Performance y Escalabilidad:;### Testing y Calidad:;### Observabilidad y Debugging:;### Arquitectura y Diseño:;### Control de Versiones y Colaboración:;### i18n y Accesibilidad:;### Error Handling:; | AST: No AST rules for backend"
+      "summary": "IDE Rules: ### ANTES de implementar CUALQUIER cosa (aplicables en todas las tecnologías):;### Reglas de Arquitectura:;### Seguridad y Validación:;### Performance y Escalabilidad:;### Testing y Calidad:;### Observabilidad y Debugging:;### Arquitectura y Diseño:;### Control de Versiones y Colaboración:;### i18n y Accesibilidad:;### Error Handling:; | AST: Files: 25, Rules: "
     }
   ],
-  "also_read": [".AI_SESSION_START.md"],
+  "also_read": [
+    ".AI_SESSION_START.md"
+  ],
   "protocol_3_questions": {
     "answered": true,
-    "question_1_file_type": "Documentation task on branch 'feature/e2e-branch-wrapper'. Modifying mixed files in: general. No code rules apply - focus on clarity and accuracy.",
-    "question_2_similar_exists": "Documentation in: general. Recent commits: e6e3f14 fix: implement nestjs-patterns-analyzer to satisfy tests;f24a05c fix: restore original branch after E2E pre-flight test;5ed7eb3 fix: legacy paths in shell scripts;. Check for duplicate docs before creating new ones.",
-    "question_3_clean_architecture": "Documentation changes in general. Keep docs in sync with code. Update related READMEs if needed."
+    "question_1_file_type": "Code task on branch 'feature/test-plan-fixes'. Modifying  markdown, typescript, shell-scripts, javascript, json-config in: general. Target layer: multiple layers.",
+    "question_2_similar_exists": "Modules affected: general. Recent commits: cd657cf Merge pull request #34 from SwiftEnProfundidad/feature/e2e-branch-wrapper;4b978de chore: auto-commit changes on feature/e2e-branch-wrapper;e6e3f14 fix: implement nestjs-patterns-analyzer to satisfy tests;. Check for existing patterns before adding new code.",
+    "question_3_clean_architecture": "Code changes in multiple layers layer affecting general. Ensure dependencies point inward (Domain <- App <- Infra)."
   },
   "current_context": {
-    "branch": "feature/e2e-branch-wrapper",
-    "last_commits": "e6e3f14 fix: implement nestjs-patterns-analyzer to satisfy tests;f24a05c fix: restore original branch after E2E pre-flight test;5ed7eb3 fix: legacy paths in shell scripts;"
+    "branch": "feature/test-plan-fixes",
+    "last_commits": "cd657cf Merge pull request #34 from SwiftEnProfundidad/feature/e2e-branch-wrapper;4b978de chore: auto-commit changes on feature/e2e-branch-wrapper;e6e3f14 fix: implement nestjs-patterns-analyzer to satisfy tests;"
   },
-  "justification": "Context-aware evidence for branch 'feature/e2e-branch-wrapper'. Auto-detected modules and file types from current work.",
-  "approved_by": "Pumuki Team®"
+  "justification": "Context-aware evidence for branch 'feature/test-plan-fixes'. Auto-detected modules and file types from current work.",
+  "approved_by": "Pumuki Team®",
+  "severity_metrics": {
+    "last_updated": "2025-12-16T07:27:19.213Z",
+    "total_violations": 0,
+    "by_severity": {
+      "CRITICAL": 0,
+      "HIGH": 0,
+      "MEDIUM": 0,
+      "LOW": 0
+    },
+    "average_severity_score": 0,
+    "intelligent_evaluation_rate": 0,
+    "gate_status": "PASSED",
+    "blocked_by": null
+  },
+  "token_usage": {
+    "estimated": 50000.5,
+    "percent_used": 5,
+    "remaining": 949999.5,
+    "warning_level": "OK"
+  },
+  "ai_gate": {
+    "status": "ALLOWED",
+    "last_check": "2025-12-16T07:27:19.258Z",
+    "violations": [],
+    "instruction": "🚨 AI MUST call mcp_ast-intelligence-automation_ai_gate_check BEFORE any action. If BLOCKED, fix violations first!",
+    "mandatory": true
+  },
+  "git_flow": {
+    "branch_protection": {
+      "main": "protected",
+      "develop": "protected",
+      "feature_branches": "allowed"
+    },
+    "commit_validation": {
+      "require_evidence": true,
+      "require_tests": true,
+      "require_build": true,
+      "allow_no_verify": false
+    },
+    "current_branch": "feature/test-plan-fixes",
+    "base_branch": "develop",
+    "is_protected": false
+  },
+  "watchers": {
+    "token_monitor": {
+      "enabled": true,
+      "status": "active",
+      "current_usage": "50K/1M tokens (5%)",
+      "warning_threshold": 750000,
+      "critical_threshold": 900000,
+      "notify_at_percent": 90
+    },
+    "violations_watcher": {
+      "enabled": true,
+      "status": "monitoring",
+      "blocking_threshold": "HIGH",
+      "auto_fix_enabled": false
+    },
+    "evidence_watcher": {
+      "enabled": true,
+      "status": "active",
+      "sla_minutes": 10,
+      "auto_refresh": true
+    }
+  }
 }

--- a/.audit_tmp/health-status.json
+++ b/.audit_tmp/health-status.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-12-16T05:52:46.081Z",
+  "timestamp": "2025-12-16T07:26:36.333Z",
   "reason": "cli",
   "status": "error",
   "results": [
@@ -7,22 +7,34 @@
       "name": "evidence",
       "status": "ok",
       "details": {
-        "ageMs": 5081,
-        "timestamp": "2025-12-16T06:52:41+01:00"
+        "ageMs": 3333,
+        "timestamp": "2025-12-16T08:26:33+01:00"
       }
     },
     {
       "name": "gitTree",
-      "status": "ok",
+      "status": "warn",
       "details": {
         "stagedFiles": [],
         "workingFiles": [
           ".AI_EVIDENCE.json",
-          "infrastructure/ast/backend/nestjs-patterns-analyzer.js"
+          ".gitignore",
+          "README.md",
+          "application/services/IntelligentCommitAnalyzer.js",
+          "bin/install.js",
+          "bin/update-evidence.sh",
+          "hooks/getSkillRulesPath.ts",
+          "hooks/git-status-monitor.ts",
+          "hooks/post-tool-use-tracker.sh",
+          "hooks/skill-activation-prompt.sh",
+          "hooks/skill-activation-prompt.ts",
+          "infrastructure/hooks/pre-tool-use-intelligent-enforcer.sh",
+          "infrastructure/mcp/ast-intelligence-automation.js",
+          "infrastructure/shell/validators/validate-ai-protocol.sh"
         ],
         "stagedCount": 0,
-        "workingCount": 2,
-        "uniqueCount": 2
+        "workingCount": 14,
+        "uniqueCount": 14
       }
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,8 @@ ANNOUNCEMENTS.md
 .AI_TOKEN_STATUS.txt
 .coverage/
 
-# Claude Desktop configuration (user-specific, similar to .cursor/rules/)
-.claude/
+# AST Intelligence configuration (user-specific, similar to .cursor/rules/)
+.ast-intelligence/
 
 # IDE-specific configurations (user-specific)
 .windsurf/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This library was conceived to solve this fundamental problem by creating a **per
      - Example: `"Code changes in Domain layer affecting auth, users. Ensure dependencies point inward."`
 
 3. **Rules are automatically loaded**:
-   - `DynamicRulesLoader` scans agentic IDE rules directories (`.cursor/rules/`, `.claude/skills/`, `.windsurf/rules/`, `.vscode/rules/`, `.kilo/rules/`, `.cline/rules/`) for platform-specific rules
+   - `DynamicRulesLoader` scans agentic IDE rules directories (`.cursor/rules/`, `.ast-intelligence/skills/`, `.windsurf/rules/`, `.vscode/rules/`, `.kilo/rules/`, `.cline/rules/`) for platform-specific rules
    - **Always loads `rulesgold.mdc` first** (generic rules that apply to all projects)
    - Then loads platform-specific rules: `rulesbackend.mdc`, `rulesios.mdc`, `rulesandroid.mdc`, `rulesfront.mdc`
    - Aggregates all 798+ validation rules into a single context

--- a/application/services/IntelligentCommitAnalyzer.js
+++ b/application/services/IntelligentCommitAnalyzer.js
@@ -87,15 +87,15 @@ class IntelligentCommitAnalyzer {
             return 'hooks-system';
         }
 
-        if (filePath.includes('.claude/')) {
-            return 'claude-config';
+        if (filePath.includes('.ast-intelligence/')) {
+            return 'ast-intelligence-config'
         }
 
         if (filePath.includes('docs/')) {
             return 'docs';
         }
 
-        if (filePath.match(/^(\.github|\.vscode|\.cursor|\.claude)/)) {
+        if (filePath.match(/^(\.github|\.vscode|\.cursor|\.ast-intelligence)/)) {
             return null;
         }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -310,7 +310,7 @@ ${COLORS.reset}`);
   }
 
   installCursorHooks() {
-    const claudeDir = path.join(this.targetRoot, '.claude');
+    const claudeDir = path.join(this.targetRoot, '.ast-intelligence');
     const claudeSkillsDir = path.join(claudeDir, 'skills');
     const claudeHooksDir = path.join(claudeDir, 'hooks');
     const cursorSettingsPath = path.join(this.targetRoot, '.cursor', 'settings.json');

--- a/hooks/getSkillRulesPath.ts
+++ b/hooks/getSkillRulesPath.ts
@@ -11,7 +11,7 @@ export function getSkillRulesPath(projectDir: string): string | null {
 
     const nodeModulesPath = join(projectDir, 'node_modules', '@carlos', 'ast-intelligence-hooks', 'skills', 'skill-rules.json');
 
-    const claudePath = join(projectDir, '.claude', 'skills', 'skill-rules.json');
+    const claudePath = join(projectDir, '.ast-intelligence', 'skills', 'skill-rules.json');
 
     if (existsSync(librarySkillsPath)) {
         return librarySkillsPath;
@@ -34,7 +34,7 @@ export function getSkillPath(projectDir: string, skillName: string): string | nu
 
     const nodeModulesPath = join(projectDir, 'node_modules', '@carlos', 'ast-intelligence-hooks', 'skills', skillName, 'SKILL.md');
 
-    const claudePath = join(projectDir, '.claude', 'skills', skillName, 'SKILL.md');
+    const claudePath = join(projectDir, '.ast-intelligence', 'skills', skillName, 'SKILL.md');
 
     if (existsSync(librarySkillPath)) {
         return librarySkillPath;

--- a/hooks/git-status-monitor.ts
+++ b/hooks/git-status-monitor.ts
@@ -50,7 +50,7 @@ function detectPlatformFromFiles(projectDir: string): string[] {
     const platforms: string[] = [];
 
     try {
-        const cacheDir = join(projectDir, '.claude', 'tsc-cache');
+        const cacheDir = join(projectDir, '.ast-intelligence', 'tsc-cache');
         const sessionDirs = execSync(`find "${cacheDir}" -type d -maxdepth 1 2>/dev/null | head -5`, { encoding: 'utf8' }).trim().split('\n');
 
         const recentFiles: string[] = [];

--- a/hooks/post-tool-use-tracker.sh
+++ b/hooks/post-tool-use-tracker.sh
@@ -15,7 +15,7 @@ if [[ "$file_path" =~ \.(md|markdown)$ ]]; then
     exit 0
 fi
 
-cache_dir="$CLAUDE_PROJECT_DIR/.claude/tsc-cache/${session_id:-default}"
+cache_dir="$CLAUDE_PROJECT_DIR/.ast-intelligence/tsc-cache/${session_id:-default}"
 mkdir -p "$cache_dir"
 
 detect_repo() {

--- a/hooks/skill-activation-prompt.sh
+++ b/hooks/skill-activation-prompt.sh
@@ -2,7 +2,7 @@
 set -e
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HOOKS_DIR="$PROJECT_DIR/.claude/hooks"
+HOOKS_DIR="$PROJECT_DIR/.ast-intelligence/hooks"
 
 cd "$HOOKS_DIR"
 cat | npx tsx skill-activation-prompt.ts

--- a/hooks/skill-activation-prompt.ts
+++ b/hooks/skill-activation-prompt.ts
@@ -128,7 +128,7 @@ async function main() {
         const prompt = data.prompt.toLowerCase();
 
         const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-        const rulesPath = join(projectDir, '.claude', 'skills', 'skill-rules.json');
+        const rulesPath = join(projectDir, '.ast-intelligence', 'skills', 'skill-rules.json');
 
         if (!existsSync(rulesPath)) {
             process.exit(0);

--- a/infrastructure/hooks/pre-tool-use-intelligent-enforcer.sh
+++ b/infrastructure/hooks/pre-tool-use-intelligent-enforcer.sh
@@ -333,7 +333,7 @@ detect_work_phase_mismatch() {
     fi
 
     if [[ -z "$work_phase" ]] && [[ -n "$file_path" ]]; then
-        if echo "$file_path" | grep -qE "(\.claude/skills/|skill-rules\.json|SKILL\.md|skills/README\.md)"; then
+        if echo "$file_path" | grep -qE "(\.ast-intelligence/skills/|skill-rules\.json|SKILL\.md|skills/README\.md)"; then
             work_phase="2"
         elif echo "$file_path" | grep -qE "(dev-docs|/dev-docs|dev/active)"; then
             work_phase="3"

--- a/infrastructure/mcp/ast-intelligence-automation.js
+++ b/infrastructure/mcp/ast-intelligence-automation.js
@@ -250,6 +250,10 @@ function checkEvidence() {
         const isStale = ageSeconds > MAX_EVIDENCE_AGE;
         const checkedAt = new Date(nowMs).toISOString();
 
+        if (isStale) {
+            sendNotification('⚠️ Evidence Stale', `Evidence is ${ageSeconds}s old (max ${MAX_EVIDENCE_AGE}s). Run ai-start to refresh.`, 'Basso');
+        }
+
         return {
             status: isStale ? 'stale' : 'fresh',
             message: isStale ? `Evidence is STALE (${ageSeconds}s old, max ${MAX_EVIDENCE_AGE}s)` : `Evidence is fresh (${ageSeconds}s old)`,
@@ -1404,7 +1408,7 @@ setInterval(async () => {
                     file.includes('package-lock.json') ||
                     file.startsWith('.git/') ||
                     file.startsWith('.cursor/') ||
-                    file.startsWith('.claude/') ||
+                    file.startsWith('.ast-intelligence/') ||
                     file.startsWith('.vscode/') ||
                     file.startsWith('.idea/')) {
                     return;

--- a/infrastructure/shell/validators/validate-ai-protocol.sh
+++ b/infrastructure/shell/validators/validate-ai-protocol.sh
@@ -186,8 +186,8 @@ detect_platform_for_file() {
   local filename=$(basename "$file")
 
   # Exclude hooks-system tooling files from platform validation
-  if [[ "$file" =~ scripts/hooks-system/ ]] || [[ "$file" =~ \.claude/hooks/ ]]; then
-    # Hooks system scripts and .claude/hooks are tooling, not application code
+  if [[ "$file" =~ scripts/hooks-system/ ]] || [[ "$file" =~ \.ast-intelligence/hooks/ ]]; then
+    # Hooks system scripts and .ast-intelligence/hooks are tooling, not application code
     echo ""
     return
   fi


### PR DESCRIPTION
## Changes

### Evidence System Improvements
- Add notification when `check_evidence_status` detects stale evidence (fix 2.1.2)
- Execute full AST analysis in `--auto` mode to generate `ast-summary.json` (fix 3.1.6/6.1.3)
- Fix `HOOKS_SYSTEM_DIR` detection for local development

### Refactor: Rename .claude to .ast-intelligence (8.3.1)
- Rename `.claude/` directory to `.ast-intelligence/` for IDE-agnostic naming
- Update all references across codebase:
  - `IntelligentCommitAnalyzer.js`
  - `ast-intelligence-automation.js`
  - `validate-ai-protocol.sh`
  - `pre-tool-use-intelligent-enforcer.sh`
  - `install.js`
  - All hooks TypeScript/Shell files
  - `README.md`
  - `.gitignore`

### Tests
- 890 passed, 5 skipped, 2 failed (known Babel flaky issues)
- No regressions from these changes