### PR TITLE
fix: iOS testing false positives + include assets in npm package (5.6.12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.11",
+  "version": "5.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.11",
+      "version": "5.6.12",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.11",
+  "version": "5.6.12",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {
@@ -116,6 +116,7 @@
     "skills/",
     "hooks/",
     "docs/",
+    "assets/",
     "index.js",
     "README.md",
     "LICENSE"

--- a/tests/package-publish-assets.spec.js
+++ b/tests/package-publish-assets.spec.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('npm package contents', () => {
+    it('should include assets/ folder in package.json files whitelist (README images rely on it)', () => {
+        const pkgPath = path.join(__dirname, '..', 'package.json');
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+        expect(Array.isArray(pkg.files)).toBe(true);
+        expect(pkg.files).toContain('assets/');
+    });
+});


### PR DESCRIPTION
## Changes\n- Fix false positives for  and  in Swift/Kotlin tests by falling back to disk read when ts-morph content is empty (keeps enforcement, improves detection).\n- Ensure  is included in npm package so README images render on npm.\n- Add regression tests for both behaviors.\n\n## Notes\n- This release targets Ruralgo iOS test refactor false positives and npm README visuals.