### PR TITLE
chore(release): bump version to 5.6.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.10",
+  "version": "5.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.10",
+      "version": "5.6.11",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.10",
+  "version": "5.6.11",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/application/services/installation/VSCodeTaskConfigurator.js
+++ b/scripts/hooks-system/application/services/installation/VSCodeTaskConfigurator.js
@@ -61,25 +61,11 @@ class VSCodeTaskConfigurator {
                 args: [
                     '-lc',
                     [
-                        'ROOT="${workspaceFolder}"',
-                        'PRIMARY="$ROOT/scripts/hooks-system/bin/session-loader.sh"',
-                        'FALLBACK="$ROOT/node_modules/pumuki-ast-hooks/scripts/hooks-system/bin/session-loader.sh"',
-                        'FALLBACK2="$ROOT/node_modules/@pumuki/ast-intelligence-hooks/bin/session-loader.sh"',
-                        'if [ -f "$PRIMARY" ]; then',
-                        '  exec bash "$PRIMARY"',
-                        'elif [ -f "$FALLBACK" ]; then',
-                        '  exec bash "$FALLBACK"',
-                        'elif [ -f "$FALLBACK2" ]; then',
-                        '  exec bash "$FALLBACK2"',
-                        'else',
-                        '  echo "AST Session Loader not found." >&2',
-                        '  echo "Tried:" >&2',
-                        '  echo "  - $PRIMARY" >&2',
-                        '  echo "  - $FALLBACK" >&2',
-                        '  echo "  - $FALLBACK2" >&2',
-                        '  exit 127',
-                        'fi'
-                    ].join('\n')
+                        'bash "${workspaceFolder}/scripts/hooks-system/bin/session-loader.sh"',
+                        '|| bash "${workspaceFolder}/node_modules/pumuki-ast-hooks/scripts/hooks-system/bin/session-loader.sh"',
+                        '|| bash "${workspaceFolder}/node_modules/@pumuki/ast-intelligence-hooks/bin/session-loader.sh"',
+                        '|| (echo "AST Session Loader not found." >&2; exit 127)'
+                    ].join(' ')
                 ],
                 problemMatcher: [],
                 runOptions: {

--- a/scripts/hooks-system/application/services/installation/__tests__/VSCodeTaskConfigurator.spec.js
+++ b/scripts/hooks-system/application/services/installation/__tests__/VSCodeTaskConfigurator.spec.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const VSCodeTaskConfigurator = require('../VSCodeTaskConfigurator');
+
+describe('VSCodeTaskConfigurator', () => {
+    let testRoot;
+
+    beforeEach(() => {
+        testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ast-hooks-vscode-task-'));
+    });
+
+    afterEach(() => {
+        if (testRoot && fs.existsSync(testRoot)) {
+            fs.rmSync(testRoot, { recursive: true, force: true });
+        }
+    });
+
+    it('should generate AST Session Loader task with a short command (no multiline bash -lc script)', () => {
+        const configurator = new VSCodeTaskConfigurator(testRoot, null);
+        configurator.configure();
+
+        const tasksJsonPath = path.join(testRoot, '.vscode', 'tasks.json');
+        expect(fs.existsSync(tasksJsonPath)).toBe(true);
+
+        const tasksJson = JSON.parse(fs.readFileSync(tasksJsonPath, 'utf8'));
+        const task = tasksJson.tasks.find(t => t.label === 'AST Session Loader' || t.identifier === 'ast-session-loader');
+        expect(task).toBeTruthy();
+
+        expect(task.command).toBe('bash');
+        expect(Array.isArray(task.args)).toBe(true);
+
+        // Current implementation embeds a multi-line script in args[1] (very noisy in terminal as "Executing task: ...")
+        // We want a single-line command.
+        expect(String(task.args[1] || '')).not.toContain('\n');
+    });
+});

--- a/scripts/hooks-system/bin/__tests__/session-loader.spec.js
+++ b/scripts/hooks-system/bin/__tests__/session-loader.spec.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('session-loader.sh', () => {
+    it('should not hardcode the displayed version header', () => {
+        const filePath = path.join(__dirname, '..', 'session-loader.sh');
+        const content = fs.readFileSync(filePath, 'utf8');
+
+        expect(content).not.toContain('AST Intelligence Hooks v5.5.22');
+        expect(content).toMatch(/\bVERSION=/);
+        expect(content).toContain('package.json');
+        expect(content).toMatch(/AST Intelligence Hooks v\$VERSION/);
+    });
+});

--- a/scripts/hooks-system/bin/session-loader.sh
+++ b/scripts/hooks-system/bin/session-loader.sh
@@ -3,6 +3,8 @@
 # Runs on IDE startup to initialize AST hooks, show context and check tokens
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
 
+VERSION=$(node -p "require('${REPO_ROOT}/package.json').version" 2>/dev/null || echo "unknown")
+
 BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 GREEN='\033[0;32m'
@@ -22,7 +24,7 @@ fi
 
 echo ""
 echo -e "${BLUE}╔══════════════════════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║         🤖 AST Intelligence Hooks v5.5.22                ║${NC}"
+echo -e "${BLUE}║         🤖 AST Intelligence Hooks v$VERSION                ║${NC}"
 echo -e "${BLUE}║         Workspace Opened - Loading Context...            ║${NC}"
 echo -e "${BLUE}╚══════════════════════════════════════════════════════════╝${NC}"
 echo ""


### PR DESCRIPTION
## Summary
- Simplify VS Code task `AST Session Loader` to a single-line command (reduces noisy `Executing task:` output)
- Session loader banner now displays version dynamically from `package.json`
- Adds Jest tests to prevent regressions

## Notes
- Patch release to ship the task-output improvement to consumers (e.g. Ruralgo).