### PR TITLE
fix(ios): add AnyView exceptions for RouteRegistry and fix makeSUT test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to `pumuki-ast-hooks` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.5] - 2026-01-25
+
+### Fixed
+
+- **ios.swiftui.forbidden_any_view**: Added exceptions for legitimate AnyView usage:
+  - `RouteRegistry` files (navigation type erasure)
+  - `RouteViewFactory` files (factory pattern)
+  - `NavigationRegistry` files (navigation pattern)
+  - Files containing `// AnyView: authorized` comment
+  - Files containing `// anyview-ok` comment
+  - Files containing `@AnyViewAuthorized` annotation
+- **iOSModernPracticesRules**: Fixed `pushFinding` function signature to use `pushFileFinding` correctly
+
+### Added
+
+- New test suite `ios-anyview-exceptions.spec.js` with 6 tests for AnyView exception handling
+
+---
+
 ## [6.2.0] - 2026-01-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/infrastructure/ast/ios/__tests__/missing-makesut-leaks.spec.js
+++ b/scripts/hooks-system/infrastructure/ast/ios/__tests__/missing-makesut-leaks.spec.js
@@ -1,12 +1,14 @@
 const { detectMissingMakeSUT, detectMissingLeakTracking } = require('../ast-ios');
 
 describe('iOS testing rules - makeSUT / leak tracking', () => {
-    it('flags missing makeSUT as HIGH when tests exist', () => {
+    it('flags missing makeSUT as HIGH when 3+ tests exist', () => {
         const filePath = '/SomeModule/Tests/FooTests.swift';
         const content = [
             'import XCTest',
             'final class FooTests: XCTestCase {',
             '  func test_one() { XCTAssertTrue(true) }',
+            '  func test_two() { XCTAssertTrue(true) }',
+            '  func test_three() { XCTAssertTrue(true) }',
             '}'
         ].join('\n');
 

--- a/tests/integration/ios-anyview-exceptions.spec.js
+++ b/tests/integration/ios-anyview-exceptions.spec.js
@@ -1,0 +1,111 @@
+const path = require('path');
+const { iOSModernPracticesRules } = require('../../scripts/hooks-system/infrastructure/ast/ios/analyzers/iOSModernPracticesRules');
+
+describe('iOS AnyView Exceptions', () => {
+    let findings;
+    let analyzer;
+
+    beforeEach(() => {
+        findings = [];
+        analyzer = new iOSModernPracticesRules(findings, '/tmp/test-project');
+    });
+
+    describe('AnyView detection with exceptions', () => {
+        it('should detect AnyView in regular files', () => {
+            const content = `
+import SwiftUI
+
+struct SomeView: View {
+    var body: some View {
+        AnyView(Text("Hello"))
+    }
+}
+`;
+            analyzer.analyzeFile('/tmp/test-project/SomeView.swift', content);
+
+            const anyViewFindings = findings.filter(f => f.ruleId === 'ios.swiftui.forbidden_any_view');
+            expect(anyViewFindings.length).toBe(1);
+            expect(anyViewFindings[0].severity).toBe('HIGH');
+        });
+
+        it('should NOT detect AnyView in RouteRegistry files', () => {
+            const content = `
+import SwiftUI
+
+@MainActor
+public final class RouteRegistry {
+    public static let shared = RouteRegistry()
+    private var routes: [RouteKey: (RouteContext) -> AnyView] = [:]
+
+    public func register(_ key: RouteKey, builder: @escaping (RouteContext) -> AnyView) {
+        routes[key] = builder
+    }
+}
+`;
+            analyzer.analyzeFile('/tmp/test-project/RouteRegistry.swift', content);
+
+            const anyViewFindings = findings.filter(f => f.ruleId === 'ios.swiftui.forbidden_any_view');
+            expect(anyViewFindings.length).toBe(0);
+        });
+
+        it('should NOT detect AnyView in RouteViewFactory files', () => {
+            const content = `
+import SwiftUI
+
+protocol RouteViewFactory {
+    func makeView(for route: Route) -> AnyView
+}
+`;
+            analyzer.analyzeFile('/tmp/test-project/RouteViewFactory.swift', content);
+
+            const anyViewFindings = findings.filter(f => f.ruleId === 'ios.swiftui.forbidden_any_view');
+            expect(anyViewFindings.length).toBe(0);
+        });
+
+        it('should NOT detect AnyView when authorized comment is present', () => {
+            const content = `
+import SwiftUI
+
+// AnyView: authorized - type erasure needed for dynamic routing
+struct DynamicRouter: View {
+    var body: some View {
+        AnyView(currentView)
+    }
+}
+`;
+            analyzer.analyzeFile('/tmp/test-project/DynamicRouter.swift', content);
+
+            const anyViewFindings = findings.filter(f => f.ruleId === 'ios.swiftui.forbidden_any_view');
+            expect(anyViewFindings.length).toBe(0);
+        });
+
+        it('should NOT detect AnyView with anyview-ok comment', () => {
+            const content = `
+import SwiftUI
+
+// anyview-ok
+func wrapView(_ view: some View) -> AnyView {
+    return AnyView(view)
+}
+`;
+            analyzer.analyzeFile('/tmp/test-project/ViewWrapper.swift', content);
+
+            const anyViewFindings = findings.filter(f => f.ruleId === 'ios.swiftui.forbidden_any_view');
+            expect(anyViewFindings.length).toBe(0);
+        });
+
+        it('should NOT detect AnyView in NavigationRegistry files', () => {
+            const content = `
+import SwiftUI
+
+class NavigationRegistry {
+    var destinations: [String: AnyView] = [:]
+}
+`;
+            analyzer.analyzeFile('/tmp/test-project/NavigationRegistry.swift', content);
+
+            const anyViewFindings = findings.filter(f => f.ruleId === 'ios.swiftui.forbidden_any_view');
+            expect(anyViewFindings.length).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add exceptions for legitimate AnyView usage (RouteRegistry, RouteViewFactory, NavigationRegistry)
- Add authorization comments support (`// AnyView: authorized`, `// anyview-ok`)
- Fix pushFinding wrapper to use pushFileFinding correctly
- Fix missing-makesut-leaks test to require 3+ tests
- Add ios-anyview-exceptions.spec.js with 6 tests
- Bump version to 6.2.5

## Changes

- `iOSModernPracticesRules.js`: Added exceptions array and logic to skip AnyView detection for legitimate uses
- `missing-makesut-leaks.spec.js`: Fixed test to require 3+ tests (matching implementation)
- `ios-anyview-exceptions.spec.js`: New test suite with 6 tests
- `CHANGELOG.md`: Documented v6.2.5 changes
- `package.json`: Version bump to 6.2.5

## Testing

All 177 test suites pass (1136 tests)

---
🐈💚 Pumuki Team® - AST Intelligence Framework