### PR TITLE
fix(exports): export package.json for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to `@pumuki-ast-intelligence-hooks` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.42] - 2026-01-05
+
+### Fixed
+- **exports**: Exported `./package.json` so consumers can safely read the installed version via `require('pumuki-ast-hooks/package.json')` (Node 20+ compatible)
+
 ## [5.5.41] - 2026-01-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.41",
+  "version": "5.5.42",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {
@@ -126,6 +126,7 @@
   },
   "exports": {
     ".": "./index.js",
+    "./package.json": "./package.json",
     "./ast": "./scripts/hooks-system/infrastructure/ast/ast-intelligence.js",
     "./domain": "./scripts/hooks-system/domain/index.js",
     "./application": "./scripts/hooks-system/application/index.js",


### PR DESCRIPTION
## Summary

Export  in  so consumers on Node 20+ can read version via:



## Changes
- Added  to 
- Bumped version to 
- Updated CHANGELOG

## Why
RuralGo failed with  when trying to read .
