### PR TITLE
fix: Support ISO8601 timestamps with timezone offsets in evidence validation

### DIFF
--- a/bin/start-guards.sh
+++ b/bin/start-guards.sh
@@ -80,7 +80,10 @@ from datetime import datetime, timezone
 ts = "$timestamp"
 
 try:
-    dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    normalized = ts.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(normalized)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     now_utc = datetime.now(timezone.utc)
     diff = now_utc - dt
     print(int(diff.total_seconds()))


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
`start-guards.sh` was using `datetime.strptime()` with a hardcoded `%Y-%m-%dT%H:%M:%SZ` format, which **only accepts UTC timestamps ending in `Z`**.

However, `update-evidence.sh` generates timestamps with timezone offsets like `2025-12-26T23:41:05+01:00`, causing:
- ❌ False "stale evidence" errors
- ❌ Guard startup abortion
- ❌ Manual workarounds needed in every project

### Solution
Replace `strptime` with `datetime.fromisoformat()` to accept **both formats**:
- ✅ `2025-12-26T22:41:05Z` (UTC with Z)
- ✅ `2025-12-26T23:41:05+01:00` (with timezone offset)

### Changes
```python
# Before (rigid)
dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)

# After (flexible)
normalized = ts.replace("Z", "+00:00")
dt = datetime.fromisoformat(normalized)
if dt.tzinfo is None:
    dt = dt.replace(tzinfo=timezone.utc)
```

### Impact
- 🔧 Fixes guard startup in **all projects** using the library
- 🌍 Works with any timezone offset format
- 🚀 No breaking changes (backward compatible)
- ✅ Tested in R_GO project

### Testing
```bash
# Verified with timestamp: 2025-12-26T23:41:05+01:00
npx ast-hooks guards restart
# ✅ Guards start successfully (no "stale evidence" error)
```

---

**Pumuki Team®** - Enterprise Git Automation