### PR TITLE
chore(release): merge 5.5.40 and 5.5.39 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-All notable changes to `@pumuki/ast-intelligence-hooks` will be documented in this file.
+All notable changes to `@pumuki-ast-intelligence-hooks` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [5.5.40] - 2026-01-04
+
+### Fixed
+- **severity-evaluator.js**: Intelligent evaluation now respects base severity floor (CRITICAL/HIGH cannot be downgraded)
+- **intelligent-audit.js**: Robust staged-files matching to avoid missing violations in evidence
+- **.AI_EVIDENCE.json**: Now consistent with pre-commit hook blocking behavior
+
+### Added
+- **tests/integration/severity-floor.spec.js**: Regression tests for severity floor invariance
 
 ## [5.5.39] - 2026-01-04
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.39",
+  "version": "5.5.40",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary\n- Merge both 5.5.40 (severity consistency fix) and 5.5.39 (cleanup duplicate rules) into develop\n- Resolved merge conflicts in CHANGELOG.md and package.json\n- Version set to 5.5.40 (highest version)\n\n## Changes\n- CHANGELOG.md: merged both 5.5.40 and 5.5.39 entries\n- package.json: version set to 5.5.40