### PR TITLE
fix: hotfix framework menu runtime crash

### DIFF
--- a/docs/MENU_UIUX_MODERNIZATION_CYCLE.md
+++ b/docs/MENU_UIUX_MODERNIZATION_CYCLE.md
@@ -60,7 +60,7 @@ Modernizar la experiencia CLI del menu (Consumer + Advanced) con una UX clara, v
 - ✅ F7.T1 Actualizar `README.md` con nuevo flujo UI/UX y flags.
 - ✅ F7.T2 Actualizar `docs/USAGE.md` y `docs/API_REFERENCE.md` con nuevos comportamientos de menu.
 - ✅ F7.T3 Actualizar `docs/REFRACTOR_PROGRESS.md` y dejar cierre del ciclo documentado.
-- ✅ F7.T4 Cierre Git Flow end-to-end (commits atomicos, PR a `develop`, merge, sync `develop -> main`).
+- ✅ F7.T4 Cierre Git Flow end-to-end (incluye hotfix de runtime detectado en verificacion final).
 
 ## Politica de despliegue del ciclo
 - Estrategia: `Feature flag`.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -42,7 +42,7 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F7.T1` completada: `README.md` actualizado con rollout de `PUMUKI_MENU_UI_V2` y compatibilidad de flags.
 - ✅ `F7.T2` completada: `docs/USAGE.md` y `docs/API_REFERENCE.md` actualizados (modo clásico/v2, fallback y comandos matrix/canary).
 - ✅ `F7.T3` completada: tracker y plan de ciclo sincronizados con cierre documental de fase.
-- ✅ `F7.T4` completada: cierre Git Flow end-to-end ejecutado (commit, PR/merge y sync de ramas).
+- ✅ `F7.T4` completada: hotfix runtime por TDD aplicado (`runStagedGate` importado), CLI validada en clásico/v2 y cierre Git Flow ejecutado.
 - ✅ Ciclo `MENU_UIUX_MODERNIZATION_CYCLE` cerrado.
 
 ## Hitos recientes

--- a/scripts/__tests__/framework-menu-cli-runtime.test.ts
+++ b/scripts/__tests__/framework-menu-cli-runtime.test.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process';
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+const runFrameworkMenu = (env: NodeJS.ProcessEnv) =>
+  spawnSync(process.execPath, ['bin/pumuki-framework.js'], {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    input: '10\n',
+  });
+
+test('framework menu CLI exits cleanly in classic mode', () => {
+  const result = runFrameworkMenu({
+    PUMUKI_MENU_UI_V2: '0',
+    PUMUKI_MENU_COLOR: '0',
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `framework menu classic mode must exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert.ok(!result.stderr.includes('ReferenceError'));
+});
+
+test('framework menu CLI exits cleanly in modern mode', () => {
+  const result = runFrameworkMenu({
+    PUMUKI_MENU_UI_V2: '1',
+    PUMUKI_MENU_COLOR: '0',
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `framework menu modern mode must exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert.ok(!result.stderr.includes('ReferenceError'));
+});

--- a/scripts/framework-menu.ts
+++ b/scripts/framework-menu.ts
@@ -11,6 +11,7 @@ import {
   runRepoAndStagedGate,
   runRepoAndStagedGateSilent,
   runRepoGateSilent,
+  runStagedGate,
   runStagedGateSilent,
   runWorkingTreeGateSilent,
   runRepoAndStagedPrePushGateSilent,


### PR DESCRIPTION
## Summary
- fix runtime crash in framework menu by restoring missing runStagedGate import
- add CLI regression test to ensure classic and modern menu exit cleanly
- update cycle tracking docs to close F7.T4 after hotfix

## Validation
- node --test scripts/__tests__/framework-menu-cli-runtime.test.ts
- npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-*.test.ts
- npm run typecheck
- printf '10\n' | npm run framework:menu
- printf '10\n' | PUMUKI_MENU_UI_V2=1 npm run framework:menu