### PR TITLE
docs: fix npm documentation (npx ast-install)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `pumuki-ast-hooks` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.7] - 2026-01-15
+
+### Fixed
+
+- **Documentation in npm**: Updated README, USAGE, and INSTALLATION to reflect correct Quick Start commands (`npx ast-install` instead of `npm run install-hooks`).
+
+## [6.1.6] - 2026-01-15
+
+### Added
+
+- **`npx ast-uninstall`**: New command for safe cleanup of framework artifacts (dry-run by default, `--apply --yes` to execute).
+
 ## [6.1.5] - 2026-01-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Portable, project‑agnostic, multi‑platform enterprise framework to govern AI
 ## Quick Start (30–60s)
 
 ```bash
+git init
 npm install --save-dev pumuki-ast-hooks
-npm run install-hooks
-npx ast-hooks
+npx ast-install
+npx ast-hooks audit
 ```
 
 Default installation mode is `npm-runtime`.
@@ -26,7 +27,7 @@ Default installation mode is `npm-runtime`.
 To opt into an embedded runtime copy (`vendored` mode):
 
 ```bash
-HOOK_INSTALL_MODE=vendored npm run install-hooks
+HOOK_INSTALL_MODE=vendored npx ast-install
 ```
 
 ---

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -84,11 +84,11 @@ The installer will detect if Git is missing and show a clear warning:
 ### Option 1: Local Installation (Recommended)
 
 ```bash
-# Install as development dependency
+# Install as dev dependency
 npm install --save-dev pumuki-ast-hooks
 
 # Configure hooks
-npm run install-hooks
+npx ast-install
 ```
 
 By default, the installer uses npm-runtime mode (no embedded copy of `scripts/hooks-system` into your project). To use the vendored mode (embedded runtime), run the installer with `HOOK_INSTALL_MODE=vendored`.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -17,8 +17,9 @@
 ### Step 1: Install
 
 ```bash
+git init
 npm install --save-dev pumuki-ast-hooks
-npm run install-hooks
+npx ast-install
 ```
 
 ### Step 2: Make a commit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Fix documentación en npm

### Problema
La versión 6.1.6 publicada en npm muestra documentación desactualizada en el README:
- ❌ `npm run install-hooks` (comando que no existe en proyectos consumidores)
- ✅ Debería ser `npx ast-install`

### Solución
Actualizar README, USAGE e INSTALLATION para reflejar los comandos correctos:
- `git init` (necesario para Quick Start reproducible)
- `npx ast-install` (en lugar de `npm run install-hooks`)
- `npx ast-hooks audit` (comando completo)

### Archivos actualizados
- `README.md` - Quick Start corregido
- `docs/USAGE.md` - Minimal Example corregido
- `docs/INSTALLATION.md` - Comandos de instalación corregidos
- `CHANGELOG.md` - Entrada para 6.1.7
- `package.json` - Bump a 6.1.7

### Verificación
- Tests: ✅ PASS
- Lint: ✅ PASS
