### PR TITLE
fix(hooks): avoid false positives on CRITICAL=0/HIGH=0

### DIFF
--- a/scripts/hooks-system/infrastructure/mcp/services/McpProtocolHandler.js
+++ b/scripts/hooks-system/infrastructure/mcp/services/McpProtocolHandler.js
@@ -163,4 +163,4 @@ class McpProtocolHandler {
 }
 
 module.exports = McpProtocolHandler;
-// test
+


### PR DESCRIPTION
## Summary\n- Fix generated pre-commit hook to only block when CRITICAL/HIGH violations are > 0 (avoid false positives from summary lines).\n- Remove accidental trailing test line from McpProtocolHandler.\n\n## Verification\n- Commit hook no longer blocks when AST reports CRITICAL=0 and HIGH=0.\n- MCP handler remains async-safe (awaits async handlers).