### PR TITLE
fix(ios): last hardcoded_strings false positive v6.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `pumuki-ast-hooks` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.8] - 2026-01-25
+
+### Fixed
+
+- **ios.i18n.hardcoded_strings**: Fixed LAST remaining false positive in text-scanner.js:697 - now checks for `String(localized:)`, `LocalizedStringKey`, `bundle: .module/.presentation`
+
+---
+
 ## [6.2.7] - 2026-01-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki-ast-hooks",
-  "version": "6.2.7",
+  "version": "6.2.8",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/hooks-system/infrastructure/ast/text/text-scanner.js
+++ b/scripts/hooks-system/infrastructure/ast/text/text-scanner.js
@@ -693,7 +693,8 @@ function runTextScanner(root, findings) {
       if (/([A-Za-z_]\w*)\s*!=\s*nil\s*\?\s*\1!\s*:\s*[^\n;]+/.test(content)) {
         pushFileFinding('ios.optionals.missing_nil_coalescing', 'medium', file, 1, 1, 'Prefer ?? over ternary with force unwrap', findings);
       }
-      if (/Text\(\s*\"[^\"]+\"\s*\)/.test(content) && !/NSLocalizedString|\.localized/.test(content)) {
+      const hasL10nSupport = /String\(localized:|LocalizedStringKey|bundle:\s*\.module|bundle:\s*\.presentation|NSLocalizedString|\.localized/.test(content);
+      if (/Text\(\s*\"[^\"]+\"\s*\)/.test(content) && !hasL10nSupport) {
         pushFileFinding('ios.i18n.hardcoded_strings', 'medium', file, 1, 1, 'Hardcoded string in Text() without localization', findings);
       }
       if (!isAnalyzer && !isTestFile && shouldFlagMessageProviderSwitch(content, file, 'swift')) {


### PR DESCRIPTION
Fix last remaining false positive for ios.i18n.hardcoded_strings in text-scanner.js:697