### PR TITLE
fix(cli): make npx ast-hooks audit work

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,4 +3,6 @@
  * Script Wrapper
  * Redirects to the centralized implementation in scripts/hooks-system
  */
-require('../scripts/hooks-system/bin/cli.js');
+const { runCli } = require('../scripts/hooks-system/bin/cli.js');
+
+runCli(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.8",
+  "version": "5.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.8",
+      "version": "5.6.9",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.8",
+  "version": "5.6.9",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/bin/cli.js
+++ b/scripts/hooks-system/bin/cli.js
@@ -11,8 +11,8 @@ const fs = require('fs');
 const path = require('path');
 const env = require('../config/env');
 
-const command = process.argv[2];
-const args = process.argv.slice(3);
+let command = process.argv[2];
+let args = process.argv.slice(3);
 
 const HOOKS_ROOT = path.join(__dirname, '..');
 
@@ -623,12 +623,15 @@ Documentation:
   },
 
   version: () => {
-    const pkg = require('../package.json');
+    const pkg = require(path.join(__dirname, '../../../package.json'));
     console.log(`v${pkg.version}`);
   }
 };
 
-if (require.main === module) {
+function runCli(argv = process.argv) {
+  command = argv[2];
+  args = argv.slice(3);
+
   if (!command || !commands[command]) {
     commands.help();
     process.exit(command ? 1 : 0);
@@ -636,4 +639,8 @@ if (require.main === module) {
   commands[command]();
 }
 
-module.exports = { commands, proposeHumanIntent };
+if (require.main === module) {
+  runCli(process.argv);
+}
+
+module.exports = { commands, proposeHumanIntent, runCli };


### PR DESCRIPTION
Fix npm bin wrapper so `npx ast-hooks audit` executes the CLI (previously a no-op due to require.main check). Includes version bump to 5.6.9.