### PR TITLE
docs: close T8 and set T9 active in stabilization cycle

### DIFF
--- a/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
+++ b/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
@@ -25,16 +25,22 @@ Todas las fases/tareas están definidas por anticipación; no se añaden tareas 
 ## Fase 2 — Hardening legacy scripts
 - ✅ T6. Hardening de comandos Git Flow (`npm run gitflow*`) con contrato TDD.
 - ✅ T7. Saneamiento de aliases legacy rotos de `package.json` (sin targets locales inexistentes).
-- 🚧 T8. Cierre Git Flow del bloque T6+T7.
-  - Preparar commits atómicos del bloque.
-  - Push de feature.
-  - PR a `develop`, merge y validación post-merge (`typecheck` + tests del bloque).
-  - Criterio de salida: bloque integrado end-to-end sin drift.
+- ✅ T8. Cierre Git Flow del bloque T6+T7.
+  - ✅ Commits atómicos del bloque:
+    - `06e2bc2` feat(gitflow): add deterministic gitflow CLI with contract tests
+    - `d9bec69` chore(scripts): fix legacy aliases with missing local targets
+    - `9a0feb1` docs(plan): set stabilization cycle as sole active tracker
+  - ✅ Push de feature ejecutado.
+  - ✅ PR a `develop` mergeada:
+    - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/316`
+  - ✅ Validación post-merge en `develop`:
+    - `npm run typecheck` (verde)
+    - `npx --yes tsx@4.21.0 --test scripts/__tests__/gitflow-cli.test.ts scripts/__tests__/package-script-targets.test.ts` (`6/6` verde)
+  - ✅ Criterio de salida cumplido: bloque integrado end-to-end sin drift.
 
 ## Fase 3 — Cierre del ciclo
-- ⏳ T9. Sincronización final `main/develop` y verificación de ramas limpias.
+- 🚧 T9. Sincronización final `main/develop` y verificación de ramas limpias.
 - ⏳ T10. Cierre formal del ciclo:
   - checklist final de evidencias,
   - estado final de salud del repo,
   - archivo del ciclo en documento de cierre.
-

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -527,7 +527,7 @@ Estado operativo del plan activo para restaurar capacidades enterprise sin rompe
   - Validación post-merge en `develop`:
     - `npm run typecheck` (verde).
     - matriz `framework-menu-matrix*` (`11/11` verde).
-- ✅ Estado actual: ciclo activo (`docs/ENTERPRISE_AUDIT_CYCLE_ACTIVE.md`) cerrado, sin tarea en construcción.
+- ✅ Estado actual: el ciclo operativo activo está en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.
 
 ## Fase 27 — Release Flow (`develop` -> `main`)
 - ✅ PR de release abierta desde `develop` hacia `main`.
@@ -546,5 +546,5 @@ Estado operativo del plan activo para restaurar capacidades enterprise sin rompe
 ## Estado de referencia (sin fases nuevas)
 - ✅ `docs/REFRACTOR_PROGRESS.md` se mantiene como histórico.
 - ✅ El seguimiento operativo del ciclo actual vive solo en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.
-- ✅ `docs/ENTERPRISE_AUDIT_CYCLE_ACTIVE.md` queda cerrado y sin uso operativo.
-- 🚧 Tarea activa actual: `T8` en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.
+- ✅ Bloque `T8` cerrado en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md` (PR `#316` mergeada en `develop`).
+- 🚧 Tarea activa actual: `T9` en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.


### PR DESCRIPTION
## Summary
- mark `T8` as completed in `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`
- set `T9` as the only active task (`🚧`) in the stabilization plan
- align `docs/REFRACTOR_PROGRESS.md` as historical reference to the active plan

## Notes
- No production code changes in this PR.
