### PR TITLE
chore(release): bump version to 5.5.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@pumuki/ast-intelligence-hooks` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.40] - 2026-01-04
+
+### Fixed
+- **severity-evaluator.js**: Intelligent evaluation now respects base severity floor (CRITICAL/HIGH cannot be downgraded)
+- **intelligent-audit.js**: Robust staged-files matching to avoid missing violations in evidence
+- **.AI_EVIDENCE.json**: Now consistent with pre-commit hook blocking behavior
+
+### Added
+- **tests/integration/severity-floor.spec.js**: Regression tests for severity floor invariance
+
 ## [5.5.38] - 2026-01-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.38",
+  "version": "5.5.40",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary\n- Bump package version to 5.5.40\n- Update CHANGELOG with severity consistency fix notes\n\n## Changes\n- package.json: version 5.5.38 → 5.5.40\n- CHANGELOG.md: added release notes for 5.5.40