### PR TITLE
fix: gitflow-enforcer lint should run from repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to `@pumuki-ast-intelligence-hooks` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.44] - 2026-01-05
+
+### Fixed
+- **gitflow-enforcer**: Lint hooks-system se ejecuta contra el `package.json` del repo (y muestra output en caso de fallo) para evitar falsos negativos en pre-push
+
 ## [5.5.43] - 2026-01-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.43",
+  "version": "5.5.44",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/infrastructure/shell/gitflow/gitflow-enforcer.sh
+++ b/scripts/hooks-system/infrastructure/shell/gitflow/gitflow-enforcer.sh
@@ -94,12 +94,27 @@ refresh_evidence() {
 }
 
 lint_hooks_system() {
-  if npm --prefix "${REPO_ROOT}/scripts/hooks-system" run lint:hooks >/dev/null 2>&1; then
-    printf "${GREEN}✅ Lint hooks-system OK.${NC}\n"
-  else
-    printf "${RED}❌ Lint hooks-system falló.${NC}\n"
-    return 1
+  local repo_pkg="${REPO_ROOT}/package.json"
+  local hooks_pkg="${REPO_ROOT}/scripts/hooks-system/package.json"
+
+  if [[ -f "${repo_pkg}" ]]; then
+    printf "${CYAN}🔎 Ejecutando lint (repo root)...${NC}\n"
+    if npm --prefix "${REPO_ROOT}" run lint:hooks; then
+      printf "${GREEN}✅ Lint hooks-system OK.${NC}\n"
+      return 0
+    fi
   fi
+
+  if [[ -f "${hooks_pkg}" ]]; then
+    printf "${CYAN}🔎 Ejecutando lint (scripts/hooks-system)...${NC}\n"
+    if npm --prefix "${REPO_ROOT}/scripts/hooks-system" run lint:hooks; then
+      printf "${GREEN}✅ Lint hooks-system OK.${NC}\n"
+      return 0
+    fi
+  fi
+
+  printf "${RED}❌ Lint hooks-system falló.${NC}\n"
+  return 1
 }
 
 run_mobile_checks() {


### PR DESCRIPTION
## Que
- Corrige el gitflow-enforcer para ejecutar npm run lint:hooks desde el repo root (y no desde scripts/hooks-system).

## Por que
- Evita falsos negativos en pre-push cuando no existe scripts/hooks-system/package.json.
- Mejora DX mostrando output del lint si falla.

## Cambios
- lint_hooks_system ahora intenta primero repo root y cae a scripts/hooks-system solo si hay package.json.
- Bump a 5.5.44 + entrada en CHANGELOG.

## Verificacion
- bash -n gitflow-enforcer.sh
- npm run lint:hooks
- npm test