### PR TITLE
Fix iOS AST rules + preflight blocks tests + audit CLI exit handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/bin/__tests__/cli-audit-no-stack.spec.js
+++ b/scripts/hooks-system/bin/__tests__/cli-audit-no-stack.spec.js
@@ -1,0 +1,22 @@
+jest.mock('child_process', () => ({
+    execSync: jest.fn(() => {
+        const err = new Error('audit failed');
+        err.status = 1;
+        throw err;
+    })
+}));
+
+describe('cli audit', () => {
+    it('exits with the same status instead of throwing a stacktrace', () => {
+        const cli = require('../cli.js');
+
+        const exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
+            throw new Error(`process.exit:${code}`);
+        });
+
+        expect(() => cli.commands.audit()).toThrow('process.exit:1');
+        expect(exitSpy).toHaveBeenCalledWith(1);
+
+        exitSpy.mockRestore();
+    });
+});

--- a/scripts/hooks-system/bin/cli.js
+++ b/scripts/hooks-system/bin/cli.js
@@ -136,7 +136,12 @@ function buildHealthSnapshot() {
 
 const commands = {
   audit: () => {
-    execSync(`bash ${path.join(HOOKS_ROOT, 'presentation/cli/audit.sh')}`, { stdio: 'inherit' });
+    try {
+      execSync(`bash ${path.join(HOOKS_ROOT, 'presentation/cli/audit.sh')}`, { stdio: 'inherit' });
+    } catch (err) {
+      const status = (err && typeof err.status === 'number') ? err.status : 1;
+      process.exit(status);
+    }
   },
 
   'evidence:update': () => {
@@ -408,9 +413,12 @@ Documentation:
   }
 };
 
-if (!command || !commands[command]) {
-  commands.help();
-  process.exit(command ? 1 : 0);
+if (require.main === module) {
+  if (!command || !commands[command]) {
+    commands.help();
+    process.exit(command ? 1 : 0);
+  }
+  commands[command]();
 }
 
-commands[command]();
+module.exports = { commands };

--- a/scripts/hooks-system/infrastructure/ast/common/__tests__/ast-common.spec.js
+++ b/scripts/hooks-system/infrastructure/ast/common/__tests__/ast-common.spec.js
@@ -1,3 +1,8 @@
+jest.mock('../BDDTDDWorkflowRules', () => ({
+  BDDTDDWorkflowRules: jest.fn().mockImplementation(() => ({ analyze: jest.fn() }))
+}));
+
+const { Project } = require('../../ast-core');
 const { runCommonIntelligence } = require('../ast-common');
 
 describe('AST Common Module', () => {
@@ -8,6 +13,20 @@ describe('AST Common Module', () => {
 
     it('should be callable', () => {
       expect(runCommonIntelligence).toBeDefined();
+    });
+
+    it('does not apply makeSUT/trackForMemoryLeaks rules to Jest spec files', () => {
+      const project = new Project({
+        useInMemoryFileSystem: true,
+        skipAddingFilesFromTsConfig: true,
+      });
+      project.createSourceFile('/tmp/foo.spec.js', "import XCTest\n\ndescribe('x', () => {})");
+
+      const findings = [];
+      runCommonIntelligence(project, findings);
+
+      expect(findings.some(f => f.ruleId === 'common.testing.missing_makesut')).toBe(false);
+      expect(findings.some(f => f.ruleId === 'common.testing.missing_track_for_memory_leaks')).toBe(false);
     });
   });
 

--- a/scripts/hooks-system/infrastructure/ast/common/ast-common.js
+++ b/scripts/hooks-system/infrastructure/ast/common/ast-common.js
@@ -210,26 +210,31 @@ function runCommonIntelligence(project, findings) {
     if (isTestFilePath(filePath)) {
       const content = sf.getFullText();
 
-      if (!shouldSkipMakeSUTRule(filePath) && !hasMakeSUT(content)) {
-        pushFinding(
-          'common.testing.missing_makesut',
-          'high',
-          sf,
-          sf,
-          'Test file without makeSUT factory - use makeSUT pattern for consistent DI and teardown',
-          findings
-        );
-      }
+      const ext = path.extname(filePath).toLowerCase();
+      const isSwiftOrKotlinTest = ext === '.swift' || ext === '.kt' || ext === '.kts';
 
-      if (!shouldSkipTrackForMemoryLeaksRule(filePath) && !hasTrackForMemoryLeaksEvidence(content)) {
-        pushFinding(
-          'common.testing.missing_track_for_memory_leaks',
-          'critical',
-          sf,
-          sf,
-          'Test file without trackForMemoryLeaks - add memory leak tracking to prevent leaks and cross-test interference',
-          findings
-        );
+      if (isSwiftOrKotlinTest) {
+        if (!shouldSkipMakeSUTRule(filePath) && !hasMakeSUT(content)) {
+          pushFinding(
+            'common.testing.missing_makesut',
+            'high',
+            sf,
+            sf,
+            'Test file without makeSUT factory - use makeSUT pattern for consistent DI and teardown',
+            findings
+          );
+        }
+
+        if (!shouldSkipTrackForMemoryLeaksRule(filePath) && !hasTrackForMemoryLeaksEvidence(content)) {
+          pushFinding(
+            'common.testing.missing_track_for_memory_leaks',
+            'critical',
+            sf,
+            sf,
+            'Test file without trackForMemoryLeaks - add memory leak tracking to prevent leaks and cross-test interference',
+            findings
+          );
+        }
       }
 
       if (!shouldSkipSpyOverMockRule(filePath)) {

--- a/scripts/hooks-system/infrastructure/ast/ios/__tests__/forbidden-testable-import.spec.js
+++ b/scripts/hooks-system/infrastructure/ast/ios/__tests__/forbidden-testable-import.spec.js
@@ -1,0 +1,21 @@
+const { detectForbiddenTestableImport } = require('../ast-ios');
+
+describe('ios.imports.forbidden_testable', () => {
+    it('returns a finding when @testable is present in XCTest test file', () => {
+        const filePath = '/SomeModule/Tests/FooTests.swift';
+        const content = 'import XCTest\n@testable import Foo\nfinal class FooTests: XCTestCase {}';
+
+        const finding = detectForbiddenTestableImport({ filePath, content });
+
+        expect(finding).not.toBeNull();
+        expect(finding.ruleId).toBe('ios.imports.forbidden_testable');
+        expect(finding.severity).toBe('high');
+    });
+
+    it('returns null when @testable is not present', () => {
+        const filePath = '/SomeModule/Tests/FooTests.swift';
+        const content = 'import XCTest\nimport Foo\nfinal class FooTests: XCTestCase {}';
+
+        expect(detectForbiddenTestableImport({ filePath, content })).toBeNull();
+    });
+});

--- a/scripts/hooks-system/infrastructure/ast/ios/__tests__/missing-makesut-leaks.spec.js
+++ b/scripts/hooks-system/infrastructure/ast/ios/__tests__/missing-makesut-leaks.spec.js
@@ -1,0 +1,64 @@
+const { detectMissingMakeSUT, detectMissingLeakTracking } = require('../ast-ios');
+
+describe('iOS testing rules - makeSUT / leak tracking', () => {
+    it('flags missing makeSUT as HIGH when tests exist', () => {
+        const filePath = '/SomeModule/Tests/FooTests.swift';
+        const content = [
+            'import XCTest',
+            'final class FooTests: XCTestCase {',
+            '  func test_one() { XCTAssertTrue(true) }',
+            '}'
+        ].join('\n');
+
+        const finding = detectMissingMakeSUT({ filePath, content });
+        expect(finding).not.toBeNull();
+        expect(finding.ruleId).toBe('ios.testing.missing_make_sut');
+        expect(finding.severity).toBe('high');
+    });
+
+    it('does not flag missing makeSUT when file defines makeSUT()', () => {
+        const filePath = '/SomeModule/Tests/FooTests.swift';
+        const content = [
+            'import XCTest',
+            'final class FooTests: XCTestCase {',
+            '  func makeSUT() -> Foo { Foo() }',
+            '  func test_one() { let _ = makeSUT() }',
+            '}'
+        ].join('\n');
+
+        expect(detectMissingMakeSUT({ filePath, content })).toBeNull();
+    });
+
+    it('flags missing leak tracking as HIGH when tests exist and no tracking is present', () => {
+        const filePath = '/SomeModule/Tests/FooTests.swift';
+        const content = [
+            'import XCTest',
+            'final class FooTests: XCTestCase {',
+            '  func makeSUT() -> Foo { Foo() }',
+            '  func test_one() { let _ = makeSUT() }',
+            '}'
+        ].join('\n');
+
+        const finding = detectMissingLeakTracking({ filePath, content });
+        expect(finding).not.toBeNull();
+        expect(finding.ruleId).toBe('ios.testing.missing_leak_tracking');
+        expect(finding.severity).toBe('high');
+    });
+
+    it('does not flag leak tracking when makeSUT includes trackForMemoryLeaks', () => {
+        const filePath = '/SomeModule/Tests/FooTests.swift';
+        const content = [
+            'import XCTest',
+            'final class FooTests: XCTestCase {',
+            '  func makeSUT() -> Foo {',
+            '    let sut = Foo()',
+            '    trackForMemoryLeaks(sut)',
+            '    return sut',
+            '  }',
+            '  func test_one() { _ = makeSUT() }',
+            '}'
+        ].join('\n');
+
+        expect(detectMissingLeakTracking({ filePath, content })).toBeNull();
+    });
+});

--- a/scripts/hooks-system/infrastructure/ast/ios/detectors/__tests__/ios-encapsulation-public-mutable.spec.js
+++ b/scripts/hooks-system/infrastructure/ast/ios/detectors/__tests__/ios-encapsulation-public-mutable.spec.js
@@ -1,0 +1,63 @@
+const { analyzePropertyAST } = require('../ios-ast-intelligent-strategies');
+
+describe('ios.encapsulation.public_mutable', () => {
+    function makeAnalyzer() {
+        const findings = [];
+        return {
+            findings,
+            getAttributes: () => [],
+            pushFinding: (ruleId, severity, filePath, line, message) => {
+                findings.push({ ruleId, severity, filePath, line, message });
+            }
+        };
+    }
+
+    it('does not flag public computed get-only property', () => {
+        const analyzer = makeAnalyzer();
+        const node = {
+            'key.name': 'state',
+            'key.line': 10,
+            'key.kind': 'source.lang.swift.decl.var.instance',
+            'key.accessibility': 'source.lang.swift.accessibility.public',
+            'key.substructure': [
+                { 'key.kind': 'source.lang.swift.decl.function.accessor.get' }
+            ]
+        };
+
+        analyzePropertyAST(analyzer, node, '/tmp/Foo.swift');
+
+        expect(analyzer.findings.find(f => f.ruleId === 'ios.encapsulation.public_mutable')).toBeUndefined();
+    });
+
+    it('flags public stored property (mutable)', () => {
+        const analyzer = makeAnalyzer();
+        const node = {
+            'key.name': 'state',
+            'key.line': 10,
+            'key.kind': 'source.lang.swift.decl.var.instance',
+            'key.accessibility': 'source.lang.swift.accessibility.public'
+        };
+
+        analyzePropertyAST(analyzer, node, '/tmp/Foo.swift');
+
+        expect(analyzer.findings.find(f => f.ruleId === 'ios.encapsulation.public_mutable')).toBeDefined();
+    });
+
+    it('flags public computed property with setter', () => {
+        const analyzer = makeAnalyzer();
+        const node = {
+            'key.name': 'state',
+            'key.line': 10,
+            'key.kind': 'source.lang.swift.decl.var.instance',
+            'key.accessibility': 'source.lang.swift.accessibility.public',
+            'key.substructure': [
+                { 'key.kind': 'source.lang.swift.decl.function.accessor.get' },
+                { 'key.kind': 'source.lang.swift.decl.function.accessor.set' }
+            ]
+        };
+
+        analyzePropertyAST(analyzer, node, '/tmp/Foo.swift');
+
+        expect(analyzer.findings.find(f => f.ruleId === 'ios.encapsulation.public_mutable')).toBeDefined();
+    });
+});

--- a/scripts/hooks-system/infrastructure/ast/ios/detectors/__tests__/ios-unused-imports.spec.js
+++ b/scripts/hooks-system/infrastructure/ast/ios/detectors/__tests__/ios-unused-imports.spec.js
@@ -1,0 +1,34 @@
+const { analyzeImportsAST } = require('../ios-ast-intelligent-strategies');
+
+describe('ios.imports.unused', () => {
+    function makeAnalyzer({ fileContent, allNodes }) {
+        const findings = [];
+        return {
+            fileContent,
+            allNodes,
+            imports: [],
+            functions: [],
+            hasAttribute: () => false,
+            pushFinding: (ruleId, severity, filePath, line, message) => {
+                findings.push({ ruleId, severity, filePath, line, message });
+            },
+            findings,
+        };
+    }
+
+    it('does not report unused imports when types use the module name as a prefix', () => {
+        const filePath = '/tmp/Foo.swift';
+        const analyzer = makeAnalyzer({
+            fileContent: 'import Authentication\n\nstruct Foo { let s: AuthenticationState }',
+            allNodes: [
+                { 'key.typename': 'AuthenticationState' },
+            ]
+        });
+
+        analyzer.imports = [{ name: 'Authentication', line: 1 }];
+
+        analyzeImportsAST(analyzer, filePath);
+
+        expect(analyzer.findings.find(f => f.ruleId === 'ios.imports.unused')).toBeUndefined();
+    });
+});

--- a/scripts/hooks-system/infrastructure/mcp/__tests__/preflight-check-blocks-tests.spec.js
+++ b/scripts/hooks-system/infrastructure/mcp/__tests__/preflight-check-blocks-tests.spec.js
@@ -1,0 +1,14 @@
+const { preFlightCheck } = require('../ast-intelligence-automation');
+
+describe('pre_flight_check - tests are first-class', () => {
+    it('blocks test edits when AST analysis finds CRITICAL violations', () => {
+        const result = preFlightCheck({
+            action_type: 'edit',
+            target_file: '/SomeModule/Tests/FooTests.swift',
+            proposed_code: 'import XCTest\nfinal class FooTests: XCTestCase { func testX() { do { } catch { } } }'
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.blocked).toBe(true);
+    });
+});


### PR DESCRIPTION
## What
- iOS: forbid @testable import (HIGH) with guidance to expose APIs as public/open or via TestUtilities
- iOS tests: enforce makeSUT + trackForMemoryLeaks as HIGH with better detection
- Pre-flight: tests are first-class; block on HIGH/CRITICAL; avoid starting MCP server when imported by Jest
- iOS AST strategies: fix false positives for public_mutable (computed get-only) and imports.unused
- Common: scope makeSUT/leak rules to Swift/Kotlin tests (avoid blocking Jest specs)
- CLI: audit exits with status without Node stacktrace
- Version bump: 5.6.6

## Tests
Focused Jest suite run (6 suites / 12 tests).