### PR TITLE
fix(ios): resolve false positive in force_unwrapping detector

### DIFF
--- a/scripts/hooks-system/infrastructure/ast/text/text-scanner.js
+++ b/scripts/hooks-system/infrastructure/ast/text/text-scanner.js
@@ -642,8 +642,8 @@ function runTextScanner(root, findings) {
       }
       const hasForceUnwrap = /\w+!\s*[.\[\(\),;\s]/.test(content) || /\bas!\s/.test(content);
       const hasLogicalNegation = /[^\w]!\w/.test(content);
-      const usesLocalization = /String\(localized:/.test(content);
-      if (hasForceUnwrap && !hasLogicalNegation && !/@IBOutlet\b/.test(content) && !usesLocalization) {
+      const usesModernLocalization = /String\(localized:/.test(content) || /bundle:\s*\.module/.test(content) || /bundle:\s*\.presentation/.test(content);
+      if (hasForceUnwrap && !hasLogicalNegation && !/@IBOutlet\b/.test(content) && !usesModernLocalization) {
         pushFileFinding('ios.force_unwrapping', 'high', file, 1, 1, 'Force unwrapping detected', findings);
       }
       if (/\[[ ]*(weak|unowned)[ ]+self[ ]*\]/.test(content) === false && /self\./.test(content) && /\{[^\n]*in/.test(content)) {


### PR DESCRIPTION
## 🐛 Fix

Resolves code review feedback from PR #273.

### Problem
The  detector was reporting false positives in files using modern localization ( with  or ).

### Solution
- Disable detector when file uses modern localization patterns
- Check for: , , 

### Testing
- ✅ No false positives in localized files
- ✅ Still detects real force unwraps in non-localized code

---
🐈💚 Pumuki Team® - AST Intelligence Framework