### PR TITLE
feat(menu-matrix): automate non-interactive 1/2/3/4/9 matrix with canary diagnostics

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -324,4 +324,38 @@ Estado operativo del plan activo para restaurar capacidades enterprise sin rompe
 - ✅ Próxima tarea anterior completada: commit atómico del cierre de validación manual ejecutado en local.
 - ✅ Próxima tarea anterior completada: push final de sincronización ejecutado (`fb3c30d -> origin/main`) y rama alineada.
 - ✅ Próxima tarea anterior completada: estado final limpio validado (`git status` = `main...origin/main`) y bloque cerrado.
-- 🚧 Próxima tarea: esperar siguiente instrucción del usuario para abrir nuevo bloque de trabajo.
+- ✅ Próxima tarea anterior completada: instrucción recibida para abrir nuevo bloque.
+
+## Fase 19 — Automatización de Matriz de Menú Consumer (1/2/3/4/9)
+- ✅ RED: crear test de integración que ejecute la matriz `1/2/3/4/9` y valide contrato mínimo por opción (`stage`, `outcome`, `files_scanned`, `total_violations`).
+  - ✅ Test añadido: `scripts/__tests__/framework-menu-matrix-runner.test.ts`.
+  - ✅ Estado RED confirmado: `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-runner.test.ts` falla con `MODULE_NOT_FOUND` de `../framework-menu-matrix-runner-lib`.
+- ✅ GREEN: implementar runner determinista de matriz (sin interacción manual) para menú consumer.
+  - ✅ Implementado: `scripts/framework-menu-matrix-runner-lib.ts` con ejecución secuencial de opciones `1/2/3/4/9` y reporte tipado por opción.
+  - ✅ Validación GREEN: `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-runner.test.ts` (1/1).
+- ✅ REFACTOR: extraer utilidades comunes de parseo/validación de `.ai_evidence.json` usadas por la matriz.
+  - ✅ Nueva utilidad: `scripts/framework-menu-matrix-evidence-lib.ts` (`readMatrixOptionReport`, `toMatrixOptionReport`, tipos compartidos de matriz).
+  - ✅ Runner simplificado: `scripts/framework-menu-matrix-runner-lib.ts` ahora usa `runOption(...)` + utilidad compartida, sin duplicación de normalización.
+  - ✅ Validación post-refactor: `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-runner.test.ts` (1/1).
+- ✅ RED: crear test canario controlado que inyecte una violación temporal y exija detección efectiva en `repo` (`option 1`).
+  - ✅ Test añadido: `scripts/__tests__/framework-menu-matrix-canary.test.ts`.
+  - ✅ Estado RED confirmado: `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-canary.test.ts` falla con `MODULE_NOT_FOUND` de `../framework-menu-matrix-canary-lib`.
+- ✅ GREEN: implementar helper canario reutilizable y cleanup garantizado tras ejecución.
+  - ✅ Implementado: `scripts/framework-menu-matrix-canary-lib.ts`.
+  - ✅ Cubre creación de violación temporal, ejecución de `option 1` (`repo`) y cleanup garantizado en `finally`.
+  - ✅ Validación GREEN: `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-canary.test.ts` (1/1).
+- ✅ REFACTOR: consolidar salida de diagnóstico para diferenciar explícitamente `scope vacío` vs `repo limpio`.
+  - ✅ `scripts/framework-menu-matrix-evidence-lib.ts` ahora emite `diagnosis` por opción: `scope-empty | repo-clean | violations-detected | unknown`.
+  - ✅ `scripts/framework-menu-matrix-runner-lib.ts` y `scripts/framework-menu-matrix-canary-lib.ts` adaptados al nuevo contrato tipado.
+  - ✅ RED del refactor añadido y validado: `scripts/__tests__/framework-menu-matrix-evidence.test.ts`.
+  - ✅ Validación post-refactor:
+    - `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-evidence.test.ts scripts/__tests__/framework-menu-matrix-runner.test.ts scripts/__tests__/framework-menu-matrix-canary.test.ts` (5/5).
+- ✅ Validación: ejecutar suite nueva + suites relacionadas del menú y dejar evidencia de resultados en esta fase.
+  - ✅ Ejecutado:
+    - `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-*.test.ts scripts/__tests__/framework-menu-consumer-runtime.test.ts scripts/__tests__/framework-menu-consumer-actions.test.ts scripts/__tests__/framework-menu-gate-lib.test.ts`
+  - ✅ Resultado: `11/11` tests en verde.
+- ✅ Documentación: actualizar `docs/USAGE.md` con ejecución no interactiva de la matriz y lectura de resultados.
+  - ✅ Añadida sección `1.1) Non-interactive consumer matrix (1/2/3/4/9)` con comando, contrato de salida y semántica de `diagnosis`.
+  - ✅ Añadido comando opcional de canary no interactivo (`runConsumerMenuCanary`) con cleanup garantizado.
+- ✅ Cierre: commit atómico + push y actualización final de esta fase en `REFRACTOR_PROGRESS.md`.
+- 🚧 Próxima tarea: esperar siguiente instrucción del usuario para abrir el siguiente bloque.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -101,6 +101,41 @@ Adapter readiness diagnostics are available from the interactive menu as:
 - `Run phase5 execution closure (one-shot orchestration)`
 - `Clean local validation artifacts`
 
+### 1.1) Non-interactive consumer matrix (1/2/3/4/9)
+
+For deterministic validation without interactive prompts, run the matrix helper:
+
+```bash
+node --import tsx -e "const { runConsumerMenuMatrix } = await import('./scripts/framework-menu-matrix-runner-lib.ts'); const report = await runConsumerMenuMatrix({ repoRoot: process.cwd() }); console.log(JSON.stringify(report, null, 2));"
+```
+
+Expected output shape:
+
+```json
+{
+  "byOption": {
+    "1": { "stage": "PRE_COMMIT", "outcome": "BLOCK|PASS", "filesScanned": 0, "totalViolations": 0, "diagnosis": "scope-empty|repo-clean|violations-detected|unknown" },
+    "2": { "stage": "PRE_PUSH", "outcome": "BLOCK|PASS", "filesScanned": 0, "totalViolations": 0, "diagnosis": "scope-empty|repo-clean|violations-detected|unknown" },
+    "3": { "stage": "PRE_COMMIT", "outcome": "BLOCK|PASS", "filesScanned": 0, "totalViolations": 0, "diagnosis": "scope-empty|repo-clean|violations-detected|unknown" },
+    "4": { "stage": "PRE_PUSH", "outcome": "BLOCK|PASS", "filesScanned": 0, "totalViolations": 0, "diagnosis": "scope-empty|repo-clean|violations-detected|unknown" },
+    "9": { "stage": "PRE_PUSH|PRE_COMMIT", "outcome": "BLOCK|PASS", "filesScanned": 0, "totalViolations": 0, "diagnosis": "scope-empty|repo-clean|violations-detected|unknown" }
+  }
+}
+```
+
+Diagnosis semantics:
+
+- `scope-empty`: selected scope has no files to evaluate (common in option `3` staged-only or option `4` working-tree).
+- `repo-clean`: files were scanned and no violations were detected.
+- `violations-detected`: one or more findings were produced.
+- `unknown`: evidence is missing/invalid or report normalization could not resolve status.
+
+Optional canary execution (controlled temporary violation + cleanup):
+
+```bash
+node --import tsx -e "const { runConsumerMenuCanary } = await import('./scripts/framework-menu-matrix-canary-lib.ts'); const report = await runConsumerMenuCanary({ repoRoot: process.cwd() }); console.log(JSON.stringify(report, null, 2));"
+```
+
 ### 2) Direct stage CLI execution
 
 ```bash

--- a/scripts/__tests__/framework-menu-matrix-canary.test.ts
+++ b/scripts/__tests__/framework-menu-matrix-canary.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runConsumerMenuCanary } from '../framework-menu-matrix-canary-lib';
+
+test('runConsumerMenuCanary inyecta violación temporal y exige detección en opción 1 (repo)', async () => {
+  const result = await runConsumerMenuCanary({ repoRoot: process.cwd() });
+
+  assert.equal(result.option, '1');
+  assert.equal(typeof result.detected, 'boolean');
+  assert.equal(typeof result.totalViolations, 'number');
+  assert.equal(typeof result.filesScanned, 'number');
+  assert.equal(typeof result.ruleIds.includes('skills.backend.no-empty-catch'), 'boolean');
+
+  assert.equal(
+    result.detected,
+    true,
+    'Expected canary detection in option 1 to be true'
+  );
+});

--- a/scripts/__tests__/framework-menu-matrix-evidence.test.ts
+++ b/scripts/__tests__/framework-menu-matrix-evidence.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { toMatrixOptionReport } from '../framework-menu-matrix-evidence-lib';
+import type { LegacyAuditSummary } from '../framework-menu-legacy-audit-lib';
+
+const buildSummary = (overrides: Partial<LegacyAuditSummary>): LegacyAuditSummary => {
+  return {
+    status: 'ok',
+    stage: 'PRE_COMMIT',
+    outcome: 'PASS',
+    totalViolations: 0,
+    filesScanned: 0,
+    filesAffected: 0,
+    bySeverity: {
+      CRITICAL: 0,
+      HIGH: 0,
+      MEDIUM: 0,
+      LOW: 0,
+    },
+    patternChecks: {
+      todoFixme: 0,
+      consoleLog: 0,
+      anyType: 0,
+      sqlRaw: 0,
+    },
+    eslint: {
+      errors: 0,
+      warnings: 0,
+    },
+    platforms: [],
+    rulesets: [],
+    topViolations: [],
+    topFiles: [],
+    codeHealthScore: 100,
+    ...overrides,
+  };
+};
+
+test('toMatrixOptionReport clasifica scope vacío cuando no hay archivos escaneados', () => {
+  const report = toMatrixOptionReport('3', buildSummary({ filesScanned: 0, totalViolations: 0 }));
+  assert.equal(report.diagnosis, 'scope-empty');
+});
+
+test('toMatrixOptionReport clasifica repo limpio cuando hay escaneo sin violaciones', () => {
+  const report = toMatrixOptionReport('1', buildSummary({ filesScanned: 25, totalViolations: 0 }));
+  assert.equal(report.diagnosis, 'repo-clean');
+});
+
+test('toMatrixOptionReport clasifica violaciones detectadas cuando totalViolations > 0', () => {
+  const report = toMatrixOptionReport('2', buildSummary({ filesScanned: 25, totalViolations: 3 }));
+  assert.equal(report.diagnosis, 'violations-detected');
+});

--- a/scripts/__tests__/framework-menu-matrix-runner.test.ts
+++ b/scripts/__tests__/framework-menu-matrix-runner.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runConsumerMenuMatrix } from '../framework-menu-matrix-runner-lib';
+
+test('runConsumerMenuMatrix ejecuta 1/2/3/4/9 y devuelve contrato mínimo por opción', async () => {
+  const result = await runConsumerMenuMatrix({ repoRoot: process.cwd() });
+
+  assert.deepEqual(Object.keys(result.byOption), ['1', '2', '3', '4', '9']);
+
+  const option1 = result.byOption['1'];
+  const option2 = result.byOption['2'];
+  const option3 = result.byOption['3'];
+  const option4 = result.byOption['4'];
+  const option9 = result.byOption['9'];
+
+  assert.ok(option1, 'Expected option 1 report');
+  assert.ok(option2, 'Expected option 2 report');
+  assert.ok(option3, 'Expected option 3 report');
+  assert.ok(option4, 'Expected option 4 report');
+  assert.ok(option9, 'Expected option 9 report');
+
+  assert.equal(typeof option1.stage, 'string');
+  assert.equal(typeof option1.outcome, 'string');
+  assert.equal(typeof option1.filesScanned, 'number');
+  assert.equal(typeof option1.totalViolations, 'number');
+  assert.equal(typeof option1.diagnosis, 'string');
+
+  assert.equal(typeof option2.stage, 'string');
+  assert.equal(typeof option2.outcome, 'string');
+  assert.equal(typeof option2.filesScanned, 'number');
+  assert.equal(typeof option2.totalViolations, 'number');
+  assert.equal(typeof option2.diagnosis, 'string');
+
+  assert.equal(typeof option3.stage, 'string');
+  assert.equal(typeof option3.outcome, 'string');
+  assert.equal(typeof option3.filesScanned, 'number');
+  assert.equal(typeof option3.totalViolations, 'number');
+  assert.equal(typeof option3.diagnosis, 'string');
+
+  assert.equal(typeof option4.stage, 'string');
+  assert.equal(typeof option4.outcome, 'string');
+  assert.equal(typeof option4.filesScanned, 'number');
+  assert.equal(typeof option4.totalViolations, 'number');
+  assert.equal(typeof option4.diagnosis, 'string');
+
+  assert.equal(typeof option9.stage, 'string');
+  assert.equal(typeof option9.outcome, 'string');
+  assert.equal(typeof option9.filesScanned, 'number');
+  assert.equal(typeof option9.totalViolations, 'number');
+  assert.equal(typeof option9.diagnosis, 'string');
+});

--- a/scripts/framework-menu-matrix-canary-lib.ts
+++ b/scripts/framework-menu-matrix-canary-lib.ts
@@ -1,0 +1,81 @@
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { chdir, cwd } from 'node:process';
+import { runRepoGateSilent } from './framework-menu-gate-lib';
+import { readMatrixOptionReport } from './framework-menu-matrix-evidence-lib';
+
+export type ConsumerMenuCanaryResult = {
+  option: '1';
+  detected: boolean;
+  totalViolations: number;
+  filesScanned: number;
+  ruleIds: string[];
+};
+
+const buildCanaryRelativePath = (): string => {
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  return `scripts/__pumuki_matrix_canary_${suffix}.ts`;
+};
+
+const extractRuleIdsFromEvidence = (repoRoot: string): string[] => {
+  const evidencePath = join(repoRoot, '.ai_evidence.json');
+  try {
+    const parsed = JSON.parse(readFileSync(evidencePath, 'utf8')) as {
+      snapshot?: { findings?: Array<{ ruleId?: unknown }> };
+    };
+    const findings = parsed?.snapshot?.findings;
+    if (!Array.isArray(findings)) {
+      return [];
+    }
+    return findings
+      .map((finding) => (typeof finding.ruleId === 'string' ? finding.ruleId : ''))
+      .filter((ruleId) => ruleId.length > 0);
+  } catch {
+    return [];
+  }
+};
+
+export const runConsumerMenuCanary = async (params?: {
+  repoRoot?: string;
+}): Promise<ConsumerMenuCanaryResult> => {
+  const previousCwd = cwd();
+  const repoRoot = params?.repoRoot ?? previousCwd;
+  const canaryRelativePath = buildCanaryRelativePath();
+  const canaryAbsolutePath = join(repoRoot, canaryRelativePath);
+
+  chdir(repoRoot);
+  try {
+    writeFileSync(
+      canaryAbsolutePath,
+      [
+        'export const __pumukiMatrixCanary = (): void => {',
+        '  try {',
+        "    throw new Error('pumuki-matrix-canary')",
+        '  } catch {}',
+        '};',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    await runRepoGateSilent();
+    const option1Report = readMatrixOptionReport(repoRoot, '1');
+    const ruleIds = extractRuleIdsFromEvidence(repoRoot);
+
+    return {
+      option: '1',
+      detected:
+        option1Report.totalViolations > 0 && ruleIds.includes('skills.backend.no-empty-catch'),
+      totalViolations: option1Report.totalViolations,
+      filesScanned: option1Report.filesScanned,
+      ruleIds,
+    };
+  } finally {
+    try {
+      unlinkSync(canaryAbsolutePath);
+    } catch {
+      // best effort cleanup
+    }
+    chdir(previousCwd);
+  }
+};

--- a/scripts/framework-menu-matrix-evidence-lib.ts
+++ b/scripts/framework-menu-matrix-evidence-lib.ts
@@ -1,0 +1,67 @@
+import { readLegacyAuditSummary, type LegacyAuditSummary } from './framework-menu-legacy-audit-lib';
+
+export type MatrixOptionId = '1' | '2' | '3' | '4' | '9';
+export type MatrixOptionDiagnosis =
+  | 'scope-empty'
+  | 'repo-clean'
+  | 'violations-detected'
+  | 'unknown';
+
+export type ConsumerMenuMatrixOptionReport = {
+  stage: string;
+  outcome: string;
+  filesScanned: number;
+  totalViolations: number;
+  diagnosis: MatrixOptionDiagnosis;
+};
+
+export type ConsumerMenuMatrixReport = {
+  byOption: Record<MatrixOptionId, ConsumerMenuMatrixOptionReport>;
+};
+
+const EMPTY_OPTION_REPORT: ConsumerMenuMatrixOptionReport = {
+  stage: 'UNKNOWN',
+  outcome: 'UNKNOWN',
+  filesScanned: 0,
+  totalViolations: 0,
+  diagnosis: 'unknown',
+};
+
+const resolveMatrixOptionDiagnosis = (
+  summary: LegacyAuditSummary
+): MatrixOptionDiagnosis => {
+  if (summary.status !== 'ok') {
+    return 'unknown';
+  }
+  if (summary.totalViolations > 0) {
+    return 'violations-detected';
+  }
+  if (summary.filesScanned <= 0) {
+    return 'scope-empty';
+  }
+  return 'repo-clean';
+};
+
+export const toMatrixOptionReport = (
+  optionId: MatrixOptionId,
+  summary: LegacyAuditSummary
+): ConsumerMenuMatrixOptionReport => {
+  void optionId;
+  if (summary.status !== 'ok') {
+    return EMPTY_OPTION_REPORT;
+  }
+  return {
+    stage: summary.stage,
+    outcome: summary.outcome,
+    filesScanned: summary.filesScanned,
+    totalViolations: summary.totalViolations,
+    diagnosis: resolveMatrixOptionDiagnosis(summary),
+  };
+};
+
+export const readMatrixOptionReport = (
+  repoRoot: string,
+  optionId: MatrixOptionId
+): ConsumerMenuMatrixOptionReport => {
+  return toMatrixOptionReport(optionId, readLegacyAuditSummary(repoRoot));
+};

--- a/scripts/framework-menu-matrix-runner-lib.ts
+++ b/scripts/framework-menu-matrix-runner-lib.ts
@@ -1,0 +1,49 @@
+import { chdir, cwd } from 'node:process';
+import {
+  runRepoAndStagedPrePushGateSilent,
+  runRepoGateSilent,
+  runStagedGateSilent,
+  runWorkingTreePrePushGateSilent,
+} from './framework-menu-gate-lib';
+import {
+  readMatrixOptionReport,
+  type ConsumerMenuMatrixReport,
+  type ConsumerMenuMatrixOptionReport,
+  type MatrixOptionId,
+} from './framework-menu-matrix-evidence-lib';
+
+const runOption = async (
+  optionId: MatrixOptionId,
+  repoRoot: string,
+  gate: () => Promise<void>
+): Promise<ConsumerMenuMatrixOptionReport> => {
+  await gate();
+  return readMatrixOptionReport(repoRoot, optionId);
+};
+
+export const runConsumerMenuMatrix = async (params?: {
+  repoRoot?: string;
+}): Promise<ConsumerMenuMatrixReport> => {
+  const previousCwd = cwd();
+  const repoRoot = params?.repoRoot ?? previousCwd;
+  chdir(repoRoot);
+  try {
+    const option1 = await runOption('1', repoRoot, runRepoGateSilent);
+    const option2 = await runOption('2', repoRoot, runRepoAndStagedPrePushGateSilent);
+    const option3 = await runOption('3', repoRoot, runStagedGateSilent);
+    const option4 = await runOption('4', repoRoot, runWorkingTreePrePushGateSilent);
+    const option9 = readMatrixOptionReport(repoRoot, '9');
+
+    return {
+      byOption: {
+        '1': option1,
+        '2': option2,
+        '3': option3,
+        '4': option4,
+        '9': option9,
+      },
+    };
+  } finally {
+    chdir(previousCwd);
+  }
+};


### PR DESCRIPTION
## Summary
- add non-interactive matrix automation for menu options 1/2/3/4/9
- add canary diagnostics and evidence parser tests for matrix output validation
- update usage and refactor tracker docs for phase-19 closure

## Validation
- npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-*.test.ts scripts/__tests__/framework-menu-consumer-runtime.test.ts scripts/__tests__/framework-menu-consumer-actions.test.ts scripts/__tests__/framework-menu-gate-lib.test.ts
