### PR TITLE
chore: release v5.5.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.52",
+  "version": "5.5.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.5.52",
+      "version": "5.5.54",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.5.53",
+  "version": "5.5.54",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Changes
- Fix empty_catch detector to recognize test assertions (XCTFail, XCTAssert, guard case)
- Bump version to 5.5.54

Ready to publish to npm.