### PR TITLE
fix(mcp): accept LF/CRLF Content-Length delimiters + mirror delimiter

### DIFF
--- a/ast-summary.json
+++ b/ast-summary.json
@@ -1,0 +1,30 @@
+{
+  "totals": {
+    "errors": 0,
+    "warnings": 0,
+    "infos": 0
+  },
+  "levels": {
+    "CRITICAL": 0,
+    "HIGH": 0,
+    "MEDIUM": 0,
+    "LOW": 0
+  },
+  "platforms": {
+    "Backend": 0,
+    "Frontend": 0,
+    "iOS": 0,
+    "Android": 0,
+    "Other": 0
+  },
+  "rules": {},
+  "platformDetails": {},
+  "ruleDetails": {},
+  "fileDetails": {},
+  "findings": [],
+  "metadata": {
+    "totalFiles": 206,
+    "timestamp": "2025-12-26T19:25:16.986Z",
+    "root": "/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks"
+  }
+}


### PR DESCRIPTION
## What
Fix MCP stdio framing so it parses both header delimiters:
- `\r\n\r\n` (CRLF)
- `\n\n` (LF)

…and mirrors the delimiter back in responses.

## Why
Windsurf sends headers using `\n\n`, which caused timeouts / parsing failures.

## Files touched
- `scripts/hooks-system/infrastructure/mcp/ast-intelligence-automation.js`
- `infrastructure/mcp/ast-intelligence-automation.js` (legacy copy)
- `scripts/hooks-system/infrastructure/mcp/evidence-watcher.js`
- `infrastructure/mcp/evidence-watcher.js` (legacy copy)

## How to test
Pipe an MCP request framed with `Content-Length` using `\n\n` and confirm the server responds framed using the same delimiter.

(Already verified in Windsurf: MCP connects and responds correctly.)