### PR TITLE
fix(ios): strong enforcement for makeSUT/leak tracking (explicit ignore only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.14",
+  "version": "5.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.14",
+      "version": "5.6.15",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.14",
+  "version": "5.6.15",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/infrastructure/ast/common/ast-common.js
+++ b/scripts/hooks-system/infrastructure/ast/common/ast-common.js
@@ -288,11 +288,8 @@ function runCommonIntelligence(project, findings) {
       }
 
       if (isSwiftOrKotlinTest) {
-        const isSimple = isSimpleValueTypeTest(content);
-
         if (!shouldSkipMakeSUTRule(filePath) &&
           !hasMakeSUT(content) &&
-          !isSimple &&
           !hasAstIgnoreComment(content, 'missing_makesut')) {
           pushFinding(
             'common.testing.missing_makesut',
@@ -306,7 +303,6 @@ function runCommonIntelligence(project, findings) {
 
         if (!shouldSkipTrackForMemoryLeaksRule(filePath) &&
           !hasTrackForMemoryLeaksEvidence(content) &&
-          !isSimple &&
           !hasAstIgnoreComment(content, 'missing_track_for_memory_leaks')) {
           pushFinding(
             'common.testing.missing_track_for_memory_leaks',


### PR DESCRIPTION
## Summary
Switch to strong enforcement policy for Swift/Kotlin testing rules.

## What changed
- Removed heuristic auto-skip ("simple test") from:
  - common.testing.missing_makesut
  - common.testing.missing_track_for_memory_leaks
- The only ways to skip are now explicit:
  - env globs: AST_TESTING_MAKESUT_EXCEPTIONS / AST_TESTING_TRACK_FOR_MEMORY_LEAKS_EXCEPTIONS
  - file-level comment: // ast-ignore: missing_makesut, missing_track_for_memory_leaks

## Why
Heuristics can hide real memory leaks. Strong enforcement guarantees we keep leak tracking and consistent SUT creation unless you explicitly opt out.

## Tests
Updated regression tests:
- Ruralgo value-type test now triggers both rules by default
- Added test that shows ast-ignore disables them

## Version
5.6.15
