### PR TITLE
fix(hooks): strict staged violations filter

### DIFF
--- a/tests/integration/intelligent-audit-staged-filter.spec.js
+++ b/tests/integration/intelligent-audit-staged-filter.spec.js
@@ -1,0 +1,13 @@
+describe('intelligent-audit staged filtering', () => {
+    it('matches only exact staged paths and ignores .audit_tmp', () => {
+        const mod = require('../../scripts/hooks-system/infrastructure/orchestration/intelligent-audit');
+
+        const stagedSet = new Set(['apps/ios/Application/AppCoordinator.swift']);
+
+        expect(mod.isViolationInStagedFiles('apps/ios/Application/AppCoordinator.swift', stagedSet)).toBe(true);
+        expect(mod.isViolationInStagedFiles('apps/ios/Application/AppCoordinator.swift.backup', stagedSet)).toBe(false);
+        expect(mod.isViolationInStagedFiles('.audit_tmp/AppCoordinator.123.staged.swift', stagedSet)).toBe(false);
+        expect(mod.isViolationInStagedFiles('some/dir/.audit_tmp/AppCoordinator.123.staged.swift', stagedSet)).toBe(false);
+        expect(mod.isViolationInStagedFiles('apps/ios/Application/AppCoordinator', stagedSet)).toBe(false);
+    });
+});


### PR DESCRIPTION
## 🎯 Summary
Fix false positives where the pre-commit intelligent gate could count non-staged violations due to loose path matching.

## ✨ Changes
- Make staged matching strict: only exact repo-relative paths are considered staged
- Ignore artifacts under .audit_tmp when computing staged violations
- Add regression test for staged filtering

## ✅ Testing
- npm test

---
🐈💚 Pumuki Team® - Automated Git Flow
