### PR TITLE
fix: compute evidence platforms and rules from real inputs

### DIFF
--- a/scripts/hooks-system/infrastructure/orchestration/__tests__/intelligent-audit.spec.js
+++ b/scripts/hooks-system/infrastructure/orchestration/__tests__/intelligent-audit.spec.js
@@ -23,7 +23,15 @@ describe('AI_EVIDENCE.json structure validation', () => {
       question_3_clean_architecture: 'Verify that the code follows Clean Architecture and SOLID principles',
       last_answered: new Date().toISOString()
     },
-    rules_read: {
+    rules_read: [
+      {
+        file: 'rulesgold.mdc',
+        verified: true,
+        summary: 'loaded (example)',
+        path: '/tmp/rulesgold.mdc'
+      }
+    ],
+    rules_read_flags: {
       backend: true,
       frontend: false,
       ios: false,
@@ -79,15 +87,25 @@ describe('AI_EVIDENCE.json structure validation', () => {
     expect(evidence.protocol_3_questions.last_answered).toBeDefined();
   });
 
-  it('should have rules_read field tracking all platforms', () => {
+  it('should have rules_read field with rule load evidence entries', () => {
     const evidence = createMockEvidence();
     expect(evidence.rules_read).toBeDefined();
-    expect(evidence.rules_read.backend).toBe(true);
-    expect(evidence.rules_read.frontend).toBe(false);
-    expect(evidence.rules_read.ios).toBe(false);
-    expect(evidence.rules_read.android).toBe(false);
-    expect(evidence.rules_read.gold).toBe(true);
-    expect(evidence.rules_read.last_checked).toBeDefined();
+    expect(Array.isArray(evidence.rules_read)).toBe(true);
+    expect(evidence.rules_read.length).toBeGreaterThan(0);
+    expect(evidence.rules_read[0]).toHaveProperty('file');
+    expect(evidence.rules_read[0]).toHaveProperty('verified');
+    expect(evidence.rules_read[0]).toHaveProperty('summary');
+  });
+
+  it('should have rules_read_flags legacy field tracking platform flags', () => {
+    const evidence = createMockEvidence();
+    expect(evidence.rules_read_flags).toBeDefined();
+    expect(evidence.rules_read_flags.backend).toBe(true);
+    expect(evidence.rules_read_flags.frontend).toBe(false);
+    expect(evidence.rules_read_flags.ios).toBe(false);
+    expect(evidence.rules_read_flags.android).toBe(false);
+    expect(evidence.rules_read_flags.gold).toBe(true);
+    expect(evidence.rules_read_flags.last_checked).toBeDefined();
   });
 
   it('should have current_context field with branch and file info', () => {

--- a/tests/integration/protocol-3-questions.spec.js
+++ b/tests/integration/protocol-3-questions.spec.js
@@ -7,12 +7,10 @@ describe('Integration: protocol_3_questions', () => {
     const EVIDENCE_FILE = path.join(REPO_ROOT, '.AI_EVIDENCE.json');
 
     beforeAll(() => {
-        if (!fs.existsSync(EVIDENCE_FILE)) {
-            execSync('bash scripts/hooks-system/bin/update-evidence.sh', {
-                cwd: REPO_ROOT,
-                stdio: 'pipe'
-            });
-        }
+        execSync('bash scripts/hooks-system/bin/update-evidence.sh', {
+            cwd: REPO_ROOT,
+            stdio: 'pipe'
+        });
     });
 
     describe('protocol_3_questions structure', () => {
@@ -59,11 +57,11 @@ describe('Integration: protocol_3_questions', () => {
         });
 
         test('should mention file type or context', () => {
-            const q1 = evidence.protocol_3_questions.question_1_file_type;
+            const q1 = (evidence.protocol_3_questions.question_1_file_type || '').toLowerCase();
             const hasRelevantInfo =
                 q1.includes('file') ||
                 q1.includes('code') ||
-                q1.includes('Documentation') ||
+                q1.includes('documentation') ||
                 q1.includes('branch');
             expect(hasRelevantInfo).toBe(true);
         });
@@ -85,11 +83,11 @@ describe('Integration: protocol_3_questions', () => {
         });
 
         test('should mention commits or similar code', () => {
-            const q2 = evidence.protocol_3_questions.question_2_similar_exists;
+            const q2 = (evidence.protocol_3_questions.question_2_similar_exists || '').toLowerCase();
             const hasRelevantInfo =
                 q2.includes('commit') ||
                 q2.includes('similar') ||
-                q2.includes('Recent') ||
+                q2.includes('recent') ||
                 q2.includes('duplicate');
             expect(hasRelevantInfo).toBe(true);
         });
@@ -111,12 +109,12 @@ describe('Integration: protocol_3_questions', () => {
         });
 
         test('should mention architecture or structure', () => {
-            const q3 = evidence.protocol_3_questions.question_3_clean_architecture;
+            const q3 = (evidence.protocol_3_questions.question_3_clean_architecture || '').toLowerCase();
             const hasRelevantInfo =
                 q3.includes('architecture') ||
                 q3.includes('docs') ||
                 q3.includes('sync') ||
-                q3.includes('README');
+                q3.includes('readme');
             expect(hasRelevantInfo).toBe(true);
         });
     });


### PR DESCRIPTION
Fix evidence generation to remove hardcoded platforms/rules_read.\n\n- Compute platforms from staged files + violation categories\n- Generate rules_read as array of loaded rule file evidence via DynamicRulesLoader\n- Keep legacy flags in rules_read_flags\n- Update integration tests to match new evidence schema\n