### PR TITLE
fix(orchestrator): restore scoreConfidence for ai gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.51",
+  "version": "5.5.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.5.51",
+      "version": "5.5.52",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.51",
+  "version": "5.5.52",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/application/services/AutonomousOrchestrator.js
+++ b/scripts/hooks-system/application/services/AutonomousOrchestrator.js
@@ -59,6 +59,19 @@ class AutonomousOrchestrator {
         return this.detectFromASTSystemFiles(files);
     }
 
+    async scoreConfidence(platforms) {
+        try {
+            const PlatformAnalysisService = require('./PlatformAnalysisService');
+            const analysisService = new PlatformAnalysisService(this.platformDetector);
+            const context = await this.contextEngine.detectContext();
+            return analysisService.analyzeConfidence(platforms || [], context || {});
+        } catch (error) {
+            const msg = error && error.message ? error.message : String(error);
+            this.logger?.debug?.('ORCHESTRATOR_SCORE_CONFIDENCE_ERROR', { error: msg });
+            return [];
+        }
+    }
+
     async analyzeContext() {
         const platforms = await this.detectActivePlatforms();
         const scores = await this.scoreConfidence(platforms);


### PR DESCRIPTION
Restores missing scoreConfidence wrapper in AutonomousOrchestrator so ai_gate_check can load mandatory rules reliably.