### PR TITLE
Canonical rules source + lite mode fixes

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -339,15 +339,16 @@ ${COLORS.cyan}[0.5/8] Configuring artifact exclusions...${COLORS.reset}`);
   }
 
   copyIDERules() {
-    const sourceRulesDir = path.join(this.hookSystemRoot, '.cursor', 'rules');
-
-    if (!fs.existsSync(sourceRulesDir)) {
+    // Canonical source: .ast-intelligence/rules inside the hooks system
+    const canonicalDir = path.join(this.hookSystemRoot, '.ast-intelligence', 'rules');
+    if (!fs.existsSync(canonicalDir)) {
       return;
     }
 
     const ideTargets = [
       { name: 'Cursor', dir: path.join(this.targetRoot, '.cursor', 'rules') },
-      { name: 'Windsurf', dir: path.join(this.targetRoot, '.windsurf', 'rules') }
+      { name: 'Windsurf', dir: path.join(this.targetRoot, '.windsurf', 'rules') },
+      { name: 'AST', dir: path.join(this.targetRoot, '.ast-intelligence', 'rules') }
     ];
 
     ideTargets.forEach(ide => {
@@ -355,9 +356,9 @@ ${COLORS.cyan}[0.5/8] Configuring artifact exclusions...${COLORS.reset}`);
         fs.mkdirSync(ide.dir, { recursive: true });
       }
 
-      const ruleFiles = fs.readdirSync(sourceRulesDir).filter(f => f.endsWith('.mdc'));
+      const ruleFiles = fs.readdirSync(canonicalDir).filter(f => f.endsWith('.mdc'));
       ruleFiles.forEach(ruleFile => {
-        const sourcePath = path.join(sourceRulesDir, ruleFile);
+        const sourcePath = path.join(canonicalDir, ruleFile);
         const targetPath = path.join(ide.dir, ruleFile);
         fs.copyFileSync(sourcePath, targetPath);
       });


### PR DESCRIPTION
## Summary
Establish .ast-intelligence/rules as the canonical source of truth for IDE rules and fix guards CLI path resolution for lite mode.

## Changes
- Prioritize .ast-intelligence/rules in evidence extractor (bin/update-evidence.sh)
- Installer copies from canonical directory to IDE folders (bin/install.js)
- Add canonical English rules for all platforms (gold/front/back/ios/android)
- Fix guards CLI path resolution to work in lite mode (bin/cli.js)

## Testing
- Verified rules extraction prioritizes canonical source
- Tested installer copies rules correctly
- Confirmed guards CLI resolves paths in consumer repos

---
Pumuki Team - Automated Git Flow