### PR TITLE
docs(cycle): make closeout sync status sha-agnostic

### DIFF
--- a/docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md
+++ b/docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md
@@ -13,8 +13,7 @@ Fecha de cierre: `2026-02-22`
 ### Resumen ejecutivo
 - Ciclo de estabilización completado (`T1..T10` en `✅`).
 - Sincronización de ramas largas completada y verificada:
-  - `origin/main` = `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`
-  - `origin/develop` = `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`
+  - `origin/main` y `origin/develop` en el mismo SHA.
 - Cierre Git Flow documentado con PRs:
   - `#318`, `#319`, `#320`, `#321`, `#322`.
 

--- a/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
+++ b/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
@@ -48,8 +48,7 @@ Estado del ciclo: `CERRADO`.
     - `#321` `main -> develop`
   - ✅ Alineación final por fast-forward de `main` a `origin/develop` para cerrar drift de merge-commit metadata.
   - ✅ Estado remoto final:
-    - `origin/main`: `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`
-    - `origin/develop`: `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`
+    - `origin/main` y `origin/develop` alineadas (mismo SHA verificado en cierre).
   - ✅ Estado local final:
     - `main`, `develop` y `feature/enterprise-audit-cycle` alineadas y limpias.
 - ✅ T10. Cierre formal del ciclo:
@@ -58,7 +57,7 @@ Estado del ciclo: `CERRADO`.
     - Tracker histórico actualizado con referencia al cierre de `T10`.
     - PRs de sincronización y cierre registradas (`#318`, `#319`, `#320`, `#321`, `#322`).
   - ✅ Estado final de salud del repo:
-    - `origin/main` y `origin/develop` alineadas en `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`.
+    - `origin/main` y `origin/develop` alineadas (mismo SHA verificado en cierre).
     - `feature/enterprise-audit-cycle` alineada a ese mismo baseline.
     - Worktree limpio en cierre de tarea.
   - ✅ Archivo del ciclo en documento de cierre:

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -547,8 +547,8 @@ Estado operativo del plan activo para restaurar capacidades enterprise sin rompe
 - ✅ `docs/REFRACTOR_PROGRESS.md` se mantiene como histórico.
 - ✅ El seguimiento operativo del ciclo actual vive solo en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md`.
 - ✅ Bloque `T8` cerrado en `docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md` (PR `#316` mergeada en `develop`).
-- ✅ `T9` cerrado: sincronización `main/develop` completada con ramas alineadas en `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`.
+- ✅ `T9` cerrado: sincronización `main/develop` completada con ramas alineadas (mismo SHA).
 - ✅ `T10` cerrado: checklist final de evidencias, estado de salud del repo y archivo del ciclo completados.
-- ✅ Estado final de sincronización post-cierre: `main/develop` en `9f40eb9d1ae14bb32a72e696dd4fc72741a06af6`.
+- ✅ Estado final de sincronización post-cierre: `main/develop` alineadas (mismo SHA).
 - ✅ Archivo de cierre consolidado en `docs/ENTERPRISE_AUDIT_CYCLE_CLOSED.md`.
 - 🚧 Estado operativo actual: espera de definición del siguiente ciclo (sin backlog activo).


### PR DESCRIPTION
Summary: avoid stale closeout docs by using same-SHA assertions instead of fixed commit ids.