### PR TITLE
docs(cycle): close rules engine unification tracking

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -70,7 +70,7 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F6.T1` completada: `README.md` actualizado con arquitectura de rules engine unificado.
 - ✅ `F6.T2` completada: `docs/USAGE.md` y `docs/API_REFERENCE.md` actualizados con comandos/contratos de custom rules.
 - ✅ `F6.T3` completada: `docs/evidence-v2.1.md` actualizado para reflejar trazabilidad de bundles efectivos y reglas declarativas.
-- 🚧 `F6.T4` en construccion: cierre Git Flow end-to-end (`feature -> develop -> main`).
+- ✅ `F6.T4` completada: cierre Git Flow end-to-end (`feature -> develop -> main`) con PR #339 y PR #340 mergeadas.
 
 ## Hitos recientes
 - ✅ Sync Git Flow cerrado en ciclo anterior (`develop -> main`) con ramas remotas alineadas.
@@ -102,7 +102,8 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ Cobertura de menú extendida: opción `33` en acciones/builders/vista advanced verificada en tests.
 - ✅ Validación consolidada: 21 tests config + 12 tests git + 113 tests framework menu en verde.
 - ✅ Documentación enterprise alineada al motor unificado (`README`, `USAGE`, `API_REFERENCE`, `evidence-v2.1`).
-- Estado activo: `F6.T4` del ciclo `RULES_ENGINE_UNIFICATION_CYCLE` (Git Flow end-to-end).
+- ✅ Cierre de release ejecutado: `feature/rules-engine-unification -> develop` (#339) y `develop -> main` (#340).
+- Estado activo: ciclo `RULES_ENGINE_UNIFICATION_CYCLE` cerrado.
 
 ## Siguiente paso operativo
-- ⏳ Completar `F6.T4` y cerrar ciclo.
+- ⏳ N/A — ciclo cerrado.

--- a/docs/RULES_ENGINE_UNIFICATION_CYCLE.md
+++ b/docs/RULES_ENGINE_UNIFICATION_CYCLE.md
@@ -2,7 +2,7 @@
 
 Plan operativo unico para unificar el motor de reglas de Pumuki con cobertura total de reglas core + overrides custom por repo.
 
-Estado del plan: `EN_CONSTRUCCION`
+Estado del plan: `CERRADO`
 
 ## Leyenda
 - ✅ Hecho
@@ -59,7 +59,7 @@ Garantizar que Pumuki aplique siempre TODAS las reglas core del producto (sin de
 - ✅ F6.T1 Actualizar `README.md` con arquitectura core rules + custom per repo.
 - ✅ F6.T2 Actualizar `docs/USAGE.md` y `docs/API_REFERENCE.md`.
 - ✅ F6.T3 Actualizar `docs/evidence-v2.1.md` con nuevos campos de cobertura/origen.
-- 🚧 F6.T4 Cierre Git Flow end-to-end: PR a `develop`, merge, sync `develop -> main`.
+- ✅ F6.T4 Cierre Git Flow end-to-end: PR a `develop`, merge, sync `develop -> main`.
 
 ## Política cerrada del ciclo
 - Core rules siempre activas por plataforma detectada.
@@ -67,3 +67,4 @@ Garantizar que Pumuki aplique siempre TODAS las reglas core del producto (sin de
 - Overrides custom solo locales por repo.
 - Política de conflictos: `custom > core`.
 - Evidencia obligatoria y determinista para cobertura de reglas.
+- Ciclo cerrado con merge completado en `develop` y `main`.


### PR DESCRIPTION
## Summary
- mark F6.T4 as completed after #339 and #340
- set RULES_ENGINE_UNIFICATION_CYCLE status to CERRADO
- sync REFRACTOR_PROGRESS with cycle closure state

## Notes
- docs-only closure update