### PR TITLE
✨ Feature: Auto-config ai-evidence-watcher MCP & macOS notifications

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,47 @@
+# Pumuki AST Intelligence - Instrucciones para Claude Code
+
+## Flujo Operativo OBLIGATORIO
+
+1. **INICIO SESIÓN**: Ejecutar `npx ast-hooks audit` para refrescar evidencia
+2. **GATE CHECK**: Verificar `.AI_EVIDENCE.json` → `ai_gate.status` antes de editar
+3. **PRE-FLIGHT**: Antes de cada escritura, verificar que no hay violaciones bloqueantes
+4. **CAMBIOS**: Solo editar si gate = ALLOWED
+5. **VALIDACIÓN**: Ejecutar tests + lint + audit después de cambios
+
+## Comandos Disponibles
+
+- `npx ast-hooks audit` - Auditoría completa
+- `npm test` - Ejecutar tests
+- `npm run lint` - Linter
+- `npm run ast:guard:status` - Estado del guard daemon
+
+## Principios No Negociables
+
+- **Idioma**: Todo en inglés en el código
+- **Comandos**: Solo usar los definidos en package.json
+- **Cambios**: Pequeños y verificables
+- **BDD → TDD**: Feature files → specs → implementación
+- **SOLID**: SRP, OCP, LSP, ISP, DIP
+- **Sin Singletons**: Usar Inyección de Dependencias
+- **Sin comentarios**: Nombres autodescriptivos
+
+## Si Gate = BLOCKED
+
+1. Leer `.AI_EVIDENCE.json` → `ai_gate.violations`
+2. Ordenar por severidad: CRITICAL > HIGH > MEDIUM > LOW
+3. Corregir violaciones una por una
+4. Re-ejecutar `npx ast-hooks audit`
+5. Verificar gate status
+
+## Definition of Done
+
+- ✅ Tests pasan
+- ✅ Lint sin errores
+- ✅ Gate status = ALLOWED
+- ✅ Evidence actualizado
+
+## Reglas Modulares
+
+Ver `.claude/rules/` para reglas específicas por plataforma.
+
+@AGENTS.md

--- a/.claude/rules/gate-workflow.md
+++ b/.claude/rules/gate-workflow.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "**/*.js"
+  - "**/*.ts"
+  - "**/*.swift"
+---
+
+# Regla: Gate Workflow
+
+Antes de editar cualquier archivo de código:
+
+1. Verificar `.AI_EVIDENCE.json` → `ai_gate.status`
+2. Si `BLOCKED` → NO editar, resolver violaciones primero
+3. Si `ALLOWED` → Proceder con la edición
+
+Después de cada edición:
+
+1. Ejecutar `npx ast-hooks audit`
+2. Verificar que no se introdujeron nuevas violaciones

--- a/.codex/skills/pumuki-audit-workflow/SKILL.md
+++ b/.codex/skills/pumuki-audit-workflow/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: pumuki-audit-workflow
+description: Ejecuta el flujo completo de auditoría y validación antes de commit o al finalizar una tarea.
+metadata:
+  short-description: Auditoría y Definition of Done
+---
+
+## Activación
+
+Usar este skill cuando:
+- Antes de hacer commit
+- Usuario dice: "pasar auditoría", "definition of done", "verificar calidad"
+- Al finalizar una tarea o feature
+
+## Instrucciones
+
+### 1. Ejecutar tests
+
+```bash
+npm test
+```
+
+Si fallan → Corregir antes de continuar
+
+### 2. Ejecutar linter
+
+```bash
+npm run lint
+```
+
+Si hay errores → Corregir antes de continuar
+
+### 3. Actualizar evidencia
+
+```bash
+npx ast-hooks audit
+```
+
+### 4. Verificar gate final
+
+Ejecutar MCP tool `ai_gate_check()`:
+
+- `ALLOWED` → Definition of Done cumplido
+- `BLOCKED` → Resolver violaciones pendientes
+
+## Definition of Done Checklist
+
+- [ ] Tests pasan
+- [ ] Lint sin errores
+- [ ] Gate status = ALLOWED
+- [ ] `.AI_EVIDENCE.json` actualizado
+
+## Output
+
+```
+✅ Tests: PASSED
+✅ Lint: OK
+✅ Gate: ALLOWED
+✅ Evidence: FRESH
+✅ Definition of Done: CUMPLIDO
+```

--- a/.codex/skills/pumuki-gate-and-evidence/SKILL.md
+++ b/.codex/skills/pumuki-gate-and-evidence/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pumuki-gate-and-evidence
+description: Gestiona el gate check y la evidencia del sistema Pumuki al inicio de sesión o antes de editar código.
+metadata:
+  short-description: Gate check y evidencia Pumuki
+---
+
+## Activación
+
+Usar este skill cuando:
+- Inicio de sesión de trabajo
+- Antes de editar código
+- Usuario dice: "abre sesión", "empezar tarea", "antes de editar"
+
+## Instrucciones
+
+### 1. Gate Check (OBLIGATORIO)
+
+Ejecutar MCP tool `ai_gate_check()`:
+
+- `ALLOWED` → Continuar con el trabajo
+- `BLOCKED` → NO editar, resolver violaciones primero
+
+### 2. Si BLOCKED
+
+1. Leer `.AI_EVIDENCE.json` → `ai_gate.violations`
+2. Ordenar: CRITICAL > HIGH > MEDIUM > LOW
+3. Proponer fixes para cada violación
+4. Re-ejecutar `ai_gate_check()` después de cada fix
+
+### 3. Verificar Guard Daemon
+
+```bash
+npm run ast:guard:status
+```
+
+Si no está corriendo:
+
+```bash
+npm run ast:guard:start
+```
+
+## Output
+
+- ✅ Gate status: ALLOWED
+- ✅ Guard daemon: running
+- ✅ Listo para editar código

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ scripts/hooks-system/.hook-system/
 
 # IDE-specific configurations (user-specific)
 .windsurf/
+!.windsurf/skills/
 .cursor/mcp.json
 .cursor/settings.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# Pumuki AST Intelligence - Guía de Agentes IA
+
+## Flujo Operativo (OBLIGATORIO)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  1. INICIO SESIÓN                                               │
+│     npx ast-hooks audit  →  Refresca .AI_EVIDENCE.json          │
+│     npm run ast:guard:status  →  Verifica que guard esté activo │
+├─────────────────────────────────────────────────────────────────┤
+│  2. GATE CHECK (antes de cualquier acción)                      │
+│     MCP: ai_gate_check()                                        │
+│     Si BLOCKED → NO editar, arreglar violaciones primero        │
+├─────────────────────────────────────────────────────────────────┤
+│  3. PRE-FLIGHT (antes de cada escritura)                        │
+│     MCP: pre_flight_check({ action_type, target_file })         │
+│     Si blocked=true → NO escribir                               │
+├─────────────────────────────────────────────────────────────────┤
+│  4. CAMBIOS                                                     │
+│     Editar ficheros (solo si gate/pre-flight = ALLOWED)         │
+├─────────────────────────────────────────────────────────────────┤
+│  5. VALIDACIÓN                                                  │
+│     npm test  →  Tests pasan                                    │
+│     npm run lint  →  Sin errores                                │
+│     npx ast-hooks audit  →  Actualiza evidence                  │
+├─────────────────────────────────────────────────────────────────┤
+│  6. DEFINITION OF DONE                                          │
+│     ✅ Gate status = ALLOWED                                    │
+│     ✅ Tests pasan                                               │
+│     ✅ Lint sin errores                                          │
+│     ✅ .AI_EVIDENCE.json actualizado                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Si BLOCKED
+
+1. Leer `.AI_EVIDENCE.json` → sección `ai_gate.violations`
+2. Ordenar por severidad: CRITICAL > HIGH > MEDIUM > LOW
+3. Arreglar violaciones una por una
+4. Re-ejecutar `npx ast-hooks audit`
+5. Verificar gate con MCP `ai_gate_check()`
+
+## Comandos Reales Disponibles
+
+| Comando | Descripción |
+|---------|-------------|
+| `npx ast-hooks audit` | Auditoría completa + actualiza evidence |
+| `npm run ast` | Alias de audit |
+| `npm test` | Ejecuta tests Jest |
+| `npm run lint` | Linter ESLint |
+| `npm run ast:guard:status` | Estado del guard daemon |
+| `npm run gitflow` | Verificar Git Flow compliance |
+
+## Reglas Humanas vs Enforzables
+
+### Reglas Humanas (guía, no bloquean)
+- Preferir composición sobre herencia
+- Nombres autodescriptivos en inglés
+- Documentación mínima necesaria
+- KISS / YAGNI
+
+### Reglas Enforzables (bloquean si se violan)
+- `backend.antipattern.god_classes` → CRITICAL
+- `common.error.empty_catch` → CRITICAL
+- `ios.solid.dip.concrete_dependency` → HIGH
+- `common.testing.prefer_spy_over_mock` → HIGH
+
+Ver `skills/skill-rules.json` para lista completa de reglas enforzables.
+
+## Estructura del Repo
+
+```
+ast-intelligence-hooks/
+├── bin/                    # CLIs ejecutables
+├── scripts/hooks-system/   # Core del sistema
+│   ├── application/        # Use cases, servicios
+│   ├── domain/             # Entidades, puertos
+│   ├── infrastructure/     # Adaptadores, AST
+│   └── presentation/       # MCP server, CLI
+├── skills/                 # Guidelines por plataforma
+├── docs/                   # Documentación
+├── packs/                  # Packs portables por plataforma
+└── .windsurf/skills/       # Skills Windsurf
+```
+
+## Principios No Negociables
+
+- **Todo en español** (respuestas, docs operacionales)
+- **No inventar comandos** (usar solo los de package.json)
+- **Cambios pequeños y verificables**
+- **BDD → TDD** (feature files → specs → implementación)
+- **Sin comentarios en código** (nombres autodescriptivos)
+- **SOLID estricto** (SRP, OCP, LSP, ISP, DIP)
+- **Sin Singletons** (usar Inyección de Dependencias)
+
+---
+🐈💚 Pumuki Team® - AST Intelligence Framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `@pumuki-ast-intelligence-hooks` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-01-13
+
+### Added
+
+- **MCP evidence watcher auto-config**: `ast-install` now configures `ai-evidence-watcher` alongside the automation MCP server in `.cursor/mcp.json` and `.windsurf/mcp.json`.
+- **Idempotent MCP merge**: installer preserves user MCP servers, removes only legacy framework IDs, and avoids duplicated entries across re-installs.
+- **macOS notifications**: `MCP_MAC_NOTIFICATIONS` is enabled by default for `ai-evidence-watcher`.
+
 ## [6.0.16] - 2026-01-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "6.0.16",
+  "version": "6.1.0",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/application/services/installation/__tests__/McpConfigurator.mcp.spec.js
+++ b/scripts/hooks-system/application/services/installation/__tests__/McpConfigurator.mcp.spec.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const McpServerConfigBuilder = require('../mcp/McpServerConfigBuilder');
+const McpProjectConfigWriter = require('../mcp/McpProjectConfigWriter');
+
+describe('MCP installer (project-scoped)', () => {
+    let testRoot;
+
+    beforeEach(() => {
+        testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ast-hooks-mcp-'));
+        fs.mkdirSync(path.join(testRoot, 'scripts', 'hooks-system', 'infrastructure', 'mcp'), { recursive: true });
+        fs.writeFileSync(
+            path.join(testRoot, 'scripts', 'hooks-system', 'infrastructure', 'mcp', 'ast-intelligence-automation.js'),
+            '#!/usr/bin/env node\nprocess.stdin.resume();\n'
+        );
+        fs.writeFileSync(
+            path.join(testRoot, 'scripts', 'hooks-system', 'infrastructure', 'mcp', 'evidence-watcher.js'),
+            '#!/usr/bin/env node\nprocess.stdin.resume();\n'
+        );
+    });
+
+    afterEach(() => {
+        if (testRoot && fs.existsSync(testRoot)) {
+            fs.rmSync(testRoot, { recursive: true, force: true });
+        }
+    });
+
+    it('should write Cursor and Windsurf MCP configs with automation + evidence watcher servers', () => {
+        const builder = new McpServerConfigBuilder(testRoot, null, null);
+        const { serverId, mcpConfig } = builder.build();
+
+        const writer = new McpProjectConfigWriter(testRoot, null, null, null, null);
+        writer.configureProjectScoped(mcpConfig, serverId);
+
+        const cursorPath = path.join(testRoot, '.cursor', 'mcp.json');
+        const windsurfPath = path.join(testRoot, '.windsurf', 'mcp.json');
+
+        expect(fs.existsSync(cursorPath)).toBe(true);
+        expect(fs.existsSync(windsurfPath)).toBe(true);
+
+        const cursor = JSON.parse(fs.readFileSync(cursorPath, 'utf8'));
+        const windsurf = JSON.parse(fs.readFileSync(windsurfPath, 'utf8'));
+
+        const cursorServers = Object.keys(cursor.mcpServers || {});
+        const windsurfServers = Object.keys(windsurf.mcpServers || {});
+
+        expect(cursorServers.some(id => id.startsWith('ast-intelligence-automation-'))).toBe(true);
+        expect(cursorServers.some(id => id.startsWith('ai-evidence-watcher-'))).toBe(true);
+
+        expect(windsurfServers.some(id => id.startsWith('ast-intelligence-automation-'))).toBe(true);
+        expect(windsurfServers.some(id => id.startsWith('ai-evidence-watcher-'))).toBe(true);
+    });
+
+    it('should be idempotent and not duplicate servers across runs', () => {
+        const builder = new McpServerConfigBuilder(testRoot, null, null);
+        const { serverId, mcpConfig } = builder.build();
+
+        const writer = new McpProjectConfigWriter(testRoot, null, null, null, null);
+        writer.configureProjectScoped(mcpConfig, serverId);
+        writer.configureProjectScoped(mcpConfig, serverId);
+
+        const cursorPath = path.join(testRoot, '.cursor', 'mcp.json');
+        const cursor = JSON.parse(fs.readFileSync(cursorPath, 'utf8'));
+
+        const ids = Object.keys(cursor.mcpServers || {});
+        const automation = ids.filter(id => id.startsWith('ast-intelligence-automation-'));
+        const evidence = ids.filter(id => id.startsWith('ai-evidence-watcher-'));
+
+        expect(automation.length).toBe(1);
+        expect(evidence.length).toBe(1);
+    });
+});

--- a/scripts/hooks-system/application/services/installation/mcp/McpProjectConfigWriter.js
+++ b/scripts/hooks-system/application/services/installation/mcp/McpProjectConfigWriter.js
@@ -37,12 +37,24 @@ class McpProjectConfigWriter {
             if (fs.existsSync(filePath)) {
                 const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
                 if (!existing.mcpServers) existing.mcpServers = {};
+
+                const newServerIds = Object.keys(mcpConfig.mcpServers || {});
+                const prefixesToDedupe = ['ast-intelligence-automation-', 'ai-evidence-watcher-'];
+
                 Object.keys(existing.mcpServers).forEach(id => {
-                    if (id.startsWith('ast-intelligence-automation-') && id !== serverId) {
+                    const shouldDedupe = prefixesToDedupe.some(prefix => id.startsWith(prefix));
+                    if (!shouldDedupe) {
+                        return;
+                    }
+
+                    if (!newServerIds.includes(id)) {
                         delete existing.mcpServers[id];
                     }
                 });
-                existing.mcpServers[serverId] = mcpConfig.mcpServers[serverId];
+
+                newServerIds.forEach(id => {
+                    existing.mcpServers[id] = mcpConfig.mcpServers[id];
+                });
                 finalConfig = existing;
             }
 

--- a/scripts/hooks-system/infrastructure/mcp/services/McpProtocolHandler.js
+++ b/scripts/hooks-system/infrastructure/mcp/services/McpProtocolHandler.js
@@ -12,6 +12,23 @@ class McpProtocolHandler {
         this.buffer = Buffer.alloc(0);
     }
 
+    sendNotificationMessage(level, message) {
+        const payload = {
+            jsonrpc: '2.0',
+            method: 'notifications/message',
+            params: {
+                level,
+                message
+            }
+        };
+
+        this.outputStream.write(JSON.stringify(payload) + '\n');
+
+        if (typeof this.outputStream.flush === 'function') {
+            this.outputStream.flush();
+        }
+    }
+
     start(messageHandler) {
         if (process.env.DEBUG) {
             process.stderr.write('[MCP] Protocol handler starting...\n');

--- a/scripts/hooks-system/infrastructure/mcp/services/__tests__/McpProtocolHandler.notifications.spec.js
+++ b/scripts/hooks-system/infrastructure/mcp/services/__tests__/McpProtocolHandler.notifications.spec.js
@@ -1,0 +1,22 @@
+const { PassThrough } = require('stream');
+
+const McpProtocolHandler = require('../McpProtocolHandler');
+
+describe('McpProtocolHandler notifications', () => {
+    it('should write notifications/message to output stream', async () => {
+        const input = new PassThrough();
+        const output = new PassThrough();
+
+        const handler = new McpProtocolHandler(input, output, null);
+
+        handler.sendNotificationMessage('info', 'Evidence updated');
+
+        const written = output.read().toString('utf8').trim();
+        const parsed = JSON.parse(written);
+
+        expect(parsed.jsonrpc).toBe('2.0');
+        expect(parsed.method).toBe('notifications/message');
+        expect(parsed.params.level).toBe('info');
+        expect(parsed.params.message).toBe('Evidence updated');
+    });
+});


### PR DESCRIPTION
## 🎯 Summary
Automate MCP setup for ai-evidence-watcher during installation, including default macOS notifications and idempotent merge behavior.

## ✨ Changes
- Add ai-evidence-watcher MCP server to generated project configs (.cursor/.windsurf)
- Make MCP config merge idempotent and preserve user servers
- Enable MCP_MAC_NOTIFICATIONS by default for the watcher
- Add installation tests for MCP configurator
- Bump version to 6.1.0 and update CHANGELOG

## ✅ Testing
- npm test

---
🐈💚 Pumuki Team® - Automated Git Flow