### PR TITLE
chore(release): bump version to 6.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## 🎯 Version Bump

Bump version to 6.0.4 for Jest mocking fixes release.

## ✨ Changes

- Jest mocking fixes across 13 test files
- Improved test stability and reliability
- All tests passing (npm test green: 165 test suites, 1094 tests)

---
🐈💚 Pumuki Team® - Release