### PR TITLE
chore(release): sync develop into main after T10 closure

### DIFF
--- a/docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md
+++ b/docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md
@@ -2,7 +2,26 @@
 
 Estado: `CERRADO`  
 Motivo de cierre: separar histórico y abrir un nuevo plan independiente sin mezclar ciclos.  
-Continuación activa: `docs/ENTERPRISE_AUDIT_CYCLE_ACTIVE.md`
+Continuación activa: `ninguna (pendiente de nuevo ciclo)`.
+
+## Cierre adicional — Enterprise Audit Stabilization Cycle
+
+Estado: `CERRADO`  
+Plan archivado: `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`  
+Fecha de cierre: `2026-02-22`
+
+### Resumen ejecutivo
+- Ciclo de estabilización completado (`T1..T10` en `✅`).
+- Sincronización de ramas largas completada y verificada:
+  - `origin/main` = `7e883df6190af607aacef773ce12d7d14eaaa25c`
+  - `origin/develop` = `7e883df6190af607aacef773ce12d7d14eaaa25c`
+- Cierre Git Flow documentado con PRs:
+  - `#318`, `#319`, `#320`, `#321`, `#322`.
+
+### Criterio de salida
+- Evidencias y tracker histórico actualizados.
+- Ramas `main/develop` sincronizadas y feature de trabajo re-alineada.
+- Ciclo archivado sin tareas huérfanas.
 
 ## Leyenda
 - ✅ Hecho

--- a/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
+++ b/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
@@ -2,6 +2,7 @@
 
 Plan operativo **único** del ciclo vigente.  
 Todas las fases/tareas están definidas por anticipación; no se añaden tareas nuevas durante ejecución.
+Estado del ciclo: `CERRADO`.
 
 ## Leyenda
 - ✅ Hecho
@@ -47,11 +48,18 @@ Todas las fases/tareas están definidas por anticipación; no se añaden tareas 
     - `#321` `main -> develop`
   - ✅ Alineación final por fast-forward de `main` a `origin/develop` para cerrar drift de merge-commit metadata.
   - ✅ Estado remoto final:
-    - `origin/main`: `02428c0d5dbe492c745845b7a1690905ce205344`
-    - `origin/develop`: `02428c0d5dbe492c745845b7a1690905ce205344`
+    - `origin/main`: `7e883df6190af607aacef773ce12d7d14eaaa25c`
+    - `origin/develop`: `7e883df6190af607aacef773ce12d7d14eaaa25c`
   - ✅ Estado local final:
     - `main`, `develop` y `feature/enterprise-audit-cycle` alineadas y limpias.
-- 🚧 T10. Cierre formal del ciclo:
-  - checklist final de evidencias,
-  - estado final de salud del repo,
-  - archivo del ciclo en documento de cierre.
+- ✅ T10. Cierre formal del ciclo:
+  - ✅ Checklist final de evidencias consolidado:
+    - Plan activo actualizado (`T1..T10` en `✅`).
+    - Tracker histórico actualizado con referencia al cierre de `T10`.
+    - PRs de sincronización y cierre registradas (`#318`, `#319`, `#320`, `#321`, `#322`).
+  - ✅ Estado final de salud del repo:
+    - `origin/main` y `origin/develop` alineadas en `7e883df6190af607aacef773ce12d7d14eaaa25c`.
+    - `feature/enterprise-audit-cycle` alineada a ese mismo baseline.
+    - Worktree limpio en cierre de tarea.
+  - ✅ Archivo del ciclo en documento de cierre:
+    - cierre consolidado en `docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md`.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -547,5 +547,8 @@ Estado operativo del plan activo para restaurar capacidades enterprise sin rompe
 - ✅ `docs/REFRACTOR_PROGRESS.md` se mantiene como histórico.
 - ✅ El seguimiento operativo del ciclo actual vive solo en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.
 - ✅ Bloque `T8` cerrado en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md` (PR `#316` mergeada en `develop`).
-- ✅ `T9` cerrado: sincronización `main/develop` completada con ramas alineadas en `02428c0d5dbe492c745845b7a1690905ce205344`.
-- 🚧 Tarea activa actual: `T10` en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.
+- ✅ `T9` cerrado: sincronización `main/develop` completada con ramas alineadas en `7e883df6190af607aacef773ce12d7d14eaaa25c`.
+- ✅ `T10` cerrado: checklist final de evidencias, estado de salud del repo y archivo del ciclo completados.
+- ✅ Estado final de sincronización post-cierre: `main/develop` en `7e883df6190af607aacef773ce12d7d14eaaa25c`.
+- ✅ Archivo de cierre consolidado en `docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md`.
+- 🚧 Estado operativo actual: espera de definición del siguiente ciclo (sin backlog activo).


### PR DESCRIPTION
## Summary
- Sync  into  after closing T10 docs cycle.
- Keep long-lived branches aligned after stabilization closeout.
