### PR TITLE
fix: exclude Swift files from common.error.empty_catch detector

### DIFF
--- a/scripts/hooks-system/infrastructure/ast/common/ast-common.js
+++ b/scripts/hooks-system/infrastructure/ast/common/ast-common.js
@@ -145,27 +145,30 @@ function runCommonIntelligence(project, findings) {
       }
     });
 
-    sf.getDescendantsOfKind(SyntaxKind.CatchClause).forEach((clause) => {
-      const block = typeof clause.getBlock === 'function' ? clause.getBlock() : null;
-      const statements = block && typeof block.getStatements === 'function' ? block.getStatements() : [];
+    // Skip Swift files - they should only be analyzed by iOS-specific detectors
+    if (!/\.swift$/i.test(filePath)) {
+      sf.getDescendantsOfKind(SyntaxKind.CatchClause).forEach((clause) => {
+        const block = typeof clause.getBlock === 'function' ? clause.getBlock() : null;
+        const statements = block && typeof block.getStatements === 'function' ? block.getStatements() : [];
 
-      if ((statements || []).length === 0) {
-        const blockText = block ? block.getText() : '';
-        const hasTestAssertions = /XCTFail|XCTAssert|guard\s+case|expect\(|assert/i.test(blockText);
-        const hasErrorHandling = /throw|console\.|logger\.|log\(|print\(/i.test(blockText);
+        if ((statements || []).length === 0) {
+          const blockText = block ? block.getText() : '';
+          const hasTestAssertions = /XCTFail|XCTAssert|guard\s+case|expect\(|assert/i.test(blockText);
+          const hasErrorHandling = /throw|console\.|logger\.|log\(|print\(/i.test(blockText);
 
-        if (!hasTestAssertions && !hasErrorHandling) {
-          pushFinding(
-            'common.error.empty_catch',
-            'critical',
-            sf,
-            clause,
-            'Empty catch block detected - always handle errors (log, rethrow, wrap, or return Result)',
-            findings
-          );
+          if (!hasTestAssertions && !hasErrorHandling) {
+            pushFinding(
+              'common.error.empty_catch',
+              'critical',
+              sf,
+              clause,
+              'Empty catch block detected - always handle errors (log, rethrow, wrap, or return Result)',
+              findings
+            );
+          }
         }
-      }
-    });
+      });
+    }
 
     sf.getDescendantsOfKind(SyntaxKind.AnyKeyword).forEach((node) => {
 


### PR DESCRIPTION
## Problem
Swift files were being analyzed by the TypeScript AST parser in common.error.empty_catch detector, causing false positives because ts-morph cannot correctly parse Swift catch blocks.

## Solution
- Skip Swift files () in the common detector
- Swift files are now only analyzed by iOS-specific detectors using SourceKitten
- This eliminates false positives in Swift test files with XCTFail/guard case patterns

## Testing
Verified that Swift test files with proper error handling (XCTFail, guard case) no longer trigger false positives.

Related: #155