### PR TITLE
fix: exclude test files from ISP unused_dependency detection

### DIFF
--- a/scripts/hooks-system/infrastructure/ast/ios/detectors/ios-ast-intelligent-strategies.js
+++ b/scripts/hooks-system/infrastructure/ast/ios/detectors/ios-ast-intelligent-strategies.js
@@ -232,15 +232,19 @@ function analyzeClassAST(analyzer, node, filePath) {
         analyzer.pushFinding('ios.naming.god_naming', 'medium', filePath, line, `Suspicious class name '${name}' - often indicates SRP violation`);
     }
 
-    const unusedProps = findUnusedPropertiesAST(analyzer, properties, methods);
-    for (const prop of unusedProps) {
-        analyzer.pushFinding(
-            'ios.solid.isp.unused_dependency',
-            'high',
-            filePath,
-            line,
-            `Unused property '${prop}' in '${name}' - ISP violation`
-        );
+    // Skip ISP validation for test files - spies/mocks are allowed to have unused properties
+    const isTestFile = /Tests?\/|Spec|Mock|Spy|Stub|Fake|Dummy/.test(filePath);
+    if (!isTestFile) {
+        const unusedProps = findUnusedPropertiesAST(analyzer, properties, methods);
+        for (const prop of unusedProps) {
+            analyzer.pushFinding(
+                'ios.solid.isp.unused_dependency',
+                'high',
+                filePath,
+                line,
+                `Unused property '${prop}' in '${name}' - ISP violation`
+            );
+        }
     }
 
     checkDependencyInjectionAST(analyzer, properties, filePath, name, line);


### PR DESCRIPTION
Test spies/mocks are allowed to have unused properties as they implement complete protocols for testing purposes. Excluded patterns: Tests/, Test/, Spec, Mock, Spy, Stub, Fake, Dummy