### PR TITLE
feat(rules): unify core/custom skills engine

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -53,6 +53,30 @@ Behavior:
 - Emits `governance.rules.coverage.incomplete` and forces `BLOCK` when active rules remain unevaluated in `PRE_COMMIT`, `PRE_PUSH`, or `CI`.
 - Writes `.ai_evidence.json` via `generateEvidence`.
 
+## Skills rules engine APIs
+
+Files:
+
+- `integrations/config/coreSkillsLock.ts`
+- `integrations/config/skillsEffectiveLock.ts`
+- `integrations/config/skillsCustomRules.ts`
+- `integrations/config/skillsRuleSet.ts`
+
+Key functions:
+
+- `loadCoreSkillsLock(): SkillsLockV1 | undefined`
+- `loadEffectiveSkillsLock(repoRoot?): SkillsLockV1 | undefined`
+- `loadCustomSkillsRulesFile(repoRoot?): CustomSkillsRulesFileV1 | undefined`
+- `loadCustomSkillsLock(repoRoot?): SkillsLockV1 | undefined`
+- `resolveSkillImportSources({ repoRoot?, explicitSources? }): string[]`
+- `importCustomSkillsRules({ repoRoot?, sourceFiles? }): CustomSkillsImportResult`
+- `loadSkillsRuleSetForStage(stage, repoRoot?, detectedPlatforms?)`
+
+Deterministic precedence:
+
+- `core + repo + custom` merged into one effective lock.
+- Conflict policy: `custom > repo > core` by `ruleId` during ruleset materialization.
+
 ## Git scope helpers
 
 Files:
@@ -229,6 +253,7 @@ Consumer menu pre-flight:
 - pre-flight checks `repo_state`, stale/missing evidence, git-flow protected branches, and AI gate chain consistency
 - stage mapping is deterministic: `1/3 -> PRE_COMMIT`, `2/4 -> PRE_PUSH`
 - in modern UI mode (`PUMUKI_MENU_UI_V2=1`) options are grouped by domains while preserving IDs and execution wiring
+- advanced maintenance option `33` imports custom rules from `AGENTS.md/SKILLS.md` to `/.pumuki/custom-rules.json`
 
 ## Optional diagnostics adapters
 
@@ -275,6 +300,7 @@ Deterministic argument builders exported from menu module:
 
 - `buildAdapterReadinessCommandArgs({ scriptPath, adapterReportFile, outFile })`
 - `buildCleanValidationArtifactsCommandArgs({ scriptPath, dryRun })`
+- `buildImportCustomSkillsCommandArgs()`
 - `buildPhase5BlockersReadinessCommandArgs({ scriptPath, adapterReportFile, consumerTriageReportFile, outFile })`
 - `buildPhase5ExecutionClosureStatusCommandArgs({ scriptPath, phase5BlockersReportFile, consumerUnblockReportFile, adapterReadinessReportFile, outFile, requireAdapterReadiness })`
 - `buildPhase5ExternalHandoffCommandArgs({ scriptPath, repo, phase5StatusReportFile, phase5BlockersReportFile, consumerUnblockReportFile, mockAbReportFile, runReportFile, outFile, artifactUrls, requireArtifactUrls, requireMockAbReport })`

--- a/docs/ENTERPRISE_RULE_COVERAGE_CYCLE.md
+++ b/docs/ENTERPRISE_RULE_COVERAGE_CYCLE.md
@@ -55,3 +55,7 @@ Eliminar falsos verdes en auditoria garantizando trazabilidad completa por stage
 ## Cierre
 - Ciclo completado con contrato de cobertura de reglas estable en runtime/evidence.
 - `main` y `develop` sincronizadas en remoto (`origin/main...origin/develop = 0 0`).
+
+## Continuidad de ciclos
+- Este ciclo permanece `CERRADO`.
+- La continuidad activa pasa a `docs/RULES_ENGINE_UNIFICATION_CYCLE.md`.

--- a/docs/MENU_UIUX_MODERNIZATION_CYCLE.md
+++ b/docs/MENU_UIUX_MODERNIZATION_CYCLE.md
@@ -67,3 +67,7 @@ Modernizar la experiencia CLI del menu (Consumer + Advanced) con una UX clara, v
 - Activacion inicial por defecto: `OFF` (estable actual).
 - Activacion controlada: `PUMUKI_MENU_UI_V2=1`.
 - Fuera de alcance en este ciclo: cambios de logica de negocio del gate (solo UX/presentacion/ergonomia).
+
+## Continuidad de ciclos
+- Este ciclo permanece `CERRADO`.
+- La continuidad activa pasa a `docs/RULES_ENGINE_UNIFICATION_CYCLE.md`.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -44,6 +44,33 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F7.T3` completada: tracker y plan de ciclo sincronizados con cierre documental de fase.
 - ✅ `F7.T4` completada: hotfix runtime por TDD aplicado (`runStagedGate` importado), CLI validada en clásico/v2 y cierre Git Flow ejecutado.
 - ✅ Ciclo `MENU_UIUX_MODERNIZATION_CYCLE` cerrado.
+- ✅ Nuevo plan activo creado: `docs/RULES_ENGINE_UNIFICATION_CYCLE.md`.
+- ✅ `F0.T1` completada: bootstrap del ciclo con leyenda, fases, tasks y política de Git Flow.
+- ✅ `F0.T2` completada: ciclos anteriores relevantes marcados con continuidad explícita hacia `RULES_ENGINE_UNIFICATION_CYCLE`.
+- ✅ `F0.T3` completada: tracker sincronizado con arranque de ciclo y secuencia operativa.
+- ✅ `F1.T1` completada: snapshot core de reglas embebido y versionado como fuente primaria runtime.
+- ✅ `F1.T2` completada: compilacion de reglas desde skills sincronizadas y hash determinista validada por test.
+- ✅ `F1.T3` completada: carga del motor reenrutada a ruleset efectivo (`core + repo lock + custom`) validada por test.
+- ✅ `F1.T4` completada: fallback seguro sin locks locales validado con tests dedicados de `skillsEffectiveLock`.
+- ✅ `F2.T1` completada: filtrado por plataformas detectadas validado en `skillsRuleSet` sin pérdida de reglas aplicables.
+- ✅ `F2.T2` completada: clasificación `AUTO/DECLARATIVE` validada en tests de reglas no mapeadas y promoción por stage.
+- ✅ `F2.T3` completada: trazabilidad de cobertura por stage validada en suites `runPlatformGateEvaluation` y `runPlatformGateEvidence`.
+- ✅ `F2.T4` completada: bloqueo de gobernanza por cobertura incompleta validado en `runPlatformGate.test.ts`.
+- ✅ `F3.T1` completada: formato local `/.pumuki/custom-rules.json` y contrato de parseo/carga operativo.
+- ✅ `F3.T2` completada: import de reglas desde `AGENTS.md` y rutas `SKILL.md` validado con tests.
+- ✅ `F3.T3` completada: precedencia `custom > core` por `ruleId` validada en `skillsRuleSet`.
+- ✅ `F3.T4` completada: ruleset efectivo expuesto en diagnóstico de menú (`repo + custom`) con test dedicado.
+- ✅ `F4.T1` completada: opción de menú `33` añadida para importar reglas custom.
+- ✅ `F4.T2` completada: builders/runners de import custom validados con tests de comandos/acciones.
+- ✅ `F4.T3` completada: vista advanced muestra ayuda contextual de opción `33` y diagnóstico de bundles efectivos.
+- ✅ `F5.T1` completada: suites de compilación/lock en verde con extracción markdown.
+- ✅ `F5.T2` completada: `skillsRuleSet` validado con plataformas detectadas y reglas declarativas.
+- ✅ `F5.T3` completada: import custom + precedencia `custom > core` validado end-to-end.
+- ✅ `F5.T4` completada: validación funcional de menú/gate/canary en verde.
+- ✅ `F6.T1` completada: `README.md` actualizado con arquitectura de rules engine unificado.
+- ✅ `F6.T2` completada: `docs/USAGE.md` y `docs/API_REFERENCE.md` actualizados con comandos/contratos de custom rules.
+- ✅ `F6.T3` completada: `docs/evidence-v2.1.md` actualizado para reflejar trazabilidad de bundles efectivos y reglas declarativas.
+- 🚧 `F6.T4` en construccion: cierre Git Flow end-to-end (`feature -> develop -> main`).
 
 ## Hitos recientes
 - ✅ Sync Git Flow cerrado en ciclo anterior (`develop -> main`) con ramas remotas alineadas.
@@ -65,7 +92,17 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ README enterprise reescrito en ingles con cobertura funcional completa de Pumuki (onboarding + operacion).
 - ✅ Capturas de ejecucion del menu (opcion 1) generadas para README en escenarios BLOCK/PASS (`assets/readme/menu-option1`, 6 PNGs).
 - ✅ Revision editorial final y publicacion de cambios de documentacion enterprise completada.
-- 🚧 En construccion: definir siguiente ciclo operativo tras cierre documental enterprise.
+- ✅ Ciclo operativo siguiente definido y documentado (`RULES_ENGINE_UNIFICATION_CYCLE`).
+- ✅ Estabilizacion del canary matrix completada para opcion `1` (`repo`) con staging/cleanup temporal y suite `framework-menu-*` en verde.
+- ✅ Test suite nueva añadida: `integrations/config/__tests__/skillsEffectiveLock.test.ts` para fallback/merge efectivo.
+- ✅ Cobertura extendida de `skillsRuleSet` añadida para plataformas detectadas y reglas `generic/text`.
+- ✅ Suite de gate/evidence en verde: cobertura por stage y guard de gobernanza sin regresiones.
+- ✅ Nueva suite añadida: `integrations/config/__tests__/skillsCustomRules.test.ts` (formato, import y precedencia).
+- ✅ Diagnóstico de bundles activos validado con lock efectivo (`scripts/__tests__/framework-menu-format-and-policy.test.ts`).
+- ✅ Cobertura de menú extendida: opción `33` en acciones/builders/vista advanced verificada en tests.
+- ✅ Validación consolidada: 21 tests config + 12 tests git + 113 tests framework menu en verde.
+- ✅ Documentación enterprise alineada al motor unificado (`README`, `USAGE`, `API_REFERENCE`, `evidence-v2.1`).
+- Estado activo: `F6.T4` del ciclo `RULES_ENGINE_UNIFICATION_CYCLE` (Git Flow end-to-end).
 
 ## Siguiente paso operativo
-- ⏳ Pendiente definir siguiente ciclo (fuera de este cierre UI/UX).
+- ⏳ Completar `F6.T4` y cerrar ciclo.

--- a/docs/RULES_ENGINE_UNIFICATION_CYCLE.md
+++ b/docs/RULES_ENGINE_UNIFICATION_CYCLE.md
@@ -1,0 +1,69 @@
+# Rules Engine Unification Cycle
+
+Plan operativo unico para unificar el motor de reglas de Pumuki con cobertura total de reglas core + overrides custom por repo.
+
+Estado del plan: `EN_CONSTRUCCION`
+
+## Leyenda
+- ✅ Hecho
+- 🚧 En construccion (maximo 1)
+- ⏳ Pendiente
+- ⛔ Bloqueado
+
+## Reglas de seguimiento
+- Este es el unico MD de plan activo para este ciclo.
+- Solo puede haber una tarea en `🚧`.
+- Cada tarea cerrada pasa a `✅` y se activa la siguiente `🚧`.
+- Nomenclatura obligatoria: `F{fase}.T{n}`.
+- Rama del ciclo: `feature/rules-engine-unification`.
+- Cierre esperado del ciclo: Git Flow end-to-end (`feature -> develop -> main`).
+
+## Objetivo del ciclo
+Garantizar que Pumuki aplique siempre TODAS las reglas core del producto (sin dependencia externa en runtime) y permita overrides custom por repo (`custom > core`) con trazabilidad completa por stage/plataforma.
+
+## Fase 0 — Arranque de ciclo y baseline documental
+- ✅ F0.T1 Crear este plan `docs/RULES_ENGINE_UNIFICATION_CYCLE.md` con estructura oficial del ciclo.
+- ✅ F0.T2 Cerrar ciclos anteriores relevantes y dejar este como ciclo operativo activo.
+- ✅ F0.T3 Actualizar tracker `docs/REFRACTOR_PROGRESS.md` con estado del ciclo y siguiente tarea.
+
+## Fase 1 — Core ruleset embebido
+- ✅ F1.T1 Definir snapshot interno versionado de reglas core (`CoreRulesSnapshot`) como fuente primaria runtime.
+- ✅ F1.T2 Integrar compilacion de reglas desde skills sincronizadas y persistencia determinista de hash.
+- ✅ F1.T3 Reenrutar carga del motor a ruleset efectivo (`core + repo lock + custom local`).
+- ✅ F1.T4 Garantizar fallback seguro de compatibilidad en ausencia de locks locales.
+
+## Fase 2 — Cobertura total por plataforma detectada
+- ✅ F2.T1 Activar reglas por plataforma detectada (`ios/android/backend/frontend`) sin pérdidas.
+- ✅ F2.T2 Clasificar reglas en `AUTO` y `DECLARATIVE` para cobertura completa sin falsos vacíos.
+- ✅ F2.T3 Forzar trazabilidad de cobertura en evidencia (`active/evaluated/matched/unevaluated`) por stage.
+- ✅ F2.T4 Mantener bloqueo de gobernanza con mensaje accionable cuando coverage sea incompleta.
+
+## Fase 3 — Overrides custom por repo
+- ✅ F3.T1 Definir formato local `/.pumuki/custom-rules.json`.
+- ✅ F3.T2 Implementar import de reglas desde `AGENTS.md`, `SKILLS.md` y rutas `SKILL.md`.
+- ✅ F3.T3 Aplicar política de conflicto `custom sobrescribe core` con trazabilidad explícita.
+- ✅ F3.T4 Exponer ruleset efectivo para auditoría y diagnósticos.
+
+## Fase 4 — Menú interactivo y comandos
+- ✅ F4.T1 Añadir opción de menú para importar reglas custom.
+- ✅ F4.T2 Añadir runners/builders para importación y validación de custom rules.
+- ✅ F4.T3 Reflejar en vistas (consumer/advanced) el estado de bundles activos y custom import.
+
+## Fase 5 — TDD y validación funcional
+- ✅ F5.T1 Tests de compilación/lock con reglas extraídas desde markdown de skills.
+- ✅ F5.T2 Tests de `skillsRuleSet` con plataformas detectadas y reglas declarativas.
+- ✅ F5.T3 Tests de import custom + precedencia `custom > core`.
+- ✅ F5.T4 Validación visual y funcional del menú y flujos de auditoría.
+
+## Fase 6 — Documentación y cierre Git Flow
+- ✅ F6.T1 Actualizar `README.md` con arquitectura core rules + custom per repo.
+- ✅ F6.T2 Actualizar `docs/USAGE.md` y `docs/API_REFERENCE.md`.
+- ✅ F6.T3 Actualizar `docs/evidence-v2.1.md` con nuevos campos de cobertura/origen.
+- 🚧 F6.T4 Cierre Git Flow end-to-end: PR a `develop`, merge, sync `develop -> main`.
+
+## Política cerrada del ciclo
+- Core rules siempre activas por plataforma detectada.
+- Runtime sin dependencia de fuentes externas.
+- Overrides custom solo locales por repo.
+- Política de conflictos: `custom > core`.
+- Evidencia obligatoria y determinista para cobertura de reglas.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,6 +33,21 @@ Coverage guardrail:
 - If any active rule is not evaluated (`unevaluated_rule_ids` not empty), gate emits `governance.rules.coverage.incomplete` and forces `BLOCK`.
 - Coverage telemetry is persisted in `.ai_evidence.json` under `snapshot.rules_coverage`.
 
+## Skills rules engine (effective lock)
+
+Skills are resolved in deterministic precedence order:
+
+1. Core embedded lock (package snapshot, runtime-safe)
+2. Repo lock (`skills.lock.json`, optional)
+3. Custom local rules (`/.pumuki/custom-rules.json`, optional)
+
+Conflict policy: `custom > repo > core` by `ruleId`.
+
+Platform activation:
+
+- `ios/android/backend/frontend` rules activate only when platform is detected.
+- `generic/text` rules remain active as cross-platform constraints.
+
 ## Mandatory SDD/OpenSpec flow
 
 Pumuki enforces OpenSpec policy/session before allowing normal gate execution.
@@ -174,6 +189,7 @@ Stage mapping:
 If a scope is empty, the menu prints an explicit operational hint (`Scope vacío`), so `PASS` with zero findings is distinguishable from a clean repository scan.
 
 System notifications (macOS) can be enabled from advanced menu option `31` (persisted in `.pumuki/system-notifications.json`).
+Custom skills import is available in advanced menu option `33` (writes `/.pumuki/custom-rules.json`).
 
 ### 2) Direct stage CLI execution
 
@@ -237,6 +253,12 @@ npx --yes pumuki remove
 npx --yes pumuki adapter install --agent=codex --dry-run
 npx --yes pumuki adapter install --agent=cursor
 npm run adapter:install -- --agent=claude
+
+# skills engine helpers
+npm run skills:compile
+npm run skills:lock:check
+npm run skills:import:custom
+npm run skills:import:custom -- --source /abs/path/to/SKILL.md --source ./skills/backend/SKILL.md
 ```
 
 `pumuki remove` is the enterprise-safe removal path because it performs lifecycle cleanup before package uninstall.

--- a/docs/evidence-v2.1.md
+++ b/docs/evidence-v2.1.md
@@ -37,6 +37,7 @@
   - active detected platforms with confidence (`HIGH` | `MEDIUM` | `LOW`)
 - `rulesets[]`:
   - loaded bundles with versioned name and hash
+  - effective skills resolution is reflected here (core/repo/custom as loaded bundles, e.g. `custom-guidelines@1.0.0`)
 - `human_intent`:
   - preserved user goal state (or `null` when missing/expired)
   - `expires_at` is enforced deterministically (expired intent is ignored)
@@ -58,6 +59,7 @@
 - Findings are deduplicated by `ruleId + file + lines`.
 - `files_scanned` and `files_affected` are persisted independently to avoid telemetry drift.
 - `rules_coverage` is normalized with sorted+deduplicated ids and deterministic counts.
+- Declarative skills rules are kept in `active_rule_ids/evaluated_rule_ids` for deterministic coverage traceability even when no automatic detector exists yet.
 - For selected semantic rule families, equivalent baseline/heuristic duplicates on the same file are consolidated to a single finding, keeping the highest-severity signal deterministically.
 - Consolidation scope is file-level in v2.1: repeated same-family findings (including same rule on different lines) collapse to one deterministic representative.
 - When consolidation removes findings, `consolidation.suppressed[]` keeps the trace (`ruleId`, `replacedByRuleId`, `reason`) for auditability.

--- a/integrations/config/__tests__/skillsCustomRules.test.ts
+++ b/integrations/config/__tests__/skillsCustomRules.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { withTempDir } from '../../__tests__/helpers/tempDir';
+import {
+  importCustomSkillsRules,
+  loadCustomSkillsLock,
+  loadCustomSkillsRulesFile,
+  resolveSkillImportSources,
+} from '../skillsCustomRules';
+import { loadSkillsRuleSetForStage } from '../skillsRuleSet';
+
+const withCoreSkillsDisabled = async (run: () => Promise<void>): Promise<void> => {
+  const previous = process.env.PUMUKI_DISABLE_CORE_SKILLS;
+  process.env.PUMUKI_DISABLE_CORE_SKILLS = '1';
+  try {
+    await run();
+  } finally {
+    if (typeof previous === 'string') {
+      process.env.PUMUKI_DISABLE_CORE_SKILLS = previous;
+    } else {
+      delete process.env.PUMUKI_DISABLE_CORE_SKILLS;
+    }
+  }
+};
+
+test('loads custom rules file and transforms it into custom-guidelines lock bundle', async () => {
+  await withTempDir('pumuki-skills-custom-file-', async (tempRoot) => {
+    mkdirSync(join(tempRoot, '.pumuki'), { recursive: true });
+    writeFileSync(
+      join(tempRoot, '.pumuki/custom-rules.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          generatedAt: '2026-02-22T19:00:00.000Z',
+          source_files: ['AGENTS.md'],
+          rules: [
+            {
+              id: 'skills.custom.backend.guard',
+              description: 'Custom backend guard.',
+              severity: 'ERROR',
+              platform: 'backend',
+              evaluationMode: 'DECLARATIVE',
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+
+    const payload = loadCustomSkillsRulesFile(tempRoot);
+    assert.ok(payload);
+    assert.equal(payload.rules.length, 1);
+    assert.equal(payload.rules[0]?.id, 'skills.custom.backend.guard');
+
+    const lock = loadCustomSkillsLock(tempRoot);
+    assert.ok(lock);
+    assert.equal(lock.bundles.length, 1);
+    assert.equal(lock.bundles[0]?.name, 'custom-guidelines');
+    assert.equal(lock.bundles[0]?.rules[0]?.origin, 'custom');
+  });
+});
+
+test('resolveSkillImportSources discovers SKILL.md paths from AGENTS.md', async () => {
+  await withTempDir('pumuki-skills-custom-agents-', async (tempRoot) => {
+    const localSkillPath = join(tempRoot, 'docs/custom/backend/SKILL.md');
+    mkdirSync(join(tempRoot, 'docs/custom/backend'), { recursive: true });
+    writeFileSync(localSkillPath, '- ✅ Avoid empty catch blocks.\n');
+
+    writeFileSync(
+      join(tempRoot, 'AGENTS.md'),
+      [
+        '# Skills',
+        `- Backend: ${localSkillPath}`,
+        '- Local relative: docs/custom/backend/SKILL.md',
+      ].join('\n')
+    );
+
+    const sources = resolveSkillImportSources({ repoRoot: tempRoot });
+    assert.deepEqual(sources, [localSkillPath]);
+  });
+});
+
+test('importCustomSkillsRules writes .pumuki/custom-rules.json and extracts declarative + auto rules', async () => {
+  await withTempDir('pumuki-skills-custom-import-', async (tempRoot) => {
+    const backendSkillPath = join(tempRoot, 'skills/backend/SKILL.md');
+    const frontendSkillPath = join(tempRoot, 'skills/frontend/SKILL.md');
+
+    mkdirSync(join(tempRoot, 'skills/backend'), { recursive: true });
+    mkdirSync(join(tempRoot, 'skills/frontend'), { recursive: true });
+
+    writeFileSync(
+      backendSkillPath,
+      [
+        '- ❌ Avoid empty catch blocks in backend runtime code.',
+        '- Must document domain errors at use-case boundary.',
+      ].join('\n')
+    );
+    writeFileSync(
+      frontendSkillPath,
+      [
+        '- ❌ Avoid explicit any in frontend runtime code.',
+      ].join('\n')
+    );
+
+    const result = importCustomSkillsRules({
+      repoRoot: tempRoot,
+      sourceFiles: [backendSkillPath, frontendSkillPath],
+    });
+
+    assert.equal(result.sourceFiles.length, 2);
+    assert.equal(result.importedRules.length >= 3, true);
+    assert.equal(result.importedRules.every((rule) => rule.origin === 'custom'), true);
+
+    const autoRuleIds = result.importedRules
+      .filter((rule) => rule.evaluationMode === 'AUTO')
+      .map((rule) => rule.id)
+      .sort();
+    assert.equal(autoRuleIds.includes('skills.backend.no-empty-catch'), true);
+    assert.equal(autoRuleIds.includes('skills.frontend.avoid-explicit-any'), true);
+  });
+});
+
+test('custom rules override repo lock rules by id when building effective skills rule set', async () => {
+  await withCoreSkillsDisabled(async () => withTempDir('pumuki-skills-custom-precedence-', async (tempRoot) => {
+    const repoLock = {
+      version: '1.0',
+      compilerVersion: '1.0.0',
+      generatedAt: '2026-02-22T19:10:00.000Z',
+      bundles: [
+        {
+          name: 'backend-guidelines',
+          version: '1.0.0',
+          source: 'file:docs/codex-skills/windsurf-rules-backend.md',
+          hash: 'a'.repeat(64),
+          rules: [
+            {
+              id: 'skills.backend.no-empty-catch',
+              description: 'Base backend no-empty-catch rule.',
+              severity: 'WARN',
+              platform: 'backend',
+              sourceSkill: 'backend-guidelines',
+              sourcePath: 'docs/codex-skills/windsurf-rules-backend.md',
+              evaluationMode: 'AUTO',
+              origin: 'core',
+              locked: true,
+            },
+          ],
+        },
+      ],
+    } as const;
+
+    mkdirSync(join(tempRoot, '.pumuki'), { recursive: true });
+    writeFileSync(join(tempRoot, 'skills.lock.json'), JSON.stringify(repoLock, null, 2));
+    writeFileSync(
+      join(tempRoot, '.pumuki/custom-rules.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          generatedAt: '2026-02-22T19:11:00.000Z',
+          source_files: ['AGENTS.md'],
+          rules: [
+            {
+              id: 'skills.backend.no-empty-catch',
+              description: 'Custom override for backend no-empty-catch.',
+              severity: 'CRITICAL',
+              platform: 'backend',
+              evaluationMode: 'AUTO',
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+
+    const result = loadSkillsRuleSetForStage('PRE_COMMIT', tempRoot);
+    assert.equal(result.rules.length, 1);
+
+    const onlyRule = result.rules[0];
+    assert.ok(onlyRule);
+    assert.equal(onlyRule.id, 'skills.backend.no-empty-catch');
+    assert.equal(onlyRule.severity, 'CRITICAL');
+    assert.equal(onlyRule.description, 'Custom override for backend no-empty-catch.');
+  }));
+});

--- a/integrations/config/__tests__/skillsEffectiveLock.test.ts
+++ b/integrations/config/__tests__/skillsEffectiveLock.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { withTempDir } from '../../__tests__/helpers/tempDir';
+import { __resetCoreSkillsLockCacheForTests } from '../coreSkillsLock';
+import { loadEffectiveSkillsLock } from '../skillsEffectiveLock';
+
+const withCoreSkillsEnv = async (
+  value: string | undefined,
+  run: () => Promise<void>
+): Promise<void> => {
+  const previous = process.env.PUMUKI_DISABLE_CORE_SKILLS;
+  if (typeof value === 'string') {
+    process.env.PUMUKI_DISABLE_CORE_SKILLS = value;
+  } else {
+    delete process.env.PUMUKI_DISABLE_CORE_SKILLS;
+  }
+
+  try {
+    await run();
+  } finally {
+    if (typeof previous === 'string') {
+      process.env.PUMUKI_DISABLE_CORE_SKILLS = previous;
+    } else {
+      delete process.env.PUMUKI_DISABLE_CORE_SKILLS;
+    }
+  }
+};
+
+const createRepoLockFixture = (repoRoot: string): void => {
+  const lock = {
+    version: '1.0',
+    compilerVersion: '1.0.0',
+    generatedAt: '2026-02-22T18:30:00.000Z',
+    bundles: [
+      {
+        name: 'repo-local-guidelines',
+        version: '1.0.0',
+        source: 'file:docs/repo-local/SKILL.md',
+        hash: 'a'.repeat(64),
+        rules: [
+          {
+            id: 'skills.repo.local.rule',
+            description: 'Repo local deterministic rule fixture.',
+            severity: 'WARN',
+            platform: 'generic',
+            sourceSkill: 'repo-local-guidelines',
+            sourcePath: 'docs/repo-local/SKILL.md',
+            evaluationMode: 'DECLARATIVE',
+            origin: 'core',
+          },
+        ],
+      },
+    ],
+  } as const;
+
+  writeFileSync(join(repoRoot, 'skills.lock.json'), JSON.stringify(lock, null, 2));
+};
+
+const createCustomRulesFixture = (repoRoot: string): void => {
+  mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+  const customRules = {
+    version: '1.0',
+    generatedAt: '2026-02-22T18:35:00.000Z',
+    source_files: ['AGENTS.md'],
+    rules: [
+      {
+        id: 'skills.custom.repo.rule',
+        description: 'Custom rule fixture for effective lock merge.',
+        severity: 'ERROR',
+        platform: 'backend',
+        evaluationMode: 'DECLARATIVE',
+      },
+    ],
+  } as const;
+  writeFileSync(join(repoRoot, '.pumuki/custom-rules.json'), JSON.stringify(customRules, null, 2));
+};
+
+test('falls back to core lock when repo does not provide local lock files', async () => {
+  await withCoreSkillsEnv(undefined, async () => withTempDir('pumuki-skills-effective-core-', async (tempRoot) => {
+    __resetCoreSkillsLockCacheForTests();
+    const lock = loadEffectiveSkillsLock(tempRoot);
+    assert.ok(lock);
+    assert.equal(lock.bundles.length > 0, true);
+  }));
+});
+
+test('returns undefined when core is disabled and repo has no local sources', async () => {
+  await withCoreSkillsEnv('1', async () => withTempDir('pumuki-skills-effective-empty-', async (tempRoot) => {
+    const lock = loadEffectiveSkillsLock(tempRoot);
+    assert.equal(lock, undefined);
+  }));
+});
+
+test('loads repo lock when core is disabled', async () => {
+  await withCoreSkillsEnv('1', async () => withTempDir('pumuki-skills-effective-local-', async (tempRoot) => {
+    createRepoLockFixture(tempRoot);
+    const lock = loadEffectiveSkillsLock(tempRoot);
+    assert.ok(lock);
+    assert.equal(lock.bundles.length, 1);
+    assert.equal(lock.bundles[0]?.name, 'repo-local-guidelines');
+  }));
+});
+
+test('merges repo lock and custom rules when both are present', async () => {
+  await withCoreSkillsEnv('1', async () => withTempDir('pumuki-skills-effective-custom-', async (tempRoot) => {
+    createRepoLockFixture(tempRoot);
+    createCustomRulesFixture(tempRoot);
+    const lock = loadEffectiveSkillsLock(tempRoot);
+    assert.ok(lock);
+
+    const bundleNames = lock.bundles.map((bundle) => bundle.name).sort();
+    assert.deepEqual(bundleNames, ['custom-guidelines', 'repo-local-guidelines']);
+  }));
+});

--- a/integrations/config/coreSkillsLock.ts
+++ b/integrations/config/coreSkillsLock.ts
@@ -1,0 +1,30 @@
+import { resolve } from 'node:path';
+import { compileSkillsLock } from './compileSkillsLock';
+import type { SkillsLockV1 } from './skillsLock';
+
+const CORE_MANIFEST_FILE = 'skills.sources.json';
+const CORE_GENERATED_AT = '2026-02-22T00:00:00.000Z';
+const PACKAGE_ROOT = resolve(__dirname, '..', '..');
+
+let cachedCoreSkillsLock: SkillsLockV1 | undefined;
+
+export const loadCoreSkillsLock = (): SkillsLockV1 | undefined => {
+  if (cachedCoreSkillsLock) {
+    return cachedCoreSkillsLock;
+  }
+
+  try {
+    cachedCoreSkillsLock = compileSkillsLock({
+      repoRoot: PACKAGE_ROOT,
+      manifestFile: CORE_MANIFEST_FILE,
+      generatedAt: CORE_GENERATED_AT,
+    });
+    return cachedCoreSkillsLock;
+  } catch {
+    return undefined;
+  }
+};
+
+export const __resetCoreSkillsLockCacheForTests = (): void => {
+  cachedCoreSkillsLock = undefined;
+};

--- a/integrations/config/skillsCustomRules.ts
+++ b/integrations/config/skillsCustomRules.ts
@@ -1,0 +1,369 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
+import type { RuleDefinition } from '../../core/rules/RuleDefinition';
+import type { Severity } from '../../core/rules/Severity';
+import {
+  type SkillsCompiledRule,
+  type SkillsLockBundle,
+  type SkillsLockV1,
+  type SkillsRuleConfidence,
+  type SkillsRuleEvaluationMode,
+  type SkillsRuleOrigin,
+  type SkillsStage,
+} from './skillsLock';
+import { extractCompiledRulesFromSkillMarkdown } from './skillsMarkdownRules';
+
+const CUSTOM_RULES_FILE_CANDIDATES = [
+  '.pumuki/custom-rules.json',
+  'pumuki.custom-rules.json',
+] as const;
+
+type CustomSkillsRuleV1 = {
+  id: string;
+  description: string;
+  severity: Severity;
+  platform: NonNullable<RuleDefinition['platform']>;
+  stage?: SkillsStage;
+  confidence?: SkillsRuleConfidence;
+  locked?: boolean;
+  evaluationMode?: SkillsRuleEvaluationMode;
+};
+
+export type CustomSkillsRulesFileV1 = {
+  version: '1.0';
+  generatedAt: string;
+  source_files: string[];
+  rules: CustomSkillsRuleV1[];
+};
+
+export type CustomSkillsImportResult = {
+  sourceFiles: string[];
+  importedRules: SkillsCompiledRule[];
+  outputPath: string;
+};
+
+const severityValues = new Set<Severity>(['INFO', 'WARN', 'ERROR', 'CRITICAL']);
+const stageValues = new Set<SkillsStage>(['PRE_COMMIT', 'PRE_PUSH', 'CI']);
+const confidenceValues = new Set<SkillsRuleConfidence>(['HIGH', 'MEDIUM', 'LOW']);
+const evaluationModeValues = new Set<SkillsRuleEvaluationMode>(['AUTO', 'DECLARATIVE']);
+const platformValues = new Set<NonNullable<RuleDefinition['platform']>>([
+  'ios',
+  'android',
+  'backend',
+  'frontend',
+  'text',
+  'generic',
+]);
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const isNonEmptyString = (value: unknown): value is string => {
+  return typeof value === 'string' && value.trim().length > 0;
+};
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (isObject(value)) {
+    const entries = Object.entries(value).sort(([left], [right]) =>
+      left.localeCompare(right)
+    );
+    return `{${entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+};
+
+const isCustomRule = (value: unknown): value is CustomSkillsRuleV1 => {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (!isNonEmptyString(value.id) || !isNonEmptyString(value.description)) {
+    return false;
+  }
+  if (
+    typeof value.severity !== 'string' ||
+    !severityValues.has(value.severity as Severity)
+  ) {
+    return false;
+  }
+  if (
+    typeof value.platform !== 'string' ||
+    !platformValues.has(value.platform as NonNullable<RuleDefinition['platform']>)
+  ) {
+    return false;
+  }
+  if (typeof value.stage !== 'undefined' && !stageValues.has(value.stage as SkillsStage)) {
+    return false;
+  }
+  if (
+    typeof value.confidence !== 'undefined' &&
+    !confidenceValues.has(value.confidence as SkillsRuleConfidence)
+  ) {
+    return false;
+  }
+  if (
+    typeof value.evaluationMode !== 'undefined' &&
+    !evaluationModeValues.has(value.evaluationMode as SkillsRuleEvaluationMode)
+  ) {
+    return false;
+  }
+  if (typeof value.locked !== 'undefined' && typeof value.locked !== 'boolean') {
+    return false;
+  }
+  return true;
+};
+
+const isCustomSkillsRulesFile = (value: unknown): value is CustomSkillsRulesFileV1 => {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.version !== '1.0') {
+    return false;
+  }
+  if (!isNonEmptyString(value.generatedAt) || !Number.isFinite(Date.parse(value.generatedAt))) {
+    return false;
+  }
+  if (!Array.isArray(value.source_files) || !value.source_files.every(isNonEmptyString)) {
+    return false;
+  }
+  if (!Array.isArray(value.rules) || value.rules.some((rule) => !isCustomRule(rule))) {
+    return false;
+  }
+  return true;
+};
+
+const normalizePath = (params: { repoRoot: string; path: string }): string => {
+  const absolute = isAbsolute(params.path)
+    ? params.path
+    : resolve(params.repoRoot, params.path);
+  return resolve(absolute);
+};
+
+const toRepoRelativePath = (params: { repoRoot: string; absolutePath: string }): string => {
+  const rel = relative(params.repoRoot, params.absolutePath);
+  if (!rel.startsWith('..') && !isAbsolute(rel)) {
+    return rel.replace(/\\/g, '/');
+  }
+  return params.absolutePath.replace(/\\/g, '/');
+};
+
+const computeBundleHash = (rules: ReadonlyArray<SkillsCompiledRule>): string => {
+  const normalized = rules
+    .map((rule) => ({
+      id: rule.id,
+      description: rule.description,
+      severity: rule.severity,
+      platform: rule.platform,
+      stage: rule.stage ?? null,
+      confidence: rule.confidence ?? null,
+      locked: rule.locked ?? false,
+      evaluationMode: rule.evaluationMode ?? null,
+      origin: rule.origin ?? null,
+      sourceSkill: rule.sourceSkill,
+      sourcePath: rule.sourcePath,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return createHash('sha256').update(stableStringify(normalized)).digest('hex');
+};
+
+const resolveCustomRulesFilePath = (repoRoot: string): string | undefined => {
+  for (const candidate of CUSTOM_RULES_FILE_CANDIDATES) {
+    const absolute = resolve(repoRoot, candidate);
+    if (existsSync(absolute)) {
+      return absolute;
+    }
+  }
+  return undefined;
+};
+
+const toCustomRulesFile = (
+  rules: ReadonlyArray<SkillsCompiledRule>,
+  sourceFiles: ReadonlyArray<string>
+): CustomSkillsRulesFileV1 => {
+  const normalizedRules = rules
+    .map((rule) => ({
+      id: rule.id,
+      description: rule.description,
+      severity: rule.severity,
+      platform: rule.platform,
+      stage: rule.stage,
+      confidence: rule.confidence,
+      locked: rule.locked ?? false,
+      evaluationMode: rule.evaluationMode ?? 'DECLARATIVE',
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    version: '1.0',
+    generatedAt: new Date().toISOString(),
+    source_files: [...new Set(sourceFiles)].sort(),
+    rules: normalizedRules,
+  };
+};
+
+const readJson = (absolutePath: string): unknown => {
+  try {
+    return JSON.parse(readFileSync(absolutePath, 'utf8')) as unknown;
+  } catch {
+    return undefined;
+  }
+};
+
+export const loadCustomSkillsRulesFile = (
+  repoRoot: string = process.cwd()
+): CustomSkillsRulesFileV1 | undefined => {
+  const path = resolveCustomRulesFilePath(repoRoot);
+  if (!path) {
+    return undefined;
+  }
+  const parsed = readJson(path);
+  if (!isCustomSkillsRulesFile(parsed)) {
+    return undefined;
+  }
+  return parsed;
+};
+
+export const loadCustomSkillsLock = (
+  repoRoot: string = process.cwd()
+): SkillsLockV1 | undefined => {
+  const payload = loadCustomSkillsRulesFile(repoRoot);
+  if (!payload || payload.rules.length === 0) {
+    return undefined;
+  }
+
+  const rules: SkillsCompiledRule[] = payload.rules.map((rule) => ({
+    ...rule,
+    sourceSkill: 'custom-guidelines',
+    sourcePath: '.pumuki/custom-rules.json',
+    evaluationMode: rule.evaluationMode ?? 'DECLARATIVE',
+    origin: 'custom',
+  }));
+
+  const bundle: SkillsLockBundle = {
+    name: 'custom-guidelines',
+    version: '1.0.0',
+    source: 'file:.pumuki/custom-rules.json',
+    hash: computeBundleHash(rules),
+    rules,
+  };
+
+  return {
+    version: '1.0',
+    compilerVersion: 'custom-1.0.0',
+    generatedAt: payload.generatedAt,
+    bundles: [bundle],
+  };
+};
+
+const extractSkillPathsFromText = (content: string): string[] => {
+  const matches = content.match(
+    /(\/[^\s`'"]*SKILL\.md|(?:\.{1,2}\/)?[A-Za-z0-9_./-]*SKILL\.md)/g
+  );
+  if (!matches) {
+    return [];
+  }
+  return matches;
+};
+
+const sourceSkillNameFromPath = (path: string): string => {
+  const parent = basename(dirname(path));
+  if (parent && parent.toUpperCase() !== 'SKILL.MD') {
+    return parent;
+  }
+  return basename(path).replace(/\.md$/i, '');
+};
+
+export const resolveSkillImportSources = (params: {
+  repoRoot?: string;
+  explicitSources?: ReadonlyArray<string>;
+}): string[] => {
+  const repoRoot = params.repoRoot ?? process.cwd();
+  const resolved = new Set<string>();
+
+  const pushIfExists = (rawPath: string): void => {
+    const normalized = normalizePath({
+      repoRoot,
+      path: rawPath,
+    });
+    if (!existsSync(normalized)) {
+      return;
+    }
+    resolved.add(normalized);
+  };
+
+  if (params.explicitSources && params.explicitSources.length > 0) {
+    for (const source of params.explicitSources) {
+      pushIfExists(source);
+    }
+    return [...resolved].sort();
+  }
+
+  for (const profileFile of ['AGENTS.md', 'SKILLS.md']) {
+    const profilePath = resolve(repoRoot, profileFile);
+    if (!existsSync(profilePath)) {
+      continue;
+    }
+    const content = readFileSync(profilePath, 'utf8');
+    for (const candidate of extractSkillPathsFromText(content)) {
+      pushIfExists(candidate);
+    }
+  }
+
+  return [...resolved].sort();
+};
+
+export const importCustomSkillsRules = (params: {
+  repoRoot?: string;
+  sourceFiles?: ReadonlyArray<string>;
+}): CustomSkillsImportResult => {
+  const repoRoot = params.repoRoot ?? process.cwd();
+  const sourceFiles = resolveSkillImportSources({
+    repoRoot,
+    explicitSources: params.sourceFiles,
+  });
+
+  const importedRules: SkillsCompiledRule[] = [];
+  const usedRuleIds = new Set<string>();
+
+  for (const sourceFile of sourceFiles) {
+    const sourceContent = readFileSync(sourceFile, 'utf8');
+    const sourceSkill = sourceSkillNameFromPath(sourceFile);
+    const sourcePath = toRepoRelativePath({
+      repoRoot,
+      absolutePath: sourceFile,
+    });
+
+    const extracted = extractCompiledRulesFromSkillMarkdown({
+      sourceSkill,
+      sourcePath,
+      sourceContent,
+      existingRuleIds: [...usedRuleIds],
+      origin: 'custom',
+    });
+
+    for (const rule of extracted) {
+      usedRuleIds.add(rule.id);
+      importedRules.push({
+        ...rule,
+        origin: 'custom' as SkillsRuleOrigin,
+      });
+    }
+  }
+
+  const outputPath = resolve(repoRoot, '.pumuki/custom-rules.json');
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const payload = toCustomRulesFile(importedRules, sourceFiles);
+  writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+
+  return {
+    sourceFiles,
+    importedRules: importedRules.sort((left, right) => left.id.localeCompare(right.id)),
+    outputPath,
+  };
+};

--- a/integrations/config/skillsEffectiveLock.ts
+++ b/integrations/config/skillsEffectiveLock.ts
@@ -1,0 +1,140 @@
+import { createHash } from 'node:crypto';
+import { loadCoreSkillsLock } from './coreSkillsLock';
+import { loadCustomSkillsLock } from './skillsCustomRules';
+import {
+  loadSkillsLock,
+  type SkillsCompiledRule,
+  type SkillsLockBundle,
+  type SkillsLockV1,
+} from './skillsLock';
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+    return `{${entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+};
+
+const toBundleHash = (params: {
+  name: string;
+  version: string;
+  source: string;
+  rules: ReadonlyArray<SkillsCompiledRule>;
+}): string => {
+  const normalized = {
+    name: params.name,
+    version: params.version,
+    source: params.source,
+    rules: [...params.rules]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((rule) => ({
+        id: rule.id,
+        description: rule.description,
+        severity: rule.severity,
+        platform: rule.platform,
+        sourceSkill: rule.sourceSkill,
+        sourcePath: rule.sourcePath,
+        stage: rule.stage ?? null,
+        confidence: rule.confidence ?? null,
+        locked: rule.locked ?? false,
+        evaluationMode: rule.evaluationMode ?? null,
+        origin: rule.origin ?? null,
+      })),
+  };
+  return createHash('sha256').update(stableStringify(normalized)).digest('hex');
+};
+
+const mergeBundles = (
+  baseBundles: ReadonlyArray<SkillsLockBundle>,
+  overlayBundles: ReadonlyArray<SkillsLockBundle>
+): SkillsLockBundle[] => {
+  const byName = new Map<string, SkillsLockBundle>();
+  const order: string[] = [];
+
+  const addBundle = (bundle: SkillsLockBundle): void => {
+    const existing = byName.get(bundle.name);
+    if (!existing) {
+      byName.set(bundle.name, {
+        ...bundle,
+        rules: [...bundle.rules].sort((left, right) => left.id.localeCompare(right.id)),
+      });
+      order.push(bundle.name);
+      return;
+    }
+
+    const byRuleId = new Map<string, SkillsCompiledRule>();
+    for (const rule of existing.rules) {
+      byRuleId.set(rule.id, rule);
+    }
+    for (const rule of bundle.rules) {
+      byRuleId.set(rule.id, rule);
+    }
+
+    const rules = [...byRuleId.values()].sort((left, right) => left.id.localeCompare(right.id));
+    byName.set(bundle.name, {
+      ...existing,
+      ...bundle,
+      rules,
+      hash: toBundleHash({
+        name: bundle.name,
+        version: bundle.version,
+        source: bundle.source,
+        rules,
+      }),
+    });
+  };
+
+  for (const bundle of baseBundles) {
+    addBundle(bundle);
+  }
+  for (const bundle of overlayBundles) {
+    addBundle(bundle);
+  }
+
+  return order
+    .map((name) => byName.get(name))
+    .filter((bundle): bundle is SkillsLockBundle => bundle !== undefined);
+};
+
+const mergeSkillsLocks = (
+  base: SkillsLockV1,
+  overlay: SkillsLockV1
+): SkillsLockV1 => {
+  return {
+    version: '1.0',
+    compilerVersion: overlay.compilerVersion || base.compilerVersion,
+    generatedAt: overlay.generatedAt || base.generatedAt,
+    bundles: mergeBundles(base.bundles, overlay.bundles),
+  };
+};
+
+export const loadEffectiveSkillsLock = (
+  repoRoot: string = process.cwd()
+): SkillsLockV1 | undefined => {
+  const coreDisabled = process.env.PUMUKI_DISABLE_CORE_SKILLS?.trim() === '1';
+  const coreLock = coreDisabled ? undefined : loadCoreSkillsLock();
+  const repoLock = loadSkillsLock(repoRoot);
+  const customLock = loadCustomSkillsLock(repoRoot);
+
+  let effectiveLock = coreLock ?? repoLock;
+  if (!effectiveLock) {
+    return undefined;
+  }
+
+  if (repoLock && coreLock) {
+    effectiveLock = mergeSkillsLocks(coreLock, repoLock);
+  }
+  if (customLock && effectiveLock) {
+    effectiveLock = mergeSkillsLocks(effectiveLock, customLock);
+  }
+
+  return effectiveLock;
+};

--- a/integrations/config/skillsLock.ts
+++ b/integrations/config/skillsLock.ts
@@ -8,6 +8,8 @@ import type { Severity } from '../../core/rules/Severity';
 export type SkillsStage = Exclude<GateStage, 'STAGED'>;
 
 export type SkillsRuleConfidence = 'HIGH' | 'MEDIUM' | 'LOW';
+export type SkillsRuleEvaluationMode = 'AUTO' | 'DECLARATIVE';
+export type SkillsRuleOrigin = 'core' | 'custom';
 
 export type SkillsCompiledRule = {
   id: string;
@@ -19,6 +21,8 @@ export type SkillsCompiledRule = {
   stage?: SkillsStage;
   confidence?: SkillsRuleConfidence;
   locked?: boolean;
+  evaluationMode?: SkillsRuleEvaluationMode;
+  origin?: SkillsRuleOrigin;
 };
 
 export type SkillsLockBundle = {
@@ -43,6 +47,8 @@ const SHA256_PATTERN = /^[A-Fa-f0-9]{64}$/;
 const severityValues = new Set<Severity>(['INFO', 'WARN', 'ERROR', 'CRITICAL']);
 const stageValues = new Set<SkillsStage>(['PRE_COMMIT', 'PRE_PUSH', 'CI']);
 const confidenceValues = new Set<SkillsRuleConfidence>(['HIGH', 'MEDIUM', 'LOW']);
+const evaluationModeValues = new Set<SkillsRuleEvaluationMode>(['AUTO', 'DECLARATIVE']);
+const originValues = new Set<SkillsRuleOrigin>(['core', 'custom']);
 const platformValues = new Set<NonNullable<RuleDefinition['platform']>>([
   'ios',
   'android',
@@ -78,6 +84,14 @@ const isSkillsStage = (value: unknown): value is SkillsStage => {
 
 const isRuleConfidence = (value: unknown): value is SkillsRuleConfidence => {
   return typeof value === 'string' && confidenceValues.has(value as SkillsRuleConfidence);
+};
+
+const isRuleEvaluationMode = (value: unknown): value is SkillsRuleEvaluationMode => {
+  return typeof value === 'string' && evaluationModeValues.has(value as SkillsRuleEvaluationMode);
+};
+
+const isRuleOrigin = (value: unknown): value is SkillsRuleOrigin => {
+  return typeof value === 'string' && originValues.has(value as SkillsRuleOrigin);
 };
 
 const isRulePlatform = (
@@ -122,6 +136,17 @@ const isSkillsCompiledRule = (value: unknown): value is SkillsCompiledRule => {
   }
 
   if (typeof value.confidence !== 'undefined' && !isRuleConfidence(value.confidence)) {
+    return false;
+  }
+
+  if (
+    typeof value.evaluationMode !== 'undefined' &&
+    !isRuleEvaluationMode(value.evaluationMode)
+  ) {
+    return false;
+  }
+
+  if (typeof value.origin !== 'undefined' && !isRuleOrigin(value.origin)) {
     return false;
   }
 
@@ -194,6 +219,8 @@ const normalizedRuleForHash = (rule: SkillsCompiledRule): Record<string, unknown
     stage: rule.stage ?? null,
     confidence: rule.confidence ?? null,
     locked: rule.locked ?? false,
+    evaluationMode: rule.evaluationMode ?? null,
+    origin: rule.origin ?? null,
   };
 };
 

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -1,0 +1,328 @@
+import type { Severity } from '../../core/rules/Severity';
+import type {
+  SkillsCompiledRule,
+  SkillsRuleConfidence,
+  SkillsRuleEvaluationMode,
+  SkillsRuleOrigin,
+  SkillsStage,
+} from './skillsLock';
+
+const CHECK_RULE_PREFIX = /^[✅❌]\s*/u;
+const BULLET_RULE_PREFIX = /^[-*]\s+/u;
+const MARKDOWN_LINK_PATTERN = /\[([^\]]+)\]\(([^)]+)\)/g;
+const INLINE_CODE_PATTERN = /`([^`]+)`/g;
+const MARKDOWN_BOLD_PATTERN = /[*_]{1,3}/g;
+const MULTISPACE_PATTERN = /\s+/g;
+const RULE_KEYWORDS =
+  /\b(always|siempre|prefer|use|usar|avoid|evitar|never|nunca|must|obligatorio|required|disallow|do not|no)\b/i;
+
+const normalizeForLookup = (value: string): string => {
+  return value
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+};
+
+const slugify = (value: string): string => {
+  return value
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+};
+
+const sanitizeRuleDescription = (value: string): string => {
+  return value
+    .replace(CHECK_RULE_PREFIX, '')
+    .replace(BULLET_RULE_PREFIX, '')
+    .replace(MARKDOWN_LINK_PATTERN, '$1')
+    .replace(INLINE_CODE_PATTERN, '$1')
+    .replace(MARKDOWN_BOLD_PATTERN, '')
+    .replace(MULTISPACE_PATTERN, ' ')
+    .trim();
+};
+
+const inferRuleSeverity = (raw: string): Severity => {
+  const normalized = normalizeForLookup(raw);
+  if (/^\s*❌/u.test(raw)) {
+    return 'ERROR';
+  }
+  if (/\bcritical\b|\bbloqueante\b|\bblock\b/.test(normalized)) {
+    return 'CRITICAL';
+  }
+  if (
+    /\bnever\b|\bnunca\b|\bmust\b|\bobligatorio\b|\brequired\b|\bdisallow\b|\bavoid\b|\bevitar\b|\bdo not\b/.test(
+      normalized
+    )
+  ) {
+    return 'ERROR';
+  }
+  return 'WARN';
+};
+
+const inferRuleConfidence = (raw: string): SkillsRuleConfidence => {
+  if (/^\s*❌/u.test(raw)) {
+    return 'HIGH';
+  }
+  if (/\bmust\b|\bobligatorio\b|\brequired\b|\bdisallow\b/i.test(raw)) {
+    return 'HIGH';
+  }
+  return 'MEDIUM';
+};
+
+const inferRuleStage = (raw: string): SkillsStage | undefined => {
+  const normalized = normalizeForLookup(raw);
+  if (/\bpre push\b/.test(normalized)) {
+    return 'PRE_PUSH';
+  }
+  if (/\bpre commit\b/.test(normalized)) {
+    return 'PRE_COMMIT';
+  }
+  if (/\bci\b/.test(normalized)) {
+    return 'CI';
+  }
+  return undefined;
+};
+
+const isRuleCandidateLine = (line: string): boolean => {
+  if (CHECK_RULE_PREFIX.test(line)) {
+    return true;
+  }
+  if (!BULLET_RULE_PREFIX.test(line)) {
+    return false;
+  }
+  const content = line.replace(BULLET_RULE_PREFIX, '').trim();
+  if (content.length < 8) {
+    return false;
+  }
+  if (/^\[[ xX]\]\s+/.test(content)) {
+    return false;
+  }
+  if (/^\|/.test(content)) {
+    return false;
+  }
+  return RULE_KEYWORDS.test(content);
+};
+
+const extractRuleCandidateLines = (markdown: string): string[] => {
+  const lines = markdown.split('\n');
+  const candidates: string[] = [];
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) {
+      continue;
+    }
+    if (trimmed.length === 0 || trimmed.startsWith('#') || trimmed.startsWith('|')) {
+      continue;
+    }
+    if (!isRuleCandidateLine(trimmed)) {
+      continue;
+    }
+    candidates.push(trimmed);
+  }
+
+  return candidates;
+};
+
+const resolvePlatformFromBundle = (
+  bundleName: string
+): SkillsCompiledRule['platform'] => {
+  const normalized = bundleName.toLowerCase();
+  if (normalized.includes('ios')) {
+    return 'ios';
+  }
+  if (normalized.includes('android')) {
+    return 'android';
+  }
+  if (normalized.includes('backend')) {
+    return 'backend';
+  }
+  if (normalized.includes('frontend')) {
+    return 'frontend';
+  }
+  return 'generic';
+};
+
+const normalizeKnownRuleTarget = (
+  platform: SkillsCompiledRule['platform'],
+  normalizedDescription: string
+): string | null => {
+  const includes = (needle: string): boolean => normalizedDescription.includes(needle);
+
+  if (platform === 'ios') {
+    if (includes('force unwrap')) {
+      return 'skills.ios.no-force-unwrap';
+    }
+    if (includes('force try')) {
+      return 'skills.ios.no-force-try';
+    }
+    if (includes('anyview')) {
+      return 'skills.ios.no-anyview';
+    }
+    if (includes('callback style') || includes('completion handler')) {
+      return 'skills.ios.no-callback-style-outside-bridges';
+    }
+    if (includes('force cast')) {
+      return 'skills.ios.no-force-cast';
+    }
+    if (includes('dispatchqueue') || includes('dispatch queue')) {
+      return 'skills.ios.no-dispatchqueue';
+    }
+    if (includes('dispatchgroup') || includes('dispatch group')) {
+      return 'skills.ios.no-dispatchgroup';
+    }
+    if (includes('dispatchsemaphore') || includes('dispatch semaphore')) {
+      return 'skills.ios.no-dispatchsemaphore';
+    }
+    if (includes('operationqueue') || includes('operation queue')) {
+      return 'skills.ios.no-operation-queue';
+    }
+    if (includes('task detached') || includes('task.detached')) {
+      return 'skills.ios.no-task-detached';
+    }
+    if (includes('unchecked sendable')) {
+      return 'skills.ios.no-unchecked-sendable';
+    }
+    if (includes('observableobject') || includes('observable object')) {
+      return 'skills.ios.no-observable-object';
+    }
+    if (includes('navigationview') || includes('navigation view')) {
+      return 'skills.ios.no-navigation-view';
+    }
+    if (includes('ontapgesture') || includes('on tap gesture')) {
+      return 'skills.ios.no-on-tap-gesture';
+    }
+    if (includes('string format') || includes('string(format')) {
+      return 'skills.ios.no-string-format';
+    }
+    if (includes('uiscreen main bounds') || includes('uiscreen.main.bounds')) {
+      return 'skills.ios.no-uiscreen-main-bounds';
+    }
+    return null;
+  }
+
+  if (platform === 'android') {
+    if (includes('thread sleep') || includes('thread.sleep')) {
+      return 'skills.android.no-thread-sleep';
+    }
+    if (includes('globalscope') || includes('global scope')) {
+      return 'skills.android.no-globalscope';
+    }
+    if (includes('runblocking') || includes('run blocking')) {
+      return 'skills.android.no-runblocking';
+    }
+    return null;
+  }
+
+  if (platform === 'backend' || platform === 'frontend') {
+    const prefix = platform === 'backend' ? 'skills.backend' : 'skills.frontend';
+    if (includes('empty catch')) {
+      return `${prefix}.no-empty-catch`;
+    }
+    if (includes('console log') || includes('console.log')) {
+      return `${prefix}.no-console-log`;
+    }
+    if (includes('explicit any') || includes(' no any') || includes('avoid any')) {
+      return `${prefix}.avoid-explicit-any`;
+    }
+    return null;
+  }
+
+  return null;
+};
+
+const buildGeneratedRuleId = (
+  params: {
+    platform: SkillsCompiledRule['platform'];
+    sourceSkill: string;
+    description: string;
+  },
+  usedIds: Set<string>
+): string => {
+  const slug = slugify(params.description).slice(0, 70) || 'rule';
+  const sourceSlug = slugify(params.sourceSkill).replace(/-guidelines?$/, '') || 'bundle';
+  const base = `skills.${params.platform}.guideline.${sourceSlug}.${slug}`;
+  if (!usedIds.has(base)) {
+    return base;
+  }
+  let counter = 2;
+  while (usedIds.has(`${base}-${counter}`)) {
+    counter += 1;
+  }
+  return `${base}-${counter}`;
+};
+
+const dedupeById = (
+  rules: ReadonlyArray<SkillsCompiledRule>
+): SkillsCompiledRule[] => {
+  const byId = new Map<string, SkillsCompiledRule>();
+  for (const rule of rules) {
+    byId.set(rule.id, rule);
+  }
+  return [...byId.values()].sort((left, right) => left.id.localeCompare(right.id));
+};
+
+export const extractCompiledRulesFromSkillMarkdown = (params: {
+  sourceSkill: string;
+  sourcePath: string;
+  sourceContent: string;
+  existingRuleIds?: ReadonlyArray<string>;
+  origin?: SkillsRuleOrigin;
+}): SkillsCompiledRule[] => {
+  const platform = resolvePlatformFromBundle(params.sourceSkill);
+  const usedIds = new Set<string>(params.existingRuleIds ?? []);
+  const rules: SkillsCompiledRule[] = [];
+
+  for (const rawLine of extractRuleCandidateLines(params.sourceContent)) {
+    const description = sanitizeRuleDescription(rawLine);
+    if (description.length < 6) {
+      continue;
+    }
+
+    const knownRuleId = normalizeKnownRuleTarget(platform, normalizeForLookup(description));
+    const nextId =
+      knownRuleId && !usedIds.has(knownRuleId)
+        ? knownRuleId
+        : buildGeneratedRuleId(
+            {
+              platform,
+              sourceSkill: params.sourceSkill,
+              description,
+            },
+            usedIds
+          );
+
+    if (usedIds.has(nextId)) {
+      continue;
+    }
+    usedIds.add(nextId);
+
+    const evaluationMode: SkillsRuleEvaluationMode = knownRuleId
+      ? 'AUTO'
+      : 'DECLARATIVE';
+
+    rules.push({
+      id: nextId,
+      description,
+      severity: inferRuleSeverity(rawLine),
+      platform,
+      sourceSkill: params.sourceSkill,
+      sourcePath: params.sourcePath,
+      stage: inferRuleStage(rawLine),
+      confidence: inferRuleConfidence(rawLine),
+      locked: true,
+      evaluationMode,
+      origin: params.origin ?? 'core',
+    });
+  }
+
+  return dedupeById(rules);
+};

--- a/integrations/git/runPlatformGateEvaluation.ts
+++ b/integrations/git/runPlatformGateEvaluation.ts
@@ -122,7 +122,8 @@ export const evaluatePlatformGateFindings = (
   const stageForSkills = normalizeStageForSkills(params.stage);
   const skillsRuleSet = activeDependencies.loadSkillsRuleSetForStage(
     stageForSkills,
-    params.repoRoot
+    params.repoRoot,
+    detectedPlatforms
   );
   const baselineRules = activeDependencies.buildCombinedBaselineRules(detectedPlatforms);
   const shouldExtractHeuristicFacts =

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "validation:clean-artifacts": "npx --yes tsx@4.21.0 scripts/clean-validation-artifacts.ts",
     "skills:compile": "npx --yes tsx@4.21.0 scripts/compile-skills-lock.ts",
     "skills:lock:check": "npx --yes tsx@4.21.0 scripts/compile-skills-lock.ts --check",
+    "skills:import:custom": "npx --yes tsx@4.21.0 scripts/import-custom-skills.ts",
     "mcp:evidence": "node bin/pumuki-mcp-evidence.js",
     "mcp:enterprise": "node bin/pumuki-mcp-enterprise.js",
     "validate:adapter-hooks-local": "echo 'Migrated to modern TS scripts — use validation:adapter-readiness instead'",

--- a/scripts/__tests__/framework-menu-advanced-view.test.ts
+++ b/scripts/__tests__/framework-menu-advanced-view.test.ts
@@ -95,6 +95,24 @@ test('formatAdvancedMenuView conserva ayuda de opcion 8 sin truncar .ai_evidence
   assert.match(rendered, /Read current \.ai_evidence\.json[\s\S]*Lee el \.ai_evidence\.json actual/i);
 });
 
+test('formatAdvancedMenuView muestra ayuda contextual de opcion 33 para importar custom rules', () => {
+  const rendered = formatAdvancedMenuView(buildAdvancedActions(), {
+    evidenceSummary: {
+      status: 'ok',
+      stage: 'PRE_PUSH',
+      outcome: 'PASS',
+      totalFindings: 0,
+      bySeverity: { CRITICAL: 0, ERROR: 0, WARN: 0, INFO: 0 },
+      topFiles: [],
+    },
+  });
+
+  assert.match(
+    rendered,
+    /33\)\s+Import custom skills rules[\s\S]*Importa reglas custom[\s\S]*AGENTS\.md\/SKILLS\.md/i
+  );
+});
+
 test('formatAdvancedMenuClassicView conserva formato legacy sin panel agrupado', () => {
   const rendered = formatAdvancedMenuClassicView(buildAdvancedActions(), {
     evidenceSummary: {

--- a/scripts/__tests__/framework-menu-command-builders-core.test.ts
+++ b/scripts/__tests__/framework-menu-command-builders-core.test.ts
@@ -4,6 +4,7 @@ import {
   buildAdapterRealSessionReportCommandArgs,
   buildAdapterReadinessCommandArgs,
   buildConsumerStartupTriageCommandArgs,
+  buildImportCustomSkillsCommandArgs,
   buildMockConsumerAbReportCommandArgs,
   buildPhase5BlockersReadinessCommandArgs,
   buildPhase5ExternalHandoffCommandArgs,
@@ -35,6 +36,15 @@ test('builds deterministic command args for skills lock freshness check', () => 
   assert.deepEqual(args, [
     'run',
     'skills:lock:check',
+  ]);
+});
+
+test('builds deterministic command args for custom skills import', () => {
+  const args = buildImportCustomSkillsCommandArgs();
+
+  assert.deepEqual(args, [
+    'run',
+    'skills:import:custom',
   ]);
 });
 

--- a/scripts/__tests__/framework-menu-hard-mode-config.test.ts
+++ b/scripts/__tests__/framework-menu-hard-mode-config.test.ts
@@ -51,6 +51,14 @@ test('framework menu expone accion para diagnosticar cobertura de reglas', () =>
   assert.match(diagnosticsAction.label, /rule coverage|diagnostics|reglas/i);
 });
 
+test('framework menu expone accion para importar reglas custom', () => {
+  const actions = createFrameworkMenuActions(createMenuContext());
+  const importCustomAction = actions.find((action) => action.id === '33');
+
+  assert.ok(importCustomAction);
+  assert.match(importCustomAction.label, /import custom skills|agents\.md|skills\.md/i);
+});
+
 test('buildHardModeConfigFromSelection soporta critical-high y all-severities', () => {
   assert.deepEqual(buildHardModeConfigFromSelection('critical-high'), {
     enabled: true,

--- a/scripts/framework-menu-actions-diagnostics-maintenance-lib.ts
+++ b/scripts/framework-menu-actions-diagnostics-maintenance-lib.ts
@@ -1,6 +1,7 @@
 import {
   runAndPrintExitCode,
   runHardModeEnforcementConfig,
+  runImportCustomSkills,
   runRuleCoverageDiagnostics,
   runSystemNotificationsConfig,
   runSkillsLockCheck,
@@ -39,6 +40,11 @@ export const createFrameworkMenuDiagnosticsMaintenanceActions = (
       id: '32',
       label: 'Run rule coverage diagnostics (repo/stages)',
       execute: async () => runAndPrintExitCode(runRuleCoverageDiagnostics),
+    },
+    {
+      id: '33',
+      label: 'Import custom skills rules (AGENTS.md/SKILLS.md)',
+      execute: async () => runAndPrintExitCode(runImportCustomSkills),
     },
   ];
 };

--- a/scripts/framework-menu-advanced-view-lib.ts
+++ b/scripts/framework-menu-advanced-view-lib.ts
@@ -39,6 +39,7 @@ const ADVANCED_MENU_HELP: Readonly<Record<string, string>> = {
   '18': 'Configura hard mode/enforcement enterprise.',
   '31': 'Configura notificaciones del sistema (macOS) para eventos criticos.',
   '32': 'Diagnóstico de cobertura de reglas evaluadas por stage (repo completo).',
+  '33': 'Importa reglas custom desde AGENTS.md/SKILLS.md hacia .pumuki/custom-rules.json.',
   '19': 'Ejecuta startup triage bundle del consumidor.',
   '20': 'Genera reporte A/B del mock consumer.',
   '21': 'Genera reporte de blockers readiness (phase5).',

--- a/scripts/framework-menu-builders-maintenance.ts
+++ b/scripts/framework-menu-builders-maintenance.ts
@@ -16,3 +16,7 @@ export const buildCleanValidationArtifactsCommandArgs = (params: {
 export const buildSkillsLockCheckCommandArgs = (): string[] => {
   return ['run', 'skills:lock:check'];
 };
+
+export const buildImportCustomSkillsCommandArgs = (): string[] => {
+  return ['run', 'skills:import:custom'];
+};

--- a/scripts/framework-menu-builders.ts
+++ b/scripts/framework-menu-builders.ts
@@ -14,5 +14,6 @@ export {
 } from './framework-menu-builders-phase5';
 export {
   buildCleanValidationArtifactsCommandArgs,
+  buildImportCustomSkillsCommandArgs,
   buildSkillsLockCheckCommandArgs,
 } from './framework-menu-builders-maintenance';

--- a/scripts/framework-menu-layout-lib.ts
+++ b/scripts/framework-menu-layout-lib.ts
@@ -72,7 +72,7 @@ export const ADVANCED_MENU_LAYOUT: ReadonlyArray<MenuLayoutGroup> = [
   {
     key: 'maintenance',
     title: 'Maintenance',
-    itemIds: ['17', '18', '31'],
+    itemIds: ['17', '18', '31', '33'],
   },
   {
     key: 'validation',

--- a/scripts/framework-menu-runners-validation-custom-rules-lib.ts
+++ b/scripts/framework-menu-runners-validation-custom-rules-lib.ts
@@ -1,0 +1,11 @@
+import { buildImportCustomSkillsCommandArgs } from './framework-menu-builders';
+import { getExitCode, runNpm } from './framework-menu-runner-common';
+
+export const runImportCustomSkills = async (): Promise<number> => {
+  try {
+    runNpm(buildImportCustomSkillsCommandArgs());
+    return 0;
+  } catch (error) {
+    return getExitCode(error);
+  }
+};

--- a/scripts/framework-menu-runners-validation.ts
+++ b/scripts/framework-menu-runners-validation.ts
@@ -1,5 +1,6 @@
 export type { ValidationArtifactsCleanupRunnerParams } from './framework-menu-runners-validation-cleanup-lib';
 export { runValidationArtifactsCleanup } from './framework-menu-runners-validation-cleanup-lib';
+export { runImportCustomSkills } from './framework-menu-runners-validation-custom-rules-lib';
 export { runHardModeEnforcementConfig } from './framework-menu-runners-validation-hardmode-lib';
 export { runSystemNotificationsConfig } from './framework-menu-runners-validation-notifications-lib';
 export { runSkillsLockCheck } from './framework-menu-runners-validation-skills-lib';

--- a/scripts/framework-menu-skills-lib.ts
+++ b/scripts/framework-menu-skills-lib.ts
@@ -1,4 +1,5 @@
-import { type SkillsLockBundle, loadSkillsLock } from '../integrations/config/skillsLock';
+import { type SkillsLockBundle } from '../integrations/config/skillsLock';
+import { loadEffectiveSkillsLock } from '../integrations/config/skillsEffectiveLock';
 
 export const formatActiveSkillsBundles = (
   bundles: ReadonlyArray<Pick<SkillsLockBundle, 'name' | 'version' | 'hash'>>
@@ -21,6 +22,6 @@ export const formatActiveSkillsBundles = (
 };
 
 export const loadAndFormatActiveSkillsBundles = (repoRoot: string): string => {
-  const lock = loadSkillsLock(repoRoot);
+  const lock = loadEffectiveSkillsLock(repoRoot);
   return formatActiveSkillsBundles(lock?.bundles ?? []);
 };

--- a/scripts/import-custom-skills.ts
+++ b/scripts/import-custom-skills.ts
@@ -1,0 +1,69 @@
+import { loadCoreSkillsLock } from '../integrations/config/coreSkillsLock';
+import {
+  importCustomSkillsRules,
+  resolveSkillImportSources,
+} from '../integrations/config/skillsCustomRules';
+
+type ParsedArgs = {
+  repoRoot: string;
+  sources: string[];
+};
+
+const parseArgs = (argv: string[]): ParsedArgs => {
+  const parsed: ParsedArgs = {
+    repoRoot: process.cwd(),
+    sources: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if ((token === '--source' || token === '--from') && argv[index + 1]) {
+      parsed.sources.push(argv[index + 1] as string);
+      index += 1;
+      continue;
+    }
+    if (token === '--repo-root' && argv[index + 1]) {
+      parsed.repoRoot = argv[index + 1] as string;
+      index += 1;
+      continue;
+    }
+  }
+
+  return parsed;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const sourceFiles = resolveSkillImportSources({
+  repoRoot: args.repoRoot,
+  explicitSources: args.sources,
+});
+
+if (sourceFiles.length === 0) {
+  process.stderr.write(
+    '[pumuki] No se detectaron fuentes de skills. Usa --source <path> o define rutas SKILL.md en AGENTS.md/SKILLS.md.\n'
+  );
+  process.exit(1);
+}
+
+const result = importCustomSkillsRules({
+  repoRoot: args.repoRoot,
+  sourceFiles,
+});
+
+const coreRuleIds = new Set(
+  (loadCoreSkillsLock()?.bundles ?? [])
+    .flatMap((bundle) => bundle.rules)
+    .map((rule) => rule.id)
+);
+const overrideRuleIds = result.importedRules
+  .filter((rule) => coreRuleIds.has(rule.id))
+  .map((rule) => rule.id)
+  .sort();
+
+process.stdout.write('\n[pumuki] Custom skills import completed.\n');
+process.stdout.write(`- sources_detected: ${result.sourceFiles.length}\n`);
+process.stdout.write(`- imported_rules: ${result.importedRules.length}\n`);
+process.stdout.write(`- output: ${result.outputPath}\n`);
+process.stdout.write(
+  `- overridden_core_rules: ${overrideRuleIds.length > 0 ? overrideRuleIds.join(', ') : 'none'}\n`
+);


### PR DESCRIPTION
## Summary
- embed core skills lock at runtime and resolve effective lock as core + repo + custom
- add custom rules import flow (skills:import:custom) from AGENTS.md/SKILLS.md or explicit SKILL.md paths
- wire advanced menu option 33 for custom import and reflect effective bundles in diagnostics
- expand test coverage for effective lock fallback, custom import, precedence (custom > core), and menu integration
- update enterprise docs (README, USAGE, API_REFERENCE, evidence-v2.1) and cycle trackers

## Validation
- npx --yes tsx@4.21.0 --test integrations/config/__tests__/compileSkillsLock.test.ts integrations/config/__tests__/skillsRuleSet.test.ts integrations/config/__tests__/skillsEffectiveLock.test.ts integrations/config/__tests__/skillsCustomRules.test.ts
- npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGateEvaluation.test.ts integrations/git/__tests__/runPlatformGateEvidence.test.ts integrations/git/__tests__/runPlatformGate.test.ts
- npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-*.test.ts