### PR TITLE
hotfix: ensure session-loader.sh is installed for VSCode AST Session Loader (v5.5.47)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.46",
+  "version": "5.5.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.5.46",
+      "version": "5.5.47",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.46",
+  "version": "5.5.47",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Hotfix: AST Session Loader vuelve a funcionar

### Causa raíz
- El installer estaba copiando `scripts/hooks-system/bin/` **excluyendo** `session-loader.sh`.
- El task (ya portable) no podía ejecutar nada porque el script no existía en el repo.

### Cambios
- `FileSystemInstallerService`: **se deja de excluir** `session-loader.sh`.
- `VSCodeTaskConfigurator`: fallback correcto:
  - `node_modules/pumuki-ast-hooks/scripts/hooks-system/bin/session-loader.sh`
  - compatibilidad con `node_modules/@pumuki/ast-intelligence-hooks/bin/session-loader.sh`

### Release
Publicado en npm: `pumuki-ast-hooks@5.5.47`.
