### PR TITLE
docs: close F4.T5 stabilization cycle

### DIFF
--- a/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
+++ b/docs/ENTERPRISE_AUDIT_STABILIZATION_CYCLE.md
@@ -3,7 +3,7 @@
 Plan operativo **único** del proyecto para este frente de trabajo.  
 Todas las fases y tareas están definidas por anticipación en este archivo.
 
-Estado del plan: `ACTIVO`
+Estado del plan: `CERRADO`
 
 ## Leyenda
 - ✅ Hecho
@@ -111,8 +111,21 @@ Objetivo: garantizar que la auditoría enterprise refleje reglas evaluadas/match
     - `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-matrix-baseline.test.ts scripts/__tests__/framework-menu-matrix-evidence.test.ts scripts/__tests__/framework-menu-matrix-runner.test.ts scripts/__tests__/framework-menu-matrix-canary.test.ts scripts/__tests__/framework-menu-consumer-runtime.test.ts`
     - `npm run typecheck`
 
-- 🚧 F4.T5 Cierre Git Flow y handoff.
+- ✅ F4.T5 Cierre Git Flow y handoff.
   - Commits atómicos por bloque funcional.
   - PR a `develop`, merge y validación post-merge.
   - Actualizar documentación de uso si cambia el contrato de evidencia/auditoría.
   - Criterio de salida: ciclo cerrado sin tareas huérfanas.
+  - Resultado:
+    - Commits atómicos ejecutados:
+      - `2bd3482` `feat(evidence): normalize deterministic telemetry defaults across scopes`
+      - `69ff301` `feat(evidence): harden platform classification for framework and mixed repos`
+      - `e015d9d` `test(matrix): extend stage-platform canaries for ios and android`
+      - `b4dab66` `docs(plan): close F4.T2-F4.T4 and activate F4.T5 handoff`
+    - PR a `develop` mergeada:
+      - `#329` `feat: stabilize enterprise audit telemetry, platform matrix, and canaries`
+      - merge commit: `19ab4107855161ceb2cb75443df62eaf4ab6be20`
+    - Validación post-merge en `develop`:
+      - `npx --yes tsx@4.21.0 --test integrations/evidence/__tests__/buildEvidence.test.ts integrations/evidence/platformSummary.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/runPlatformGateEvidence.test.ts integrations/lifecycle/__tests__/install.test.ts scripts/__tests__/framework-menu-matrix-canary.test.ts scripts/__tests__/framework-menu-consumer-runtime.test.ts scripts/__tests__/framework-menu-matrix-baseline.test.ts scripts/__tests__/framework-menu-matrix-evidence.test.ts scripts/__tests__/framework-menu-matrix-runner.test.ts`
+      - `npm run typecheck`
+    - Resultado de validación: verde (`57/57` tests + typecheck OK).

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -12,7 +12,8 @@ Estado operativo del plan activo para restaurar capacidades enterprise sin rompe
 - ✅ F4.T2 completada (telemetría de evidencia determinista para `files_scanned`, `files_affected` y `evaluation_metrics`).
 - ✅ F4.T3 completada (clasificación multi-plataforma determinista por `path` + `ruleId` y normalización de rutas para `files_affected`).
 - ✅ F4.T4 completada (regresión e2e de matriz `happy/sad/edge` + canarios por `stage/plataforma` en verde).
-- 🚧 F4.T5 en progreso (cierre Git Flow + handoff).
+- ✅ F4.T5 completada (commits atómicos + PR `#329` mergeada a `develop` + validación post-merge en verde).
+- 🚧 Espera de nuevo ciclo enterprise (siguiente bloque de roadmap pendiente de definición).
 
 ## Fase 0 — Arranque y Preflight
 - ✅ Ejecutar preflight obligatorio (`pwd`, `git rev-parse --show-toplevel`, `git status`).


### PR DESCRIPTION
## Summary
- close F4.T5 in enterprise stabilization plan after merge `#329`
- persist post-merge validation evidence in tracking docs
- leave tracker ready for next enterprise cycle

## Notes
- no code/runtime changes
- docs-only closure for cycle governance
