### PR TITLE
docs: propagate responsive logo and English doc entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Node](https://img.shields.io/badge/node-%3E%3D18-0ea5e9)](package.json)
 [![Evidence](https://img.shields.io/badge/evidence-v2.1-7c3aed)](docs/evidence-v2.1.md)
 
-![Pumuki](assets/logo.png)
+<img src="assets/logo.png" alt="Pumuki" width="100%" />
 
 **Enterprise governance for AI-assisted code delivery**.
 

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -12,8 +12,10 @@
 - ✅ Repo analysis + documentation summary for Pumuki/AST intelligence hooks
 - ✅ PR #287 merged (`enterprise-refactor -> develop`) with refactor/doc closure
 - ✅ Release execution (`6.3.6`) completed: PRs merged, npm `latest` updated, branches cleaned, local/remote synced
-- ✅ npm smoke no interactivo validado con `npx -y pumuki-ast-hooks@latest` (exit opción `27`)
-- ✅ Logo PNG de Pumuki restaurado en `README.md` para branding npm/GitHub
+- ✅ Non-interactive npm smoke validated with `npx -y pumuki-ast-hooks@latest` (exit option `27`)
+- ✅ Pumuki PNG logo restored in `README.md` for npm/GitHub branding
+- ✅ `README.md` logo expanded to full-width responsive layout (`width="100%"`)
+- ✅ Documentation update entries normalized to English
 - 🚧 Post-release monitoring: verify downstream consumers adopt `6.3.6` baseline
 
 ## Phase 1 - Deterministic Core + Evidence v2.1


### PR DESCRIPTION
Release propagation from develop to main:\n- README full-width responsive logo\n- progress-log entries normalized to English