### PR TITLE
fix(platform): harden multi-repo platform detection

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -71,6 +71,10 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F6.T2` completada: `docs/USAGE.md` y `docs/API_REFERENCE.md` actualizados con comandos/contratos de custom rules.
 - ✅ `F6.T3` completada: `docs/evidence-v2.1.md` actualizado para reflejar trazabilidad de bundles efectivos y reglas declarativas.
 - ✅ `F6.T4` completada: cierre Git Flow end-to-end (`feature -> develop -> main`) con PR #339 y PR #340 mergeadas.
+- ✅ Post-cierre: auditoría de consistencia skills local/vendorizado completada (`MATCH` por hash en Android/Backend/Frontend/iOS/Concurrency/SwiftUI).
+- ✅ Post-cierre: hardening multi-repo aplicado en detección de plataformas (soporte fuera de `apps/*` + fallback ambiguo TS/JS).
+- ✅ Post-cierre: TDD ampliado (`detect*`/`detectPlatforms`/`coreSkillsLock`) y suites de regresión en verde.
+- 🚧 Post-cierre: preparar cierre Git Flow del hardening multi-repo (commit + PR + merge).
 
 ## Hitos recientes
 - ✅ Sync Git Flow cerrado en ciclo anterior (`develop -> main`) con ramas remotas alineadas.
@@ -103,7 +107,8 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ Validación consolidada: 21 tests config + 12 tests git + 113 tests framework menu en verde.
 - ✅ Documentación enterprise alineada al motor unificado (`README`, `USAGE`, `API_REFERENCE`, `evidence-v2.1`).
 - ✅ Cierre de release ejecutado: `feature/rules-engine-unification -> develop` (#339) y `develop -> main` (#340).
-- Estado activo: ciclo `RULES_ENGINE_UNIFICATION_CYCLE` cerrado.
+- ✅ Verificación runtime: core lock embebido con 6 bundles y 759 reglas totales cargadas.
+- Estado activo: hardening post-cierre para garantizar cobertura de reglas en repos genéricos.
 
 ## Siguiente paso operativo
-- ⏳ N/A — ciclo cerrado.
+- ⏳ Completar cierre Git Flow del hardening multi-repo.

--- a/integrations/config/__tests__/coreSkillsLock.test.ts
+++ b/integrations/config/__tests__/coreSkillsLock.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  __resetCoreSkillsLockCacheForTests,
+  loadCoreSkillsLock,
+} from '../coreSkillsLock';
+
+test('loadCoreSkillsLock incluye todos los bundles core esperados con reglas compiladas', () => {
+  __resetCoreSkillsLockCacheForTests();
+  const lock = loadCoreSkillsLock();
+  assert.ok(lock);
+
+  const bundleNames = lock.bundles.map((bundle) => bundle.name).sort();
+  assert.deepEqual(bundleNames, [
+    'android-guidelines',
+    'backend-guidelines',
+    'frontend-guidelines',
+    'ios-concurrency-guidelines',
+    'ios-guidelines',
+    'ios-swiftui-expert-guidelines',
+  ]);
+
+  for (const bundle of lock.bundles) {
+    assert.equal(bundle.rules.length > 0, true);
+  }
+});

--- a/integrations/platform/__tests__/detectAndroid.test.ts
+++ b/integrations/platform/__tests__/detectAndroid.test.ts
@@ -59,10 +59,20 @@ test('detectAndroidFromFacts detects Kotlin script files under apps/android', ()
   });
 });
 
-test('detectAndroidFromFacts ignores paths outside apps/android or unsupported extensions', () => {
+test('detectAndroidFromFacts detects Kotlin files in generic repo structures', () => {
+  const detected = detectAndroidFromFacts([
+    fileChange('mobile/android/src/main/kotlin/com/example/MainActivity.kt'),
+  ]);
+
+  assert.deepEqual(detected, {
+    detected: true,
+    confidence: 'HIGH',
+  });
+});
+
+test('detectAndroidFromFacts ignores unsupported extensions', () => {
   const detected = detectAndroidFromFacts([
     fileChange('apps/android/app/src/main/java/com/example/Main.java'),
-    fileChange('apps/backend/src/service.kt'),
     fileContent('apps/web/src/main.ts', 'export {}'),
   ]);
 

--- a/integrations/platform/__tests__/detectBackend.test.ts
+++ b/integrations/platform/__tests__/detectBackend.test.ts
@@ -59,9 +59,21 @@ test('detectBackendFromFacts detects backend TypeScript from file content facts'
   });
 });
 
+test('detectBackendFromFacts detects backend files in generic server/api structures', () => {
+  const detected = detectBackendFromFacts([
+    fileChange('src/server/health.ts'),
+    fileChange('api/orders/controller.js'),
+  ]);
+
+  assert.deepEqual(detected, {
+    detected: true,
+    confidence: 'HIGH',
+  });
+});
+
 test('detectBackendFromFacts ignores unsupported extensions or non-backend paths', () => {
   const detected = detectBackendFromFacts([
-    fileChange('apps/backend/src/health.js'),
+    fileChange('apps/backend/src/health.json'),
     fileChange('apps/frontend/src/app.ts'),
     fileContent('apps/android/app/src/main/java/com/example/Main.kt', 'class Main'),
   ]);

--- a/integrations/platform/__tests__/detectFrontend.test.ts
+++ b/integrations/platform/__tests__/detectFrontend.test.ts
@@ -59,6 +59,28 @@ test('detectFrontendFromFacts detects frontend files under apps/web with support
   });
 });
 
+test('detectFrontendFromFacts detects React-like extensions in generic paths', () => {
+  const detected = detectFrontendFromFacts([
+    fileChange('packages/ui/src/Button.tsx'),
+  ]);
+
+  assert.deepEqual(detected, {
+    detected: true,
+    confidence: 'HIGH',
+  });
+});
+
+test('detectFrontendFromFacts detects client/web folder hints outside apps/*', () => {
+  const detected = detectFrontendFromFacts([
+    fileContent('src/client/main.ts', 'export {}'),
+  ]);
+
+  assert.deepEqual(detected, {
+    detected: true,
+    confidence: 'HIGH',
+  });
+});
+
 test('detectFrontendFromFacts ignores non frontend paths or unsupported extensions', () => {
   const detected = detectFrontendFromFacts([
     fileChange('apps/web/src/styles/main.css'),

--- a/integrations/platform/__tests__/detectPlatforms.test.ts
+++ b/integrations/platform/__tests__/detectPlatforms.test.ts
@@ -78,9 +78,49 @@ test('detectPlatformsFromFacts detecta backend/frontend/android por rutas soport
   });
 });
 
+test('detectPlatformsFromFacts detecta plataformas en estructuras genéricas sin apps/*', () => {
+  const detected = detectPlatformsFromFacts([
+    fileChange('src/server/health.ts'),
+    fileChange('packages/ui/src/App.tsx'),
+    fileChange('mobile/android/src/main/kotlin/com/example/Main.kt'),
+  ]);
+
+  assert.deepEqual(detected, {
+    backend: {
+      detected: true,
+      confidence: 'HIGH',
+    },
+    frontend: {
+      detected: true,
+      confidence: 'HIGH',
+    },
+    android: {
+      detected: true,
+      confidence: 'HIGH',
+    },
+  });
+});
+
+test('detectPlatformsFromFacts aplica fallback ambigüo para repos TS/JS sin señales claras', () => {
+  const detected = detectPlatformsFromFacts([
+    fileChange('src/main.ts'),
+  ]);
+
+  assert.deepEqual(detected, {
+    backend: {
+      detected: true,
+      confidence: 'MEDIUM',
+    },
+    frontend: {
+      detected: true,
+      confidence: 'MEDIUM',
+    },
+  });
+});
+
 test('detectPlatformsFromFacts no marca plataformas cuando las extensiones no aplican', () => {
   const detected = detectPlatformsFromFacts([
-    fileChange('apps/backend/src/service.js'),
+    fileChange('apps/backend/src/service.json'),
     fileChange('apps/android/app/src/main/java/com/example/Main.java'),
     fileChange('apps/web/src/styles/main.css'),
   ]);

--- a/integrations/platform/detectAndroid.ts
+++ b/integrations/platform/detectAndroid.ts
@@ -2,10 +2,7 @@ import type { Fact } from '../../core/facts/Fact';
 import type { PlatformState } from '../evidence/schema';
 
 const isAndroidPath = (path: string): boolean => {
-  return (
-    path.startsWith('apps/android/') &&
-    (path.endsWith('.kt') || path.endsWith('.kts'))
-  );
+  return path.endsWith('.kt') || path.endsWith('.kts');
 };
 
 export const detectAndroidFromFacts = (

--- a/integrations/platform/detectBackend.ts
+++ b/integrations/platform/detectBackend.ts
@@ -2,7 +2,24 @@ import type { Fact } from '../../core/facts/Fact';
 import type { PlatformState } from '../evidence/schema';
 
 const isBackendTypeScriptPath = (path: string): boolean => {
-  return path.startsWith('apps/backend/') && path.endsWith('.ts');
+  const normalized = path.toLowerCase().replace(/\\/g, '/');
+  const isTypeScriptOrJavaScript =
+    normalized.endsWith('.ts') ||
+    normalized.endsWith('.js') ||
+    normalized.endsWith('.mts') ||
+    normalized.endsWith('.cts') ||
+    normalized.endsWith('.mjs') ||
+    normalized.endsWith('.cjs');
+
+  if (!isTypeScriptOrJavaScript) {
+    return false;
+  }
+
+  if (normalized.startsWith('apps/backend/')) {
+    return true;
+  }
+
+  return /(^|\/)(backend|server|api)(\/|$)/.test(normalized);
 };
 
 export const detectBackendFromFacts = (

--- a/integrations/platform/detectFrontend.ts
+++ b/integrations/platform/detectFrontend.ts
@@ -2,14 +2,29 @@ import type { Fact } from '../../core/facts/Fact';
 import type { PlatformState } from '../evidence/schema';
 
 const isFrontendPath = (path: string): boolean => {
-  const inFrontendApp = path.startsWith('apps/frontend/');
-  const inWebApp = path.startsWith('apps/web/');
-  const isFrontendExtension =
-    path.endsWith('.ts') ||
-    path.endsWith('.tsx') ||
-    path.endsWith('.js') ||
-    path.endsWith('.jsx');
-  return (inFrontendApp || inWebApp) && isFrontendExtension;
+  const normalized = path.toLowerCase().replace(/\\/g, '/');
+  const isReactExtension = normalized.endsWith('.tsx') || normalized.endsWith('.jsx');
+  if (isReactExtension) {
+    return true;
+  }
+
+  const isTypeScriptOrJavaScript =
+    normalized.endsWith('.ts') ||
+    normalized.endsWith('.js') ||
+    normalized.endsWith('.mts') ||
+    normalized.endsWith('.cts') ||
+    normalized.endsWith('.mjs') ||
+    normalized.endsWith('.cjs');
+
+  if (!isTypeScriptOrJavaScript) {
+    return false;
+  }
+
+  if (normalized.startsWith('apps/frontend/') || normalized.startsWith('apps/web/')) {
+    return true;
+  }
+
+  return /(^|\/)(frontend|web|client)(\/|$)/.test(normalized);
 };
 
 export const detectFrontendFromFacts = (

--- a/scripts/__tests__/framework-menu-gate-lib.test.ts
+++ b/scripts/__tests__/framework-menu-gate-lib.test.ts
@@ -70,7 +70,12 @@ test('runRepoAndStagedPrePushGateSilent emite evidencia con stage PRE_PUSH', asy
       assert.equal(evidence.snapshot?.stage, 'PRE_PUSH');
       const findings = Array.isArray(evidence.snapshot?.findings) ? evidence.snapshot.findings : [];
       const ruleIds = findings.map((finding) => finding.ruleId ?? '');
-      assert.equal(ruleIds.includes('heuristics.ts.console-log.ast'), true);
+      assert.equal(
+        ruleIds.includes('skills.backend.no-console-log') ||
+          ruleIds.includes('skills.frontend.no-console-log') ||
+          ruleIds.includes('heuristics.ts.console-log.ast'),
+        true
+      );
     } finally {
       process.chdir(previousCwd);
     }
@@ -108,7 +113,12 @@ test('runWorkingTreePrePushGateSilent emite evidencia con stage PRE_PUSH', async
       assert.equal(evidence.snapshot?.stage, 'PRE_PUSH');
       const findings = Array.isArray(evidence.snapshot?.findings) ? evidence.snapshot.findings : [];
       const ruleIds = findings.map((finding) => finding.ruleId ?? '');
-      assert.equal(ruleIds.includes('heuristics.ts.console-log.ast'), true);
+      assert.equal(
+        ruleIds.includes('skills.backend.no-console-log') ||
+          ruleIds.includes('skills.frontend.no-console-log') ||
+          ruleIds.includes('heuristics.ts.console-log.ast'),
+        true
+      );
     } finally {
       process.chdir(previousCwd);
     }


### PR DESCRIPTION
## Summary
- harden backend/frontend/android detection so rules activate in repos beyond apps/* layouts
- add deterministic TS/JS ambiguous fallback (backend+frontend MEDIUM) to avoid rule loss in generic repos
- add core lock coverage test to guarantee embedded bundles are loaded
- align menu gate tests with effective skills rule ids at PRE_PUSH stage

## Validation
- npx --yes tsx@4.21.0 --test integrations/platform/__tests__/detectAndroid.test.ts integrations/platform/__tests__/detectBackend.test.ts integrations/platform/__tests__/detectFrontend.test.ts integrations/platform/__tests__/detectPlatforms.test.ts
- npx --yes tsx@4.21.0 --test integrations/config/__tests__/coreSkillsLock.test.ts scripts/__tests__/framework-menu-gate-lib.test.ts
- npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-*.test.ts