### PR TITLE
fix(install): avoid ts-morph warning in monorepos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.9",
+      "version": "5.6.10",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/application/services/installation/CriticalDependenciesService.js
+++ b/scripts/hooks-system/application/services/installation/CriticalDependenciesService.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+class CriticalDependenciesService {
+    static check({ targetRoot, logger, logWarning, logSuccess }) {
+        const packageJsonPath = path.join(targetRoot, 'package.json');
+
+        if (!fs.existsSync(packageJsonPath)) {
+            logWarning('package.json not found. Skipping dependency check.');
+            return;
+        }
+
+        const isResolvableFromTargetRoot = (name) => {
+            try {
+                require.resolve(name, { paths: [targetRoot] });
+                return true;
+            } catch {
+                return false;
+            }
+        };
+
+        try {
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+            const allDeps = {
+                ...packageJson.dependencies,
+                ...packageJson.devDependencies
+            };
+
+            const criticalDeps = ['ts-morph'];
+            const missingDeps = [];
+
+            for (const dep of criticalDeps) {
+                if (allDeps[dep]) {
+                    continue;
+                }
+                if (isResolvableFromTargetRoot(dep)) {
+                    continue;
+                }
+                missingDeps.push(dep);
+            }
+
+            if (missingDeps.length > 0) {
+                logWarning(`Missing critical dependencies: ${missingDeps.join(', ')}`);
+                logWarning('AST analysis may fail without these dependencies.');
+                logWarning(`Install with: npm install --save-dev ${missingDeps.join(' ')}`);
+                if (logger && typeof logger.warn === 'function') {
+                    logger.warn('MISSING_CRITICAL_DEPENDENCIES', { missingDeps });
+                }
+            } else {
+                logSuccess('All critical dependencies present');
+            }
+        } catch (error) {
+            logWarning(`Failed to check dependencies: ${error.message}`);
+        }
+    }
+}
+
+module.exports = CriticalDependenciesService;


### PR DESCRIPTION
Improve InstallService critical dependency check: if ts-morph is hoisted/resolvable from repo root, do not warn even when not declared in root package.json. Adds tests.