### PR TITLE
chore: bump version to 5.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.4",
+      "version": "5.6.5",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Bumps pumuki-ast-hooks version to 5.6.5 so npm picks up the latest README (screenshots + fixed links).