### PR TITLE
fix: stable MCP server aliases for Codex/Windsurf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Installation manifest**: `ast-install` now generates `.ast-intelligence/install-manifest.json` tracking all created files and directories.
 - **Manifest-based uninstall**: `ast-uninstall` uses the manifest for precise cleanup when available, falling back to heuristic detection for older installations.
 
+## [6.1.10] - 2026-01-15
+
+### Fixed
+
+- **MCP stable server alias**: project-scoped MCP config now includes stable aliases `ast-intelligence-automation-hooks` and `ai-evidence-watcher-hooks` to avoid "unknown MCP server" in Codex/Windsurf when the client expects those IDs.
+
 ## [6.1.8] - 2026-01-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "6.1.9",
+  "version": "6.1.10",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/application/services/installation/__tests__/McpConfigurator.mcp.spec.js
+++ b/scripts/hooks-system/application/services/installation/__tests__/McpConfigurator.mcp.spec.js
@@ -49,8 +49,14 @@ describe('MCP installer (project-scoped)', () => {
         expect(cursorServers.some(id => id.startsWith('ast-intelligence-automation-'))).toBe(true);
         expect(cursorServers.some(id => id.startsWith('ai-evidence-watcher-'))).toBe(true);
 
+        expect(cursorServers).toContain('ast-intelligence-automation-hooks');
+        expect(cursorServers).toContain('ai-evidence-watcher-hooks');
+
         expect(windsurfServers.some(id => id.startsWith('ast-intelligence-automation-'))).toBe(true);
         expect(windsurfServers.some(id => id.startsWith('ai-evidence-watcher-'))).toBe(true);
+
+        expect(windsurfServers).toContain('ast-intelligence-automation-hooks');
+        expect(windsurfServers).toContain('ai-evidence-watcher-hooks');
     });
 
     it('should be idempotent and not duplicate servers across runs', () => {
@@ -65,10 +71,13 @@ describe('MCP installer (project-scoped)', () => {
         const cursor = JSON.parse(fs.readFileSync(cursorPath, 'utf8'));
 
         const ids = Object.keys(cursor.mcpServers || {});
-        const automation = ids.filter(id => id.startsWith('ast-intelligence-automation-'));
-        const evidence = ids.filter(id => id.startsWith('ai-evidence-watcher-'));
+        const automation = ids.filter(id => id.startsWith('ast-intelligence-automation-') && id !== 'ast-intelligence-automation-hooks');
+        const evidence = ids.filter(id => id.startsWith('ai-evidence-watcher-') && id !== 'ai-evidence-watcher-hooks');
 
         expect(automation.length).toBe(1);
         expect(evidence.length).toBe(1);
+
+        expect(ids.filter(id => id === 'ast-intelligence-automation-hooks').length).toBe(1);
+        expect(ids.filter(id => id === 'ai-evidence-watcher-hooks').length).toBe(1);
     });
 });

--- a/scripts/hooks-system/application/services/installation/mcp/McpServerConfigBuilder.js
+++ b/scripts/hooks-system/application/services/installation/mcp/McpServerConfigBuilder.js
@@ -27,6 +27,9 @@ class McpServerConfigBuilder {
         const evidenceEntrypoint = this.resolveEvidenceWatcherEntrypoint();
         const nodePath = this.resolveNodeBinary();
 
+        const stableAutomationAlias = 'ast-intelligence-automation-hooks';
+        const stableEvidenceAlias = 'ai-evidence-watcher-hooks';
+
         const mcpConfig = {
             mcpServers: {
                 [serverId]: {
@@ -40,6 +43,24 @@ class McpServerConfigBuilder {
                     }
                 },
                 [evidenceWatcherServerId]: {
+                    command: nodePath,
+                    args: [evidenceEntrypoint],
+                    env: {
+                        REPO_ROOT: this.targetRoot,
+                        MCP_MAC_NOTIFICATIONS: 'true'
+                    }
+                },
+                [stableAutomationAlias]: {
+                    command: nodePath,
+                    args: [entrypoint],
+                    env: {
+                        REPO_ROOT: this.targetRoot,
+                        AUTO_COMMIT_ENABLED: 'false',
+                        AUTO_PUSH_ENABLED: 'false',
+                        AUTO_PR_ENABLED: 'false'
+                    }
+                },
+                [stableEvidenceAlias]: {
                     command: nodePath,
                     args: [evidenceEntrypoint],
                     env: {


### PR DESCRIPTION
## Context

En RuralGO/Codex se reporta "unknown MCP server" al intentar llamar `ai_gate_check`, porque el cliente espera un ID estable (`ast-intelligence-automation-hooks`) pero el instalador solo genera IDs únicos por repo (`ast-intelligence-automation-<slug>-<fp>`).

## What changed

- `McpServerConfigBuilder` ahora incluye aliases estables:
  - `ast-intelligence-automation-hooks`
  - `ai-evidence-watcher-hooks`
- Se mantienen los IDs únicos por repo para evitar colisiones multi-proyecto.
- Tests actualizados para cubrir presencia de aliases y idempotencia.

## Impact

- Codex/Windsurf pueden registrar el servidor MCP de forma determinista.
- Evita el error "unknown MCP server" cuando el cliente usa IDs estables.

## Version

Bump patch: `6.1.10`.

## Tests

- `npm test -- McpConfigurator.mcp --no-coverage` ✅
- `npm run lint` ✅
