### PR TITLE
feat(install): add optional cleanup of duplicate .md rules files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@pumuki/ast-intelligence-hooks` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.39] - 2026-01-04
+
+### Added
+- **InstallService**: `cleanupDuplicateRules()` method to remove .md duplicate files when .mdc exists
+- **InstallService**: Cleanup controlled by `HOOK_CLEANUP_DUPLICATES` environment variable (disabled by default)
+- **Tests**: Added test suite for cleanup duplicate rules functionality
+
+### Fixed
+- **InstallService**: Integrated cleanup step into installation flow (step 7.5/8)
+
 ## [5.5.38] - 2026-01-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.38",
+  "version": "5.5.39",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/bin/__tests__/install.spec.js
+++ b/scripts/hooks-system/bin/__tests__/install.spec.js
@@ -9,3 +9,86 @@ describe('install', () => {
     expect(() => require.resolve('../install.js')).not.toThrow();
   });
 });
+
+describe('InstallService - cleanupDuplicateRules', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const InstallService = require('../../application/services/installation/InstallService');
+
+  let testRoot;
+  let service;
+
+  beforeEach(() => {
+    testRoot = path.join(__dirname, '.tmp-cleanup-test');
+    fs.mkdirSync(testRoot, { recursive: true });
+    service = new InstallService();
+    service.targetRoot = testRoot;
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('should skip cleanup when HOOK_CLEANUP_DUPLICATES is false', () => {
+    process.env.HOOK_CLEANUP_DUPLICATES = 'false';
+    service.cleanupDuplicateRules();
+    expect(fs.existsSync(testRoot)).toBe(true);
+  });
+
+  it('should skip cleanup when HOOK_CLEANUP_DUPLICATES is not set', () => {
+    delete process.env.HOOK_CLEANUP_DUPLICATES;
+    service.cleanupDuplicateRules();
+    expect(fs.existsSync(testRoot)).toBe(true);
+  });
+
+  it('should delete .md files when .mdc exists and cleanup is enabled', () => {
+    process.env.HOOK_CLEANUP_DUPLICATES = 'true';
+
+    const cursorRules = path.join(testRoot, '.cursor', 'rules');
+    fs.mkdirSync(cursorRules, { recursive: true });
+
+    fs.writeFileSync(path.join(cursorRules, 'test.md'), 'duplicate');
+    fs.writeFileSync(path.join(cursorRules, 'test.mdc'), 'canonical');
+
+    service.cleanupDuplicateRules();
+
+    expect(fs.existsSync(path.join(cursorRules, 'test.md'))).toBe(false);
+    expect(fs.existsSync(path.join(cursorRules, 'test.mdc'))).toBe(true);
+  });
+
+  it('should not delete .md files when .mdc does not exist', () => {
+    process.env.HOOK_CLEANUP_DUPLICATES = 'true';
+
+    const cursorRules = path.join(testRoot, '.cursor', 'rules');
+    fs.mkdirSync(cursorRules, { recursive: true });
+
+    fs.writeFileSync(path.join(cursorRules, 'test.md'), 'only md');
+
+    service.cleanupDuplicateRules();
+
+    expect(fs.existsSync(path.join(cursorRules, 'test.md'))).toBe(true);
+  });
+
+  it('should cleanup both .cursor and .windsurf rules directories', () => {
+    process.env.HOOK_CLEANUP_DUPLICATES = 'true';
+
+    const cursorRules = path.join(testRoot, '.cursor', 'rules');
+    const windsurfRules = path.join(testRoot, '.windsurf', 'rules');
+    fs.mkdirSync(cursorRules, { recursive: true });
+    fs.mkdirSync(windsurfRules, { recursive: true });
+
+    fs.writeFileSync(path.join(cursorRules, 'cursor.md'), 'duplicate');
+    fs.writeFileSync(path.join(cursorRules, 'cursor.mdc'), 'canonical');
+    fs.writeFileSync(path.join(windsurfRules, 'windsurf.md'), 'duplicate');
+    fs.writeFileSync(path.join(windsurfRules, 'windsurf.mdc'), 'canonical');
+
+    service.cleanupDuplicateRules();
+
+    expect(fs.existsSync(path.join(cursorRules, 'cursor.md'))).toBe(false);
+    expect(fs.existsSync(path.join(cursorRules, 'cursor.mdc'))).toBe(true);
+    expect(fs.existsSync(path.join(windsurfRules, 'windsurf.md'))).toBe(false);
+    expect(fs.existsSync(path.join(windsurfRules, 'windsurf.mdc'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary\n- Add `cleanupDuplicateRules()` method to InstallService\n- Removes .md duplicate files when .mdc exists\n- Controlled by `HOOK_CLEANUP_DUPLICATES` env var (disabled by default)\n- Added test suite for cleanup functionality\n\n## Changes\n- InstallService.js: new cleanup method integrated into installation flow\n- install.spec.js: 5 new tests for cleanup behavior\n- package.json: bump to 5.5.39\n- CHANGELOG.md: updated with release notes