### PR TITLE
fix(audit): keep CRITICAL/HIGH severities consistent in evidence

### DIFF
--- a/tests/integration/severity-floor.spec.js
+++ b/tests/integration/severity-floor.spec.js
@@ -1,0 +1,39 @@
+const { evaluateViolations } = require('../../scripts/hooks-system/infrastructure/severity/severity-evaluator');
+
+describe('severity floor', () => {
+    it('should not downgrade CRITICAL base severity', () => {
+        const violations = [
+            {
+                ruleId: 'ios.security.missing_ssl_pinning',
+                severity: 'CRITICAL',
+                filePath: '/tmp/LoginView.swift',
+                line: 1,
+                message: 'SSL pinning missing'
+            }
+        ];
+
+        const evaluated = evaluateViolations(violations);
+
+        expect(evaluated).toHaveLength(1);
+        expect(evaluated[0].originalSeverity).toBe('CRITICAL');
+        expect(evaluated[0].severity).toBe('CRITICAL');
+    });
+
+    it('should not downgrade HIGH base severity', () => {
+        const violations = [
+            {
+                ruleId: 'ios.force_unwrapping',
+                severity: 'HIGH',
+                filePath: '/tmp/LoginView.swift',
+                line: 1,
+                message: 'Force unwrapping detected'
+            }
+        ];
+
+        const evaluated = evaluateViolations(violations);
+
+        expect(evaluated).toHaveLength(1);
+        expect(evaluated[0].originalSeverity).toBe('HIGH');
+        expect(['HIGH', 'CRITICAL']).toContain(evaluated[0].severity);
+    });
+});


### PR DESCRIPTION
## Summary\n- Prevent intelligent severity evaluation from downgrading base severities (CRITICAL/HIGH)\n- Robust staged-files matching to avoid missing violations in evidence\n- Add regression test for severity floor\n\n## Why\n- Fix inconsistency where pre-commit blocks with CRITICAL but .AI_EVIDENCE.json shows LOW/ALLOWED\n\n## Changes\n- severity-evaluator.js: apply severity floor\n- intelligent-audit.js: normalize staged/violation paths\n- tests/integration/severity-floor.spec.js: regression tests