### PR TITLE
chore: improve Swift guidance for makeSUT/leak tracking findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.15",
+  "version": "5.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki-ast-hooks",
-      "version": "5.6.15",
+      "version": "5.6.16",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "5.6.15",
+  "version": "5.6.16",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/infrastructure/ast/common/ast-common.js
+++ b/scripts/hooks-system/infrastructure/ast/common/ast-common.js
@@ -296,7 +296,7 @@ function runCommonIntelligence(project, findings) {
             'high',
             sf,
             sf,
-            'Test file without makeSUT factory - use makeSUT pattern for consistent DI and teardown',
+            'Test file without makeSUT factory - use makeSUT pattern for consistent DI and teardown. Swift template:\n\nprivate func makeSUT() -> SUT {\n  let sut = SUT(/* deps */)\n  trackForMemoryLeaks(sut, testCase: self, file: #file, line: #line)\n  return sut\n}\n\nfunc test_example() {\n  let sut = makeSUT()\n  // assertions\n}',
             findings
           );
         }
@@ -309,7 +309,7 @@ function runCommonIntelligence(project, findings) {
             'critical',
             sf,
             sf,
-            'Test file without trackForMemoryLeaks - add memory leak tracking to prevent leaks and cross-test interference',
+            'Test file without trackForMemoryLeaks - add memory leak tracking to prevent leaks and cross-test interference. Swift template (helper must exist):\n\nprivate func makeSUT() -> SUT {\n  let sut = SUT(/* deps */)\n  trackForMemoryLeaks(sut, testCase: self, file: #file, line: #line)\n  return sut\n}\n\nfunc test_example() {\n  let sut = makeSUT()\n  // assertions\n}\n\nAlternative (XCTest native):\naddTeardownBlock { [weak sut] in XCTAssertNil(sut) }',
             findings
           );
         }


### PR DESCRIPTION
## Summary
Improve the actionable guidance for Swift/Kotlin test findings.

## What changed
- `common.testing.missing_makesut`: message now includes a copy/paste Swift template for `makeSUT()` + `trackForMemoryLeaks(..., testCase: self)`.
- `common.testing.missing_track_for_memory_leaks`: message now includes a copy/paste Swift template + XCTest-native alternative.

## Why
So teams (e.g. Ruralgo) do not need to deduce the fix; the rule output itself explains exactly what to implement.

## Version
5.6.16
