### PR TITLE
chore: sync develop into main after all-skills AST enforcement

### DIFF
--- a/core/facts/detectors/typescript/index.test.ts
+++ b/core/facts/detectors/typescript/index.test.ts
@@ -15,6 +15,7 @@ import {
   hasMixedCommandQueryClass,
   hasMixedCommandQueryInterface,
   hasOverrideMethodThrowingNotImplemented,
+  hasLargeClassDeclaration,
   hasSetIntervalStringCallback,
   hasSetTimeoutStringCallback,
   hasTypeDiscriminatorSwitch,
@@ -375,4 +376,24 @@ test('hasConcreteDependencyInstantiation detecta instanciacion directa de depend
 
   assert.equal(hasConcreteDependencyInstantiation(concreteAst), true);
   assert.equal(hasConcreteDependencyInstantiation(localAst), false);
+});
+
+test('hasLargeClassDeclaration detecta clases con mas de 500 lineas', () => {
+  const oversizedClassAst = {
+    type: 'ClassDeclaration',
+    loc: {
+      start: { line: 10 },
+      end: { line: 520 },
+    },
+  };
+  const compactClassAst = {
+    type: 'ClassDeclaration',
+    loc: {
+      start: { line: 10 },
+      end: { line: 80 },
+    },
+  };
+
+  assert.equal(hasLargeClassDeclaration(oversizedClassAst), true);
+  assert.equal(hasLargeClassDeclaration(compactClassAst), false);
 });

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -189,6 +189,7 @@ const astDetectorRegistry: ReadonlyArray<ASTDetectorRegistryEntry> = [
   { detect: TS.hasOverrideMethodThrowingNotImplemented, ruleId: 'heuristics.ts.solid.lsp.override-not-implemented.ast', code: 'HEURISTICS_SOLID_LSP_OVERRIDE_NOT_IMPLEMENTED_AST', message: 'AST heuristic detected LSP risk: override throws not-implemented/unsupported.' },
   { detect: TS.hasFrameworkDependencyImport, ruleId: 'heuristics.ts.solid.dip.framework-import.ast', code: 'HEURISTICS_SOLID_DIP_FRAMEWORK_IMPORT_AST', message: 'AST heuristic detected DIP risk: framework dependency imported in domain/application code.', pathCheck: isTypeScriptDomainOrApplicationPath },
   { detect: TS.hasConcreteDependencyInstantiation, ruleId: 'heuristics.ts.solid.dip.concrete-instantiation.ast', code: 'HEURISTICS_SOLID_DIP_CONCRETE_INSTANTIATION_AST', message: 'AST heuristic detected DIP risk: direct instantiation of concrete framework dependency.', pathCheck: isTypeScriptDomainOrApplicationPath },
+  { detect: TS.hasLargeClassDeclaration, ruleId: 'heuristics.ts.god-class-large-class.ast', code: 'HEURISTICS_GOD_CLASS_LARGE_CLASS_AST', message: 'AST heuristic detected God Class candidate (>500 lines in a single class declaration).' },
 
   // Process
   { detect: Process.hasProcessExitCall, ruleId: 'heuristics.ts.process-exit.ast', code: 'HEURISTICS_PROCESS_EXIT_AST', message: 'AST heuristic detected process.exit usage.' },

--- a/core/rules/presets/heuristics/typescript.ts
+++ b/core/rules/presets/heuristics/typescript.ts
@@ -330,4 +330,22 @@ export const typescriptRules: RuleSet = [
       code: 'HEURISTICS_SOLID_DIP_CONCRETE_INSTANTIATION_AST',
     },
   },
+  {
+    id: 'heuristics.ts.god-class-large-class.ast',
+    description: 'Detects God Class candidates when a class declaration exceeds 500 lines.',
+    severity: 'ERROR',
+    platform: 'generic',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.ts.god-class-large-class.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message: 'AST heuristic detected God Class candidate (>500 lines in one class declaration).',
+      code: 'HEURISTICS_GOD_CLASS_LARGE_CLASS_AST',
+    },
+  },
 ];

--- a/docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md
+++ b/docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md
@@ -1,0 +1,57 @@
+# All Skills AST Enforcement Cycle
+
+Plan operativo unico para asegurar que Pumuki aplique SIEMPRE todas las skills del core con detectores AST reales, sin fallback declarativo silencioso.
+
+Estado del plan: `ACTIVO`
+
+## Leyenda
+- ✅ Hecho
+- 🚧 En construccion (maximo 1)
+- ⏳ Pendiente
+- ⛔ Bloqueado
+
+## Reglas de seguimiento
+- Este es el unico MD de plan activo para este ciclo.
+- Solo puede haber una tarea en `🚧`.
+- Cada tarea cerrada pasa a `✅` y se activa la siguiente `🚧`.
+- Nomenclatura obligatoria: `F{fase}.T{n}`.
+- Rama del ciclo: `feature/all-skills-ast-enforcement`.
+- Cierre esperado del ciclo: Git Flow end-to-end (`feature -> develop -> main`).
+
+## Objetivo del ciclo
+Garantizar que todas las reglas derivadas de skills se apliquen por plataforma y fichero en todos los stages (`PRE_COMMIT`, `PRE_PUSH`, `CI`) y en la opcion `1` del menu interactivo, con trazabilidad completa y sin caja negra.
+
+## Fase 0 — Arranque y baseline del ciclo
+- ✅ F0.T1 Crear este plan `docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md` con estructura oficial.
+- ✅ F0.T2 Sincronizar tracker `docs/REFRACTOR_PROGRESS.md` y dejar una sola tarea activa del ciclo.
+- ✅ F0.T3 Cerrar continuidad operativa del ciclo previo y declarar este como ciclo activo unico.
+
+## Fase 1 — Contrato duro de integridad de skills
+- ✅ F1.T1 RED: tests de integridad para fallar si existe regla `AUTO` sin detector AST mapeado.
+- ✅ F1.T2 GREEN: eliminar fallback declarativo y exponer `unsupportedAutoRuleIds` en el ruleset de skills.
+- ✅ F1.T3 GREEN: bloquear gate cuando existan reglas `AUTO` sin detector mapeado.
+- ✅ F1.T4 REFACTOR: ajustar evidencia y mensajes accionables con detalle de reglas sin detector.
+
+## Fase 2 — Cobertura real de reglas SOLID/SRP y God Class
+- ✅ F2.T1 RED: tests de mapeo para reglas de skills SOLID/SRP/God Class.
+- ✅ F2.T2 GREEN: ampliar mapeo de skills -> heuristics para SOLID/SRP/Clean Architecture.
+- ✅ F2.T3 GREEN: introducir detector AST de God Class (>500 lineas en clases TS) y su rule preset.
+- ✅ F2.T4 REFACTOR: unificar severidad y trazabilidad de nuevas detecciones.
+
+## Fase 3 — Aplicacion por plataforma y fichero
+- ✅ F3.T1 RED: tests multi-plataforma (backend + ios) aplicando reglas correctas por fichero.
+- ✅ F3.T2 GREEN: reforzar filtros por plataforma detectada y scope de ruta/fichero.
+- ✅ F3.T3 GREEN: asegurar misma semantica en `PRE_COMMIT`, `PRE_PUSH`, `CI` y menu opcion `1`.
+- ✅ F3.T4 REFACTOR: limpiar contratos y utilidades de evaluacion por stage.
+
+## Fase 4 — TDD end-to-end y validacion completa
+- ✅ F4.T1 RED/GREEN/REFACTOR de suites `skillsRuleSet`, `runPlatformGateEvaluation`, `runPlatformGate`.
+- ✅ F4.T2 Validacion funcional en menu opcion `1` y evidencia runtime con coverage consistente.
+- ✅ F4.T3 Auditoria full-repo de Pumuki con skills activas y reporte por severidad.
+- 🚧 F4.T4 Cierre Git Flow end-to-end (`feature -> develop -> main`) con tracker final actualizado.
+
+## Politica cerrada del ciclo
+- No se permite una regla de skill `AUTO` sin detector AST.
+- No se permite fallback declarativo silencioso para reglas `AUTO`.
+- La aplicacion de reglas se decide por plataforma detectada y fichero compatible.
+- Evidencia y menu deben mostrar trazabilidad suficiente para eliminar caja negra.

--- a/docs/FULL_REPO_RULES_AUDIT_REPORT.md
+++ b/docs/FULL_REPO_RULES_AUDIT_REPORT.md
@@ -1,0 +1,101 @@
+# Full Repo Rules Audit Report
+
+## Scope
+- Repository: `ast-intelligence-hooks`
+- Execution date (UTC): `2026-02-22T22:18:56.584Z`
+- Command used (menu option 1): `printf '1\n10\n' | npx ast-hooks audit --scope repo`
+- Audit mode: `PRE_COMMIT` full repository snapshot
+
+## Rules Loading Verification
+
+### 1) Skills source parity (local vs vendorizado)
+All configured skill sources are synchronized (`SHA-256` identical):
+
+- `windsurf-rules-android` -> `docs/codex-skills/windsurf-rules-android.md`
+- `windsurf-rules-backend` -> `docs/codex-skills/windsurf-rules-backend.md`
+- `windsurf-rules-frontend` -> `docs/codex-skills/windsurf-rules-frontend.md`
+- `windsurf-rules-ios` -> `docs/codex-skills/windsurf-rules-ios.md`
+- `swift-concurrency` -> `docs/codex-skills/swift-concurrency.md`
+- `swiftui-expert-skill` -> `docs/codex-skills/swiftui-expert-skill.md`
+
+Hashes checked:
+
+- `windsurf-rules-android`: `c4d24bcf258af21bcfc7ae17276683ba802f7eac429dd35b15fa2e11356a339f`
+- `windsurf-rules-backend`: `5129e38ac9214d8f506c29ecf6d6bda742a43786d29baeac01f872a561196172`
+- `windsurf-rules-frontend`: `f6977fa8f4c18b3957e080701705440f15cc4c9eb2de634b72434bb000c99d7a`
+- `windsurf-rules-ios`: `d56ea2aee3eab1768937d8913363e805e70dc9213a3dda43e2d6551b0872ef19`
+- `swift-concurrency`: `62e81a46dc206ab6c4b3c5e7555e6007bb4d40db063f135eab263a4a0b9060b3`
+- `swiftui-expert-skill`: `dc785e71742a9c215c0d70b2e7bfb1c4dd41553061663f7cf0a748018664b141`
+
+### 2) Bundles loaded by runtime evidence
+Loaded in `.AI_EVIDENCE.json` (`rulesets[*].bundle`):
+
+- `backendRuleSet@1.0.0`
+- `frontendRuleSet@1.0.0`
+- `astHeuristicsRuleSet@0.5.0`
+- `gate-policy.default.PRE_COMMIT`
+- `android-guidelines@1.0.0`
+- `backend-guidelines@1.0.0`
+- `frontend-guidelines@1.0.0`
+- `ios-concurrency-guidelines@1.0.0`
+- `ios-guidelines@1.0.0`
+- `ios-swiftui-expert-guidelines@1.0.0`
+
+Lock compilation snapshot (`skills.lock.json`):
+
+- Skill bundles in lock: `6`
+- Rules compiled from those bundles: `25`
+
+### 3) Coverage integrity
+From `.AI_EVIDENCE.json` -> `snapshot.rules_coverage`:
+
+- Active rules: `409`
+- Evaluated rules: `409`
+- Matched rules: `3`
+- Unevaluated rules: `0`
+- Coverage ratio: `1.0` (100%)
+
+From `snapshot.evaluation_metrics`:
+
+- Baseline rules: `6`
+- Heuristic rules: `165`
+- Skills rules: `238`
+- Project custom rules: `0`
+
+### 4) Platform detection during this audit
+From `.AI_EVIDENCE.json` -> `platforms`:
+
+- `backend`: detected (`MEDIUM`)
+- `frontend`: detected (`MEDIUM`)
+
+## Findings (Complete Repo)
+
+### Severity summary
+Note: en métricas internas aparece `ERROR`; en UI del menú v2 se representa como `HIGH`.
+
+- `CRITICAL`: 0
+- `ERROR/HIGH`: 3
+- `WARN/MEDIUM`: 0
+- `INFO/LOW`: 0
+- Gate status: `BLOCKED`
+
+### Violations detail
+1. Rule: `heuristics.ts.child-process-exec-file-sync.ast`
+   - Severity: `ERROR` (`HIGH` en UI)
+   - File: `scripts/framework-menu-matrix-canary-lib.ts`
+   - Message: `AST heuristic detected execFileSync usage.`
+
+2. Rule: `heuristics.ts.child-process-exec-file-untrusted-args.ast`
+   - Severity: `ERROR` (`HIGH` en UI)
+   - File: `scripts/framework-menu-matrix-canary-lib.ts`
+   - Message: `AST heuristic detected execFile/execFileSync with non-literal args array.`
+
+3. Rule: `heuristics.ts.process-exit.ast`
+   - Severity: `ERROR` (`HIGH` en UI)
+   - File: `scripts/import-custom-skills.ts`
+   - Message: `AST heuristic detected process.exit usage.`
+
+## Audit Conclusion
+- The repository audit completed with full rule coverage (`409/409` evaluated, `unevaluated=0`).
+- Current gate result is `BLOCKED` by 3 high-severity (`ERROR`) findings.
+- No `CRITICAL` violations detected.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -75,7 +75,10 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ Post-cierre: hardening multi-repo aplicado en detección de plataformas (soporte fuera de `apps/*` + fallback ambiguo TS/JS).
 - ✅ Post-cierre: TDD ampliado (`detect*`/`detectPlatforms`/`coreSkillsLock`) y suites de regresión en verde.
 - ✅ Post-cierre: cierre Git Flow del hardening multi-repo completado (`feature -> develop` PR #342, `develop -> main` PR #343).
-- 🚧 Post-cierre: baseline estable, pendiente de siguiente ciclo/instrucción.
+- ✅ Post-cierre: auditoria full repo ejecutada con opcion `1` (full audit) y cobertura de reglas `414/414` sin unevaluated.
+- ✅ Post-cierre: informe formal de violaciones generado en `docs/FULL_REPO_RULES_AUDIT_REPORT.md` (resultado actual: 3 `WARN`, 0 `CRITICAL`, 0 `ERROR`).
+- ✅ Post-cierre: unificacion de enforcement entre `PRE_COMMIT`, `PRE_PUSH` y `CI` aplicada (mismas reglas activas, misma promocion de severidad y mismos umbrales por defecto).
+- ⏳ Post-cierre: exponer `PRE_WRITE` de forma visible en la matriz de diagnostico del menu sin romper contratos existentes.
 
 ## Hitos recientes
 - ✅ Sync Git Flow cerrado en ciclo anterior (`develop -> main`) con ramas remotas alineadas.
@@ -110,7 +113,38 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ Cierre de release ejecutado: `feature/rules-engine-unification -> develop` (#339) y `develop -> main` (#340).
 - ✅ Verificación runtime: core lock embebido con 6 bundles y 759 reglas totales cargadas.
 - ✅ Cierre adicional ejecutado: hardening multi-repo mergeado end-to-end (#342/#343) con ramas principales sincronizadas.
-- Estado activo: baseline estable en `main`.
+- ✅ Auditoria full repo con todas las reglas ejecutada (menu opcion 1) con evidencia actualizada y cobertura completa.
+- ✅ Informe detallado de violaciones publicado en `docs/FULL_REPO_RULES_AUDIT_REPORT.md`.
+- ✅ Auditoria transparente sin cambios de codigo ejecutada en matriz `scope=repo` para `PRE_COMMIT`, `PRE_PUSH` y `CI` con heuristicas AST activas.
+- ✅ Verificacion de carga de bundles por stage completada: `android/backend/frontend/ios/concurrency/swiftui` presentes en los 3 stages.
+- ✅ Confirmacion de cobertura por stage completada: `unevaluated=0` en `PRE_COMMIT`, `PRE_PUSH` y `CI`.
+- ✅ Unificacion de stages aplicada en motor: `PRE_COMMIT` ahora evalua el mismo set de reglas que `PRE_PUSH/CI` (`active=evaluated`, sin delta por stage).
+- ✅ Unificacion de severidad aplicada: promocion de heuristicas y `promoteToErrorRuleIds` activa tambien en `PRE_COMMIT`.
+- ✅ Validacion tecnica completada tras unificacion: `npm run test:stage-gates` (770 tests, 0 fail) + `npm run typecheck` en verde.
+- ✅ Verificacion operativa de `pre-write`: binario ejecuta flujo real (`sdd validate --stage=PRE_WRITE`) y bloquea correctamente cuando faltan precondiciones (OpenSpec/evidence/gitflow).
+- ✅ Inventario full repo generado: listado de ficheros propios de Pumuki con mas de 300 lineas (excluyendo `node_modules` y binarios).
+- ✅ Diagnostico de caja negra del rules engine completado: en estado actual no existe `.pumuki/custom-rules.json` ni `skills.policy.json`; la carga efectiva cae a `skills.lock.json` (25 reglas `AUTO`) y no incluye reglas SOLID/SRP como detectores AST dedicados.
+- ✅ Nuevo plan activo creado: `docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md`.
+- ✅ `F0.T3` completada en `ALL_SKILLS_AST_ENFORCEMENT`: continuidad operativa previa cerrada y ciclo declarado activo unico.
+- ✅ `F1.T1` completada en `ALL_SKILLS_AST_ENFORCEMENT`: RED de integridad para reglas `AUTO` sin detector AST.
+- ✅ `F1.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: eliminado fallback declarativo silencioso y contrato `unsupportedAutoRuleIds` operativo.
+- ✅ `F1.T3` completada en `ALL_SKILLS_AST_ENFORCEMENT`: gate bloquea por reglas `AUTO` sin detector con finding de gobernanza explicito.
+- ✅ `F1.T4` completada en `ALL_SKILLS_AST_ENFORCEMENT`: mensajes accionables de mapeo incompleto integrados y validados en tests.
+- ✅ `F2.T1` completada en `ALL_SKILLS_AST_ENFORCEMENT`: RED de mapeo SOLID/SRP/God Class incorporada en suites config.
+- ✅ `F2.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: mapeo skills -> heuristics ampliado para SOLID/Clean Architecture/God Class en backend/frontend.
+- ✅ `F2.T3` completada en `ALL_SKILLS_AST_ENFORCEMENT`: detector AST de God Class (>500 lineas) integrado en facts + preset heuristics.
+- ✅ `F2.T4` completada en `ALL_SKILLS_AST_ENFORCEMENT`: severidad y trazabilidad unificadas en nuevas detecciones con tests de gate/config en verde.
+- ✅ `F3.T1` completada en `ALL_SKILLS_AST_ENFORCEMENT`: RED multi-plataforma por fichero validada con casos backend + ios en layout no estandar.
+- ✅ `F3.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: scope dinamico por rutas observadas integrado en `skillsRuleSet` cuando no existe arbol `apps/*`.
+- ✅ `F3.T3` completada en `ALL_SKILLS_AST_ENFORCEMENT`: semantica alineada entre `PRE_COMMIT`, `PRE_PUSH` y `CI` validada por test de paridad.
+- ✅ `F3.T4` completada en `ALL_SKILLS_AST_ENFORCEMENT`: utilidades de evaluacion refactorizadas para reutilizar coleccion de rutas observadas.
+- ✅ `F4.T1` completada en `ALL_SKILLS_AST_ENFORCEMENT`: TDD integral de `skillsRuleSet`, `runPlatformGateEvaluation` y `runPlatformGate` en verde.
+- ✅ `F4.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: validacion funcional de menu opcion `1` ejecutada con evidencia runtime consistente (`active=409`, `evaluated=409`, `unevaluated=0`, `coverage_ratio=1`).
+- ✅ `F4.T3` completada en `ALL_SKILLS_AST_ENFORCEMENT`: auditoria full-repo publicada en `docs/FULL_REPO_RULES_AUDIT_REPORT.md` con severidad actualizada (`ERROR/HIGH=3`, gate `BLOCKED`).
+- ⏳ Post-cierre anterior pendiente: exponer `PRE_WRITE` de forma visible en la matriz de diagnostico del menu sin romper contratos existentes.
+- ✅ `F0.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: tracker sincronizado y tarea activa unica garantizada.
+- 🚧 Ciclo `ALL_SKILLS_AST_ENFORCEMENT` en ejecucion: `F4.T4` cierre Git Flow end-to-end (`feature -> develop -> main`).
+- Estado activo: ciclo `ALL_SKILLS_AST_ENFORCEMENT` en curso.
 
 ## Siguiente paso operativo
-- ⏳ Definir siguiente ciclo o directiva de trabajo.
+- ⏳ Ejecutar cierre de PRs y merge secuencial (`feature -> develop -> main`) con verificacion final de ramas.

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractCompiledRulesFromSkillMarkdown } from '../skillsMarkdownRules';
+
+test('normaliza reglas backend de SOLID/Clean Architecture/God Class a ids canonicos', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'backend-guidelines',
+    sourcePath: 'docs/codex-skills/windsurf-rules-backend.md',
+    sourceContent: [
+      '✅ Verificar que NO viole SOLID (SRP, OCP, LSP, ISP, DIP)',
+      '✅ Seguir Clean Architecture - Domain -> Application -> Infrastructure -> Presentation',
+      '❌ God classes - Servicios con >500 líneas',
+    ].join('\n'),
+  });
+
+  const ids = rules.map((rule) => rule.id).sort();
+  assert.deepEqual(ids, [
+    'skills.backend.enforce-clean-architecture',
+    'skills.backend.no-god-classes',
+    'skills.backend.no-solid-violations',
+  ]);
+  assert.equal(rules.every((rule) => rule.evaluationMode === 'AUTO'), true);
+});
+
+test('normaliza regla frontend SOLID a id canonico', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'frontend-guidelines',
+    sourcePath: 'docs/codex-skills/windsurf-rules-frontend.md',
+    sourceContent: '✅ Verificar que NO viole SOLID (SRP, OCP, LSP, ISP, DIP) en componentes',
+  });
+
+  assert.deepEqual(rules.map((rule) => rule.id), ['skills.frontend.no-solid-violations']);
+});

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -224,6 +224,21 @@ const normalizeKnownRuleTarget = (
 
   if (platform === 'backend' || platform === 'frontend') {
     const prefix = platform === 'backend' ? 'skills.backend' : 'skills.frontend';
+    if (includes('solid') || includes('single responsibility') || includes('srp')) {
+      return `${prefix}.no-solid-violations`;
+    }
+    if (includes('clean architecture')) {
+      return `${prefix}.enforce-clean-architecture`;
+    }
+    if (
+      includes('god classes') ||
+      includes('god class') ||
+      includes('500 lineas') ||
+      includes('500 li neas') ||
+      includes('500 lines')
+    ) {
+      return `${prefix}.no-god-classes`;
+    }
     if (includes('empty catch')) {
       return `${prefix}.no-empty-catch`;
     }
@@ -288,17 +303,22 @@ export const extractCompiledRulesFromSkillMarkdown = (params: {
     }
 
     const knownRuleId = normalizeKnownRuleTarget(platform, normalizeForLookup(description));
-    const nextId =
-      knownRuleId && !usedIds.has(knownRuleId)
-        ? knownRuleId
-        : buildGeneratedRuleId(
-            {
-              platform,
-              sourceSkill: params.sourceSkill,
-              description,
-            },
-            usedIds
-          );
+    let nextId: string;
+    if (knownRuleId) {
+      if (usedIds.has(knownRuleId)) {
+        continue;
+      }
+      nextId = knownRuleId;
+    } else {
+      nextId = buildGeneratedRuleId(
+        {
+          platform,
+          sourceSkill: params.sourceSkill,
+          description,
+        },
+        usedIds
+      );
+    }
 
     if (usedIds.has(nextId)) {
       continue;

--- a/integrations/config/skillsRuleSet.ts
+++ b/integrations/config/skillsRuleSet.ts
@@ -19,11 +19,12 @@ export type SkillsRuleSetLoadResult = {
   activeBundles: ReadonlyArray<SkillsLockBundle>;
   mappedHeuristicRuleIds: ReadonlySet<string>;
   requiresHeuristicFacts: boolean;
+  unsupportedAutoRuleIds?: ReadonlyArray<string>;
 };
 
 const STAGE_RANK: Record<Exclude<GateStage, 'STAGED'>, number> = {
-  PRE_COMMIT: 10,
-  PRE_PUSH: 20,
+  PRE_COMMIT: 30,
+  PRE_PUSH: 30,
   CI: 30,
 };
 
@@ -34,32 +35,58 @@ const PLATFORM_KEYS: ReadonlyArray<keyof DetectedPlatforms> = [
   'frontend',
 ];
 
-const SKILL_TO_HEURISTIC_RULE_ID: Record<string, string> = {
-  'skills.ios.no-force-unwrap': 'heuristics.ios.force-unwrap.ast',
-  'skills.ios.no-force-try': 'heuristics.ios.force-try.ast',
-  'skills.ios.no-anyview': 'heuristics.ios.anyview.ast',
-  'skills.ios.no-force-cast': 'heuristics.ios.force-cast.ast',
-  'skills.ios.no-callback-style-outside-bridges': 'heuristics.ios.callback-style.ast',
-  'skills.ios.no-dispatchqueue': 'heuristics.ios.dispatchqueue.ast',
-  'skills.ios.no-dispatchgroup': 'heuristics.ios.dispatchgroup.ast',
-  'skills.ios.no-dispatchsemaphore': 'heuristics.ios.dispatchsemaphore.ast',
-  'skills.ios.no-operation-queue': 'heuristics.ios.operation-queue.ast',
-  'skills.ios.no-task-detached': 'heuristics.ios.task-detached.ast',
-  'skills.ios.no-unchecked-sendable': 'heuristics.ios.unchecked-sendable.ast',
-  'skills.ios.no-observable-object': 'heuristics.ios.observable-object.ast',
-  'skills.ios.no-navigation-view': 'heuristics.ios.navigation-view.ast',
-  'skills.ios.no-on-tap-gesture': 'heuristics.ios.on-tap-gesture.ast',
-  'skills.ios.no-string-format': 'heuristics.ios.string-format.ast',
-  'skills.ios.no-uiscreen-main-bounds': 'heuristics.ios.uiscreen-main-bounds.ast',
-  'skills.backend.no-empty-catch': 'heuristics.ts.empty-catch.ast',
-  'skills.backend.no-console-log': 'heuristics.ts.console-log.ast',
-  'skills.backend.avoid-explicit-any': 'heuristics.ts.explicit-any.ast',
-  'skills.frontend.no-empty-catch': 'heuristics.ts.empty-catch.ast',
-  'skills.frontend.no-console-log': 'heuristics.ts.console-log.ast',
-  'skills.frontend.avoid-explicit-any': 'heuristics.ts.explicit-any.ast',
-  'skills.android.no-thread-sleep': 'heuristics.android.thread-sleep.ast',
-  'skills.android.no-globalscope': 'heuristics.android.globalscope.ast',
-  'skills.android.no-runblocking': 'heuristics.android.run-blocking.ast',
+const SKILL_TO_HEURISTIC_RULE_IDS: Record<string, ReadonlyArray<string>> = {
+  'skills.ios.no-force-unwrap': ['heuristics.ios.force-unwrap.ast'],
+  'skills.ios.no-force-try': ['heuristics.ios.force-try.ast'],
+  'skills.ios.no-anyview': ['heuristics.ios.anyview.ast'],
+  'skills.ios.no-force-cast': ['heuristics.ios.force-cast.ast'],
+  'skills.ios.no-callback-style-outside-bridges': ['heuristics.ios.callback-style.ast'],
+  'skills.ios.no-dispatchqueue': ['heuristics.ios.dispatchqueue.ast'],
+  'skills.ios.no-dispatchgroup': ['heuristics.ios.dispatchgroup.ast'],
+  'skills.ios.no-dispatchsemaphore': ['heuristics.ios.dispatchsemaphore.ast'],
+  'skills.ios.no-operation-queue': ['heuristics.ios.operation-queue.ast'],
+  'skills.ios.no-task-detached': ['heuristics.ios.task-detached.ast'],
+  'skills.ios.no-unchecked-sendable': ['heuristics.ios.unchecked-sendable.ast'],
+  'skills.ios.no-observable-object': ['heuristics.ios.observable-object.ast'],
+  'skills.ios.no-navigation-view': ['heuristics.ios.navigation-view.ast'],
+  'skills.ios.no-on-tap-gesture': ['heuristics.ios.on-tap-gesture.ast'],
+  'skills.ios.no-string-format': ['heuristics.ios.string-format.ast'],
+  'skills.ios.no-uiscreen-main-bounds': ['heuristics.ios.uiscreen-main-bounds.ast'],
+  'skills.backend.no-empty-catch': ['heuristics.ts.empty-catch.ast'],
+  'skills.backend.no-console-log': ['heuristics.ts.console-log.ast'],
+  'skills.backend.avoid-explicit-any': ['heuristics.ts.explicit-any.ast'],
+  'skills.backend.no-solid-violations': [
+    'heuristics.ts.solid.srp.class-command-query-mix.ast',
+    'heuristics.ts.solid.isp.interface-command-query-mix.ast',
+    'heuristics.ts.solid.ocp.discriminator-switch.ast',
+    'heuristics.ts.solid.lsp.override-not-implemented.ast',
+    'heuristics.ts.solid.dip.framework-import.ast',
+    'heuristics.ts.solid.dip.concrete-instantiation.ast',
+  ],
+  'skills.backend.enforce-clean-architecture': [
+    'heuristics.ts.solid.dip.framework-import.ast',
+    'heuristics.ts.solid.dip.concrete-instantiation.ast',
+  ],
+  'skills.backend.no-god-classes': ['heuristics.ts.god-class-large-class.ast'],
+  'skills.frontend.no-empty-catch': ['heuristics.ts.empty-catch.ast'],
+  'skills.frontend.no-console-log': ['heuristics.ts.console-log.ast'],
+  'skills.frontend.avoid-explicit-any': ['heuristics.ts.explicit-any.ast'],
+  'skills.frontend.no-solid-violations': [
+    'heuristics.ts.solid.srp.class-command-query-mix.ast',
+    'heuristics.ts.solid.isp.interface-command-query-mix.ast',
+    'heuristics.ts.solid.ocp.discriminator-switch.ast',
+    'heuristics.ts.solid.lsp.override-not-implemented.ast',
+    'heuristics.ts.solid.dip.framework-import.ast',
+    'heuristics.ts.solid.dip.concrete-instantiation.ast',
+  ],
+  'skills.frontend.enforce-clean-architecture': [
+    'heuristics.ts.solid.dip.framework-import.ast',
+    'heuristics.ts.solid.dip.concrete-instantiation.ast',
+  ],
+  'skills.frontend.no-god-classes': ['heuristics.ts.god-class-large-class.ast'],
+  'skills.android.no-thread-sleep': ['heuristics.android.thread-sleep.ast'],
+  'skills.android.no-globalscope': ['heuristics.android.globalscope.ast'],
+  'skills.android.no-runblocking': ['heuristics.android.run-blocking.ast'],
 };
 
 const PLATFORM_HEURISTIC_FILE_PREFIXES: Record<
@@ -74,9 +101,133 @@ const PLATFORM_HEURISTIC_FILE_PREFIXES: Record<
   generic: [],
 };
 
+const normalizeObservedPath = (path: string): string => {
+  return path.replace(/\\/g, '/').replace(/^\.\/+/, '');
+};
+
+const hasTypeScriptOrJavaScriptExtension = (path: string): boolean => {
+  const normalized = path.toLowerCase();
+  return (
+    normalized.endsWith('.ts') ||
+    normalized.endsWith('.js') ||
+    normalized.endsWith('.mts') ||
+    normalized.endsWith('.cts') ||
+    normalized.endsWith('.mjs') ||
+    normalized.endsWith('.cjs')
+  );
+};
+
+const hasReactExtension = (path: string): boolean => {
+  const normalized = path.toLowerCase();
+  return normalized.endsWith('.tsx') || normalized.endsWith('.jsx');
+};
+
+const isObservedPathForPlatform = (params: {
+  platform: NonNullable<RuleDefinition['platform']>;
+  path: string;
+}): boolean => {
+  const normalized = normalizeObservedPath(params.path).toLowerCase();
+
+  if (params.platform === 'ios') {
+    return normalized.endsWith('.swift');
+  }
+
+  if (params.platform === 'android') {
+    return normalized.endsWith('.kt') || normalized.endsWith('.kts');
+  }
+
+  if (params.platform === 'backend') {
+    if (!hasTypeScriptOrJavaScriptExtension(normalized)) {
+      return false;
+    }
+    if (normalized.startsWith('apps/backend/')) {
+      return true;
+    }
+    return /(^|\/)(backend|server|api)(\/|$)/.test(normalized);
+  }
+
+  if (params.platform === 'frontend') {
+    if (hasReactExtension(normalized)) {
+      return true;
+    }
+    if (!hasTypeScriptOrJavaScriptExtension(normalized)) {
+      return false;
+    }
+    if (
+      normalized.startsWith('apps/frontend/') ||
+      normalized.startsWith('apps/web/')
+    ) {
+      return true;
+    }
+    return /(^|\/)(frontend|web|client)(\/|$)/.test(normalized);
+  }
+
+  return false;
+};
+
+const toScopedPrefixFromObservedPath = (params: {
+  platform: NonNullable<RuleDefinition['platform']>;
+  path: string;
+}): string | null => {
+  const normalized = normalizeObservedPath(params.path);
+  const segments = normalized.split('/').filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const keywordByPlatform: Record<
+    NonNullable<RuleDefinition['platform']>,
+    ReadonlyArray<string>
+  > = {
+    ios: ['ios'],
+    backend: ['backend', 'server', 'api'],
+    frontend: ['frontend', 'web', 'client'],
+    android: ['android'],
+    text: [],
+    generic: [],
+  };
+
+  const keywords = keywordByPlatform[params.platform] ?? [];
+  const keywordIndex = segments.findIndex((segment) =>
+    keywords.includes(segment.toLowerCase())
+  );
+  if (keywordIndex >= 0) {
+    return `${segments.slice(0, keywordIndex + 1).join('/')}/`;
+  }
+
+  return null;
+};
+
+const resolveObservedPlatformPrefixes = (params: {
+  platform: NonNullable<RuleDefinition['platform']>;
+  observedFilePaths?: ReadonlyArray<string>;
+}): ReadonlyArray<string> => {
+  if (!params.observedFilePaths || params.observedFilePaths.length === 0) {
+    return [];
+  }
+
+  const prefixes = params.observedFilePaths
+    .filter((path) =>
+      isObservedPathForPlatform({
+        platform: params.platform,
+        path,
+      })
+    )
+    .map((path) =>
+      toScopedPrefixFromObservedPath({
+        platform: params.platform,
+        path,
+      })
+    )
+    .filter((prefix): prefix is string => typeof prefix === 'string' && prefix.length > 0);
+
+  return [...new Set(prefixes)].sort();
+};
+
 const resolvePlatformHeuristicPrefixes = (params: {
   platform: NonNullable<RuleDefinition['platform']>;
   repoRoot: string;
+  observedFilePaths?: ReadonlyArray<string>;
 }): ReadonlyArray<string> => {
   const prefixes = PLATFORM_HEURISTIC_FILE_PREFIXES[params.platform] ?? [];
   if (prefixes.length === 0) {
@@ -88,7 +239,10 @@ const resolvePlatformHeuristicPrefixes = (params: {
   });
 
   if (!hasPlatformTree) {
-    return [];
+    return resolveObservedPlatformPrefixes({
+      platform: params.platform,
+      observedFilePaths: params.observedFilePaths,
+    });
   }
 
   return prefixes;
@@ -96,9 +250,14 @@ const resolvePlatformHeuristicPrefixes = (params: {
 
 const resolveScopeForPlatform = (
   platform: NonNullable<RuleDefinition['platform']>,
-  repoRoot: string
+  repoRoot: string,
+  observedFilePaths?: ReadonlyArray<string>
 ): RuleDefinition['scope'] | undefined => {
-  const prefixes = resolvePlatformHeuristicPrefixes({ platform, repoRoot });
+  const prefixes = resolvePlatformHeuristicPrefixes({
+    platform,
+    repoRoot,
+    observedFilePaths,
+  });
   if (prefixes.length === 0) {
     return undefined;
   }
@@ -125,10 +284,12 @@ const buildHeuristicConditionForPlatform = (params: {
   ruleId: string;
   platform: NonNullable<RuleDefinition['platform']>;
   repoRoot: string;
+  observedFilePaths?: ReadonlyArray<string>;
 }): Condition => {
   const prefixes = resolvePlatformHeuristicPrefixes({
     platform: params.platform,
     repoRoot: params.repoRoot,
+    observedFilePaths: params.observedFilePaths,
   });
   if (prefixes.length === 0) {
     return {
@@ -178,9 +339,7 @@ const resolveRuleSeverity = (params: {
   stage: Exclude<GateStage, 'STAGED'>;
 }): Severity => {
   const promotedRuleIds = params.bundlePolicy?.promoteToErrorRuleIds ?? [];
-  const shouldPromote =
-    (params.stage === 'PRE_PUSH' || params.stage === 'CI') &&
-    promotedRuleIds.includes(params.rule.id);
+  const shouldPromote = promotedRuleIds.includes(params.rule.id);
 
   if (!shouldPromote) {
     return params.rule.severity;
@@ -197,13 +356,18 @@ const resolveRuleEvaluationMode = (
   return rule.evaluationMode ?? 'AUTO';
 };
 
+const resolveMappedHeuristicRuleIds = (ruleId: string): ReadonlyArray<string> => {
+  return SKILL_TO_HEURISTIC_RULE_IDS[ruleId] ?? [];
+};
+
 const toRuleDefinition = (params: {
   rule: SkillsCompiledRule;
   stage: Exclude<GateStage, 'STAGED'>;
   bundlePolicy?: SkillsBundlePolicy;
   repoRoot: string;
+  observedFilePaths?: ReadonlyArray<string>;
 }): RuleDefinition | undefined => {
-  const mappedHeuristicRuleId = SKILL_TO_HEURISTIC_RULE_ID[params.rule.id];
+  const mappedHeuristicRuleIds = resolveMappedHeuristicRuleIds(params.rule.id);
 
   if (!stageApplies(params.stage, params.rule.stage)) {
     return undefined;
@@ -216,7 +380,25 @@ const toRuleDefinition = (params: {
     stage: params.stage,
   });
 
-  if (mappedHeuristicRuleId && evaluationMode === 'AUTO') {
+  if (evaluationMode === 'AUTO') {
+    if (mappedHeuristicRuleIds.length === 0) {
+      return undefined;
+    }
+    const heuristicConditions = mappedHeuristicRuleIds.map((ruleId) =>
+      buildHeuristicConditionForPlatform({
+        ruleId,
+        platform: params.rule.platform,
+        repoRoot: params.repoRoot,
+        observedFilePaths: params.observedFilePaths,
+      })
+    );
+    const when: Condition =
+      heuristicConditions.length === 1
+        ? heuristicConditions[0]
+        : {
+            kind: 'Any',
+            conditions: heuristicConditions,
+          };
     return {
       id: params.rule.id,
       description: params.rule.description,
@@ -224,22 +406,22 @@ const toRuleDefinition = (params: {
       platform: params.rule.platform,
       locked: params.rule.locked ?? true,
       confidence: params.rule.confidence,
-      when: buildHeuristicConditionForPlatform({
-        ruleId: mappedHeuristicRuleId,
-        platform: params.rule.platform,
-        repoRoot: params.repoRoot,
-      }),
+      when,
       then: {
         kind: 'Finding',
         message: params.rule.description,
         code: toCode(params.rule.id),
       },
-      scope: resolveScopeForPlatform(params.rule.platform, params.repoRoot),
+      scope: resolveScopeForPlatform(
+        params.rule.platform,
+        params.repoRoot,
+        params.observedFilePaths
+      ),
     };
   }
 
-  // Declarative fallback: keep rule active/evaluable without emitting findings
-  // until a deterministic automatic detector exists for this rule.
+  // Declarative rules remain explicit, but AUTO rules without mapping are
+  // excluded from runtime rule conversion and reported separately.
   return {
     id: params.rule.id,
     description: params.rule.description,
@@ -256,7 +438,11 @@ const toRuleDefinition = (params: {
       message: `[Declarative] ${params.rule.description}`,
       code: `${toCode(params.rule.id)}_DECLARATIVE`,
     },
-    scope: resolveScopeForPlatform(params.rule.platform, params.repoRoot),
+    scope: resolveScopeForPlatform(
+      params.rule.platform,
+      params.repoRoot,
+      params.observedFilePaths
+    ),
   };
 };
 
@@ -301,13 +487,15 @@ const emptyResult = (): SkillsRuleSetLoadResult => {
     activeBundles: [],
     mappedHeuristicRuleIds: new Set<string>(),
     requiresHeuristicFacts: false,
+    unsupportedAutoRuleIds: [],
   };
 };
 
 export const loadSkillsRuleSetForStage = (
   stage: Exclude<GateStage, 'STAGED'>,
   repoRoot: string = process.cwd(),
-  detectedPlatforms?: DetectedPlatforms
+  detectedPlatforms?: DetectedPlatforms,
+  observedFilePaths?: ReadonlyArray<string>
 ): SkillsRuleSetLoadResult => {
   const lock = loadEffectiveSkillsLock(repoRoot);
   if (!lock || lock.bundles.length === 0) {
@@ -331,6 +519,7 @@ export const loadSkillsRuleSetForStage = (
 
   const rulesById = new Map<string, RuleDefinition>();
   const mappedHeuristicRuleIds = new Set<string>();
+  const unsupportedAutoRuleIds = new Set<string>();
 
   for (const bundle of activeBundles) {
     const bundlePolicy = policy?.bundles[bundle.name];
@@ -345,11 +534,19 @@ export const loadSkillsRuleSetForStage = (
         continue;
       }
 
+      const mappedRuleIds = resolveMappedHeuristicRuleIds(compiledRule.id);
+      const evaluationMode = resolveRuleEvaluationMode(compiledRule);
+      if (evaluationMode === 'AUTO' && mappedRuleIds.length === 0) {
+        unsupportedAutoRuleIds.add(compiledRule.id);
+        continue;
+      }
+
       const convertedRule = toRuleDefinition({
         rule: compiledRule,
         stage,
         bundlePolicy,
         repoRoot,
+        observedFilePaths,
       });
 
       if (!convertedRule) {
@@ -357,8 +554,7 @@ export const loadSkillsRuleSetForStage = (
       }
 
       rulesById.set(convertedRule.id, convertedRule);
-      const mappedId = SKILL_TO_HEURISTIC_RULE_ID[compiledRule.id];
-      if (mappedId) {
+      for (const mappedId of mappedRuleIds) {
         mappedHeuristicRuleIds.add(mappedId);
       }
     }
@@ -373,5 +569,6 @@ export const loadSkillsRuleSetForStage = (
     activeBundles,
     mappedHeuristicRuleIds,
     requiresHeuristicFacts: mappedHeuristicRuleIds.size > 0,
+    unsupportedAutoRuleIds: [...unsupportedAutoRuleIds].sort(),
   };
 };

--- a/integrations/gate/__tests__/stagePolicies-config-and-severity.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-config-and-severity.test.ts
@@ -17,8 +17,8 @@ import {
 test('returns expected gate policy thresholds per stage', () => {
   assert.deepEqual(policyForPreCommit(), {
     stage: 'PRE_COMMIT',
-    blockOnOrAbove: 'CRITICAL',
-    warnOnOrAbove: 'ERROR',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
   });
   assert.deepEqual(policyForPrePush(), {
     stage: 'PRE_PUSH',
@@ -73,166 +73,166 @@ test('resolves stage policy overrides from skills.policy.json', async () => {
   });
 });
 
-test('keeps heuristic severities as WARN in PRE_COMMIT', () => {
-  assert.equal(findSeverity('heuristics.ts.console-log.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.console-error.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.eval.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.function-constructor.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.set-timeout-string.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.set-interval-string.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.new-promise-async.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.with-statement.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.process-exit.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.delete-operator.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.inner-html.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.document-write.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.insert-adjacent-html.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-import.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.process-env-mutation.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.hardcoded-secret-token.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.weak-crypto-hash.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.insecure-token-math-random.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.insecure-token-date-now.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.weak-token-randomuuid.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.jwt-decode-without-verify.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.jwt-verify-ignore-expiration.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.jwt-sign-no-expiration.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.tls-reject-unauthorized-false.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.dynamic-shell-invocation.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.tls-env-override.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-shell-true.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.vm-dynamic-code-execution.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.buffer-alloc-unsafe.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.buffer-alloc-unsafe-slow.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-write-file-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-rm-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-mkdir-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-readdir-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-read-file-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-stat-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-realpath-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-lstat-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-exists-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-chmod-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-chown-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fchown-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fchmod-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fstat-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-ftruncate-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-futimes-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-lutimes-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-exec-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-exec.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-spawn-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-spawn.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-fork.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.child-process-exec-file-sync.ast', 'PRE_COMMIT'), 'WARN');
+test('promotes heuristic severities to ERROR in PRE_COMMIT', () => {
+  assert.equal(findSeverity('heuristics.ts.console-log.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.console-error.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.eval.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.function-constructor.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.set-timeout-string.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.set-interval-string.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.new-promise-async.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.with-statement.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.process-exit.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.delete-operator.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.inner-html.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.document-write.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.insert-adjacent-html.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-import.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.process-env-mutation.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.hardcoded-secret-token.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.weak-crypto-hash.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.insecure-token-math-random.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.insecure-token-date-now.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.weak-token-randomuuid.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.jwt-decode-without-verify.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.jwt-verify-ignore-expiration.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.jwt-sign-no-expiration.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.tls-reject-unauthorized-false.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.dynamic-shell-invocation.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.tls-env-override.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-shell-true.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.vm-dynamic-code-execution.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.buffer-alloc-unsafe.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.buffer-alloc-unsafe-slow.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-write-file-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-rm-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-mkdir-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-readdir-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-read-file-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-stat-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-realpath-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-lstat-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-exists-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-chmod-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-chown-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fchown-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fchmod-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fstat-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-ftruncate-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-futimes-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-lutimes-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-exec-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-exec.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-spawn-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-spawn.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-fork.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.child-process-exec-file-sync.ast', 'PRE_COMMIT'), 'ERROR');
   assert.equal(
     findSeverity('heuristics.ts.child-process-exec-file-untrusted-args.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
-  assert.equal(findSeverity('heuristics.ts.child-process-exec-file.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-append-file-sync.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-write-file.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-append-file.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-rm.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-unlink.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-read-file.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-readdir.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-mkdir.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-stat.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-copy-file.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-rename.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-access.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-chmod.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-chown.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-utimes.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-lstat.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-realpath.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-symlink.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-link.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-readlink.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-open.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-opendir.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-cp.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-promises-mkdtemp.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-utimes-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-watch-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-watch-file-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-unwatch-file-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-read-file-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-exists-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-write-file-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-append-file-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-readdir-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-mkdir-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-rmdir-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-rm-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-rename-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-copy-file-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-stat-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-statfs-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-lstat-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-realpath-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-access-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-chmod-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-chown-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-lchown-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-lchmod-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-unlink-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-readlink-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-symlink-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fsync-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fdatasync-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fchown-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fchmod-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-fstat-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-ftruncate-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-truncate-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-futimes-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-lutimes-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-link-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-mkdtemp-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-opendir-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-open-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-cp-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-close-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-read-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-readv-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-writev-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.fs-write-callback.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ts.debugger.ast', 'PRE_COMMIT'), 'WARN');
+  assert.equal(findSeverity('heuristics.ts.child-process-exec-file.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-append-file-sync.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-write-file.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-append-file.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-rm.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-unlink.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-read-file.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-readdir.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-mkdir.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-stat.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-copy-file.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-rename.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-access.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-chmod.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-chown.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-utimes.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-lstat.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-realpath.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-symlink.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-link.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-readlink.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-open.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-opendir.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-cp.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-promises-mkdtemp.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-utimes-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-watch-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-watch-file-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-unwatch-file-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-read-file-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-exists-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-write-file-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-append-file-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-readdir-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-mkdir-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-rmdir-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-rm-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-rename-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-copy-file-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-stat-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-statfs-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-lstat-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-realpath-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-access-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-chmod-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-chown-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-lchown-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-lchmod-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-unlink-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-readlink-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-symlink-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fsync-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fdatasync-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fchown-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fchmod-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-fstat-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-ftruncate-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-truncate-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-futimes-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-lutimes-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-link-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-mkdtemp-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-opendir-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-open-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-cp-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-close-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-read-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-readv-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-writev-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.fs-write-callback.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ts.debugger.ast', 'PRE_COMMIT'), 'ERROR');
   assert.equal(
     findSeverity('heuristics.ts.solid.srp.class-command-query-mix.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
   assert.equal(
     findSeverity('heuristics.ts.solid.isp.interface-command-query-mix.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
   assert.equal(
     findSeverity('heuristics.ts.solid.ocp.discriminator-switch.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
   assert.equal(
     findSeverity('heuristics.ts.solid.lsp.override-not-implemented.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
   assert.equal(
     findSeverity('heuristics.ts.solid.dip.framework-import.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
   assert.equal(
     findSeverity('heuristics.ts.solid.dip.concrete-instantiation.ast', 'PRE_COMMIT'),
-    'WARN'
+    'ERROR'
   );
-  assert.equal(findSeverity('heuristics.ios.force-unwrap.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ios.force-try.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.ios.force-cast.ast', 'PRE_COMMIT'), 'WARN');
-  assert.equal(findSeverity('heuristics.android.thread-sleep.ast', 'PRE_COMMIT'), 'WARN');
+  assert.equal(findSeverity('heuristics.ios.force-unwrap.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ios.force-try.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.ios.force-cast.ast', 'PRE_COMMIT'), 'ERROR');
+  assert.equal(findSeverity('heuristics.android.thread-sleep.ast', 'PRE_COMMIT'), 'ERROR');
 });
 
-test('promotes selected heuristic severities to ERROR in PRE_PUSH and CI', () => {
+test('promotes selected heuristic severities to ERROR in PRE_COMMIT, PRE_PUSH y CI', () => {
   assert.equal(findSeverity('heuristics.ts.console-log.ast', 'PRE_PUSH'), 'ERROR');
   assert.equal(findSeverity('heuristics.ts.console-error.ast', 'PRE_PUSH'), 'ERROR');
   assert.equal(findSeverity('heuristics.ts.eval.ast', 'PRE_PUSH'), 'ERROR');
@@ -395,9 +395,9 @@ test('promotes selected heuristic severities to ERROR in PRE_PUSH and CI', () =>
   assert.equal(findSeverity('heuristics.android.run-blocking.ast', 'CI'), 'ERROR');
 });
 
-test('keeps non-promoted heuristic severities unchanged', () => {
+test('keeps ignored heuristic severities unchanged and still promotes PRE_COMMIT', () => {
   assert.equal(findSeverity('heuristics.ts.empty-catch.ast', 'PRE_PUSH'), 'WARN');
-  assert.equal(findSeverity('heuristics.ios.callback-style.ast', 'PRE_COMMIT'), 'WARN');
+  assert.equal(findSeverity('heuristics.ios.callback-style.ast', 'PRE_COMMIT'), 'ERROR');
 });
 
 test('does not mutate the source heuristic ruleset', () => {

--- a/integrations/gate/__tests__/stagePolicies-promotions-first-fs-sync-core.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-first-fs-sync-core.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate promotes fs.writeFileSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.writeFileSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWriteFileSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-write-file-sync.ast',
@@ -24,7 +24,7 @@ test('gate promotes fs.writeFileSync heuristic to blocking in PRE_PUSH and CI on
     [fsWriteFileSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate promotes fs.writeFileSync heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.rmSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.rmSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRmSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-rm-sync.ast',
@@ -56,7 +56,7 @@ test('gate promotes fs.rmSync heuristic to blocking in PRE_PUSH and CI only', ()
     [fsRmSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes fs.rmSync heuristic to blocking in PRE_PUSH and CI only', ()
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.mkdirSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.mkdirSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsMkdirSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-mkdir-sync.ast',
@@ -88,7 +88,7 @@ test('gate promotes fs.mkdirSync heuristic to blocking in PRE_PUSH and CI only',
     [fsMkdirSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -105,7 +105,7 @@ test('gate promotes fs.mkdirSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readdirSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readdirSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReaddirSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-readdir-sync.ast',
@@ -120,7 +120,7 @@ test('gate promotes fs.readdirSync heuristic to blocking in PRE_PUSH and CI only
     [fsReaddirSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -137,7 +137,7 @@ test('gate promotes fs.readdirSync heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readFileSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readFileSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadFileSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-read-file-sync.ast',
@@ -152,7 +152,7 @@ test('gate promotes fs.readFileSync heuristic to blocking in PRE_PUSH and CI onl
     [fsReadFileSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -169,7 +169,7 @@ test('gate promotes fs.readFileSync heuristic to blocking in PRE_PUSH and CI onl
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.statSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.statSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsStatSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-stat-sync.ast',
@@ -184,7 +184,7 @@ test('gate promotes fs.statSync heuristic to blocking in PRE_PUSH and CI only', 
     [fsStatSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -201,7 +201,7 @@ test('gate promotes fs.statSync heuristic to blocking in PRE_PUSH and CI only', 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.statfsSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.statfsSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsStatfsSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-statfs-sync.ast',
@@ -216,7 +216,7 @@ test('gate promotes fs.statfsSync heuristic to blocking in PRE_PUSH and CI only'
     [fsStatfsSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -232,7 +232,7 @@ test('gate promotes fs.statfsSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.realpathSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.realpathSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRealpathSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-realpath-sync.ast',
@@ -247,7 +247,7 @@ test('gate promotes fs.realpathSync heuristic to blocking in PRE_PUSH and CI onl
     [fsRealpathSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -264,7 +264,7 @@ test('gate promotes fs.realpathSync heuristic to blocking in PRE_PUSH and CI onl
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.lstatSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.lstatSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLstatSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-lstat-sync.ast',
@@ -279,7 +279,7 @@ test('gate promotes fs.lstatSync heuristic to blocking in PRE_PUSH and CI only',
     [fsLstatSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -296,7 +296,7 @@ test('gate promotes fs.lstatSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.existsSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.existsSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsExistsSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-exists-sync.ast',
@@ -311,7 +311,7 @@ test('gate promotes fs.existsSync heuristic to blocking in PRE_PUSH and CI only'
     [fsExistsSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -328,7 +328,7 @@ test('gate promotes fs.existsSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.accessSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.accessSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsAccessSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-access-sync.ast',
@@ -343,7 +343,7 @@ test('gate promotes fs.accessSync heuristic to blocking in PRE_PUSH and CI only'
     [fsAccessSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -359,7 +359,7 @@ test('gate promotes fs.accessSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.utimesSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.utimesSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsUtimesSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-utimes-sync.ast',
@@ -374,7 +374,7 @@ test('gate promotes fs.utimesSync heuristic to blocking in PRE_PUSH and CI only'
     [fsUtimesSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -391,7 +391,7 @@ test('gate promotes fs.utimesSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.renameSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.renameSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRenameSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-rename-sync.ast',
@@ -406,7 +406,7 @@ test('gate promotes fs.renameSync heuristic to blocking in PRE_PUSH and CI only'
     [fsRenameSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -423,7 +423,7 @@ test('gate promotes fs.renameSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.copyFileSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.copyFileSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsCopyFileSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-copy-file-sync.ast',
@@ -438,7 +438,7 @@ test('gate promotes fs.copyFileSync heuristic to blocking in PRE_PUSH and CI onl
     [fsCopyFileSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-first-fs-sync-ops.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-first-fs-sync-ops.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate promotes fs.unlinkSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.unlinkSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsUnlinkSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-unlink-sync.ast',
@@ -24,7 +24,7 @@ test('gate promotes fs.unlinkSync heuristic to blocking in PRE_PUSH and CI only'
     [fsUnlinkSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate promotes fs.unlinkSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.truncateSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.truncateSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsTruncateSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-truncate-sync.ast',
@@ -56,7 +56,7 @@ test('gate promotes fs.truncateSync heuristic to blocking in PRE_PUSH and CI onl
     [fsTruncateSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes fs.truncateSync heuristic to blocking in PRE_PUSH and CI onl
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.rmdirSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.rmdirSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRmdirSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-rmdir-sync.ast',
@@ -88,7 +88,7 @@ test('gate promotes fs.rmdirSync heuristic to blocking in PRE_PUSH and CI only',
     [fsRmdirSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -105,7 +105,7 @@ test('gate promotes fs.rmdirSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.chmodSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.chmodSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsChmodSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-chmod-sync.ast',
@@ -120,7 +120,7 @@ test('gate promotes fs.chmodSync heuristic to blocking in PRE_PUSH and CI only',
     [fsChmodSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -137,7 +137,7 @@ test('gate promotes fs.chmodSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.chownSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.chownSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsChownSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-chown-sync.ast',
@@ -152,7 +152,7 @@ test('gate promotes fs.chownSync heuristic to blocking in PRE_PUSH and CI only',
     [fsChownSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -169,7 +169,7 @@ test('gate promotes fs.chownSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fchownSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fchownSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFchownSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fchown-sync.ast',
@@ -184,7 +184,7 @@ test('gate promotes fs.fchownSync heuristic to blocking in PRE_PUSH and CI only'
     [fsFchownSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -201,7 +201,7 @@ test('gate promotes fs.fchownSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fchmodSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fchmodSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFchmodSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fchmod-sync.ast',
@@ -216,7 +216,7 @@ test('gate promotes fs.fchmodSync heuristic to blocking in PRE_PUSH and CI only'
     [fsFchmodSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -233,7 +233,7 @@ test('gate promotes fs.fchmodSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fstatSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fstatSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFstatSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fstat-sync.ast',
@@ -248,7 +248,7 @@ test('gate promotes fs.fstatSync heuristic to blocking in PRE_PUSH and CI only',
     [fsFstatSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -265,7 +265,7 @@ test('gate promotes fs.fstatSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.ftruncateSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.ftruncateSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFtruncateSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-ftruncate-sync.ast',
@@ -280,7 +280,7 @@ test('gate promotes fs.ftruncateSync heuristic to blocking in PRE_PUSH and CI on
     [fsFtruncateSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -297,7 +297,7 @@ test('gate promotes fs.ftruncateSync heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.futimesSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.futimesSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFutimesSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-futimes-sync.ast',
@@ -312,7 +312,7 @@ test('gate promotes fs.futimesSync heuristic to blocking in PRE_PUSH and CI only
     [fsFutimesSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -329,7 +329,7 @@ test('gate promotes fs.futimesSync heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.lutimesSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.lutimesSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLutimesSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-lutimes-sync.ast',
@@ -344,7 +344,7 @@ test('gate promotes fs.lutimesSync heuristic to blocking in PRE_PUSH and CI only
     [fsLutimesSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -361,7 +361,7 @@ test('gate promotes fs.lutimesSync heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readvSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readvSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadvSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-readv-sync.ast',
@@ -376,7 +376,7 @@ test('gate promotes fs.readvSync heuristic to blocking in PRE_PUSH and CI only',
     [fsReadvSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -393,7 +393,7 @@ test('gate promotes fs.readvSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.writevSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.writevSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWritevSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-writev-sync.ast',
@@ -408,7 +408,7 @@ test('gate promotes fs.writevSync heuristic to blocking in PRE_PUSH and CI only'
     [fsWritevSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -425,7 +425,7 @@ test('gate promotes fs.writevSync heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.writeSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.writeSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWriteSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-write-sync.ast',
@@ -440,7 +440,7 @@ test('gate promotes fs.writeSync heuristic to blocking in PRE_PUSH and CI only',
     [fsWriteSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-first-heuristics-core-advanced.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-first-heuristics-core-advanced.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate promotes process.exit heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes process.exit heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const processExitFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.process-exit.ast',
@@ -24,7 +24,7 @@ test('gate promotes process.exit heuristic to blocking in PRE_PUSH and CI only',
     [processExitFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate promotes process.exit heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes delete-operator heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes delete-operator heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const deleteOperatorFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.delete-operator.ast',
@@ -56,7 +56,7 @@ test('gate promotes delete-operator heuristic to blocking in PRE_PUSH and CI onl
     [deleteOperatorFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes delete-operator heuristic to blocking in PRE_PUSH and CI onl
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes innerHTML heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes innerHTML heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const innerHtmlFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.inner-html.ast',
@@ -88,7 +88,7 @@ test('gate promotes innerHTML heuristic to blocking in PRE_PUSH and CI only', ()
     [innerHtmlFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -105,7 +105,7 @@ test('gate promotes innerHTML heuristic to blocking in PRE_PUSH and CI only', ()
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes document.write heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes document.write heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const documentWriteFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.document-write.ast',
@@ -120,7 +120,7 @@ test('gate promotes document.write heuristic to blocking in PRE_PUSH and CI only
     [documentWriteFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -137,7 +137,7 @@ test('gate promotes document.write heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes insertAdjacentHTML heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes insertAdjacentHTML heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const insertAdjacentHtmlFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.insert-adjacent-html.ast',
@@ -152,7 +152,7 @@ test('gate promotes insertAdjacentHTML heuristic to blocking in PRE_PUSH and CI 
     [insertAdjacentHtmlFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -169,7 +169,7 @@ test('gate promotes insertAdjacentHTML heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes child_process import heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes child_process import heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const childProcessImportFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-import.ast',
@@ -184,7 +184,7 @@ test('gate promotes child_process import heuristic to blocking in PRE_PUSH and C
     [childProcessImportFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -201,7 +201,7 @@ test('gate promotes child_process import heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes process.env mutation heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes process.env mutation heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const processEnvMutationFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.process-env-mutation.ast',
@@ -216,7 +216,7 @@ test('gate promotes process.env mutation heuristic to blocking in PRE_PUSH and C
     [processEnvMutationFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -233,7 +233,7 @@ test('gate promotes process.env mutation heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes hardcoded secret/token heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes hardcoded secret/token heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const hardcodedSecretTokenFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.hardcoded-secret-token.ast',
@@ -248,7 +248,7 @@ test('gate promotes hardcoded secret/token heuristic to blocking in PRE_PUSH and
     [hardcodedSecretTokenFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-first-heuristics-core-general.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-first-heuristics-core-general.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate blocks promoted heuristic rules only in PRE_PUSH and CI', () => {
+test('gate blocks promoted heuristic rules in PRE_COMMIT, PRE_PUSH y CI', () => {
   const consoleLogFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.console-log.ast',
@@ -24,7 +24,7 @@ test('gate blocks promoted heuristic rules only in PRE_PUSH and CI', () => {
     [consoleLogFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate blocks promoted heuristic rules only in PRE_PUSH and CI', () => {
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes console.error heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes console.error heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const consoleErrorFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.console-error.ast',
@@ -56,7 +56,7 @@ test('gate promotes console.error heuristic to blocking in PRE_PUSH and CI only'
     [consoleErrorFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes console.error heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes eval heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes eval heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const evalFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.eval.ast',
@@ -88,7 +88,7 @@ test('gate promotes eval heuristic to blocking in PRE_PUSH and CI only', () => {
     [evalFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -105,7 +105,7 @@ test('gate promotes eval heuristic to blocking in PRE_PUSH and CI only', () => {
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes Function-constructor heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes Function-constructor heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const functionConstructorFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.function-constructor.ast',
@@ -120,7 +120,7 @@ test('gate promotes Function-constructor heuristic to blocking in PRE_PUSH and C
     [functionConstructorFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -137,7 +137,7 @@ test('gate promotes Function-constructor heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes setTimeout-string heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes setTimeout-string heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const timeoutStringFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.set-timeout-string.ast',
@@ -152,7 +152,7 @@ test('gate promotes setTimeout-string heuristic to blocking in PRE_PUSH and CI o
     [timeoutStringFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -169,7 +169,7 @@ test('gate promotes setTimeout-string heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes setInterval-string heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes setInterval-string heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const intervalStringFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.set-interval-string.ast',
@@ -184,7 +184,7 @@ test('gate promotes setInterval-string heuristic to blocking in PRE_PUSH and CI 
     [intervalStringFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -201,7 +201,7 @@ test('gate promotes setInterval-string heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes async Promise-executor heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes async Promise-executor heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const asyncPromiseFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.new-promise-async.ast',
@@ -216,7 +216,7 @@ test('gate promotes async Promise-executor heuristic to blocking in PRE_PUSH and
     [asyncPromiseFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -233,7 +233,7 @@ test('gate promotes async Promise-executor heuristic to blocking in PRE_PUSH and
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes with-statement heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes with-statement heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const withStatementFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.with-statement.ast',
@@ -248,7 +248,7 @@ test('gate promotes with-statement heuristic to blocking in PRE_PUSH and CI only
     [withStatementFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -264,4 +264,3 @@ test('gate promotes with-statement heuristic to blocking in PRE_PUSH and CI only
   const ciDecision = evaluateGate([...ciFindings], policyForCI());
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
-

--- a/integrations/gate/__tests__/stagePolicies-promotions-first-heuristics-crypto.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-first-heuristics-crypto.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate promotes weak crypto hash heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes weak crypto hash heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const weakCryptoHashFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.weak-crypto-hash.ast',
@@ -24,7 +24,7 @@ test('gate promotes weak crypto hash heuristic to blocking in PRE_PUSH and CI on
     [weakCryptoHashFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate promotes weak crypto hash heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes insecure token Math.random heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes insecure token Math.random heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const insecureTokenMathRandomFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.insecure-token-math-random.ast',
@@ -56,7 +56,7 @@ test('gate promotes insecure token Math.random heuristic to blocking in PRE_PUSH
     [insecureTokenMathRandomFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes insecure token Math.random heuristic to blocking in PRE_PUSH
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes insecure token Date.now heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes insecure token Date.now heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const insecureTokenDateNowFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.insecure-token-date-now.ast',
@@ -88,7 +88,7 @@ test('gate promotes insecure token Date.now heuristic to blocking in PRE_PUSH an
     [insecureTokenDateNowFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -105,7 +105,7 @@ test('gate promotes insecure token Date.now heuristic to blocking in PRE_PUSH an
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes Buffer.allocUnsafe heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes Buffer.allocUnsafe heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const bufferAllocUnsafeFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.buffer-alloc-unsafe.ast',
@@ -120,7 +120,7 @@ test('gate promotes Buffer.allocUnsafe heuristic to blocking in PRE_PUSH and CI 
     [bufferAllocUnsafeFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -137,7 +137,7 @@ test('gate promotes Buffer.allocUnsafe heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes jsonwebtoken.decode heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes jsonwebtoken.decode heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const jwtDecodeWithoutVerifyFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.jwt-decode-without-verify.ast',
@@ -152,7 +152,7 @@ test('gate promotes jsonwebtoken.decode heuristic to blocking in PRE_PUSH and CI
     [jwtDecodeWithoutVerifyFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -169,7 +169,7 @@ test('gate promotes jsonwebtoken.decode heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes jsonwebtoken.verify ignoreExpiration heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes jsonwebtoken.verify ignoreExpiration heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const jwtVerifyIgnoreExpirationFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.jwt-verify-ignore-expiration.ast',
@@ -184,7 +184,7 @@ test('gate promotes jsonwebtoken.verify ignoreExpiration heuristic to blocking i
     [jwtVerifyIgnoreExpirationFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -201,7 +201,7 @@ test('gate promotes jsonwebtoken.verify ignoreExpiration heuristic to blocking i
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes jsonwebtoken.sign without expiration heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes jsonwebtoken.sign without expiration heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const jwtSignNoExpirationFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.jwt-sign-no-expiration.ast',
@@ -216,7 +216,7 @@ test('gate promotes jsonwebtoken.sign without expiration heuristic to blocking i
     [jwtSignNoExpirationFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -233,7 +233,7 @@ test('gate promotes jsonwebtoken.sign without expiration heuristic to blocking i
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes TLS rejectUnauthorized=false heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes TLS rejectUnauthorized=false heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const tlsRejectUnauthorizedFalseFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.tls-reject-unauthorized-false.ast',
@@ -248,7 +248,7 @@ test('gate promotes TLS rejectUnauthorized=false heuristic to blocking in PRE_PU
     [tlsRejectUnauthorizedFalseFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -265,7 +265,7 @@ test('gate promotes TLS rejectUnauthorized=false heuristic to blocking in PRE_PU
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes dynamic shell invocation heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes dynamic shell invocation heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const dynamicShellInvocationFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.dynamic-shell-invocation.ast',
@@ -280,7 +280,7 @@ test('gate promotes dynamic shell invocation heuristic to blocking in PRE_PUSH a
     [dynamicShellInvocationFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -297,7 +297,7 @@ test('gate promotes dynamic shell invocation heuristic to blocking in PRE_PUSH a
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes TLS env override heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes TLS env override heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const tlsEnvOverrideFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.tls-env-override.ast',
@@ -312,7 +312,7 @@ test('gate promotes TLS env override heuristic to blocking in PRE_PUSH and CI on
     [tlsEnvOverrideFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -329,7 +329,7 @@ test('gate promotes TLS env override heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes child_process shell=true heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes child_process shell=true heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const childProcessShellTrueFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-shell-true.ast',
@@ -344,7 +344,7 @@ test('gate promotes child_process shell=true heuristic to blocking in PRE_PUSH a
     [childProcessShellTrueFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -361,7 +361,7 @@ test('gate promotes child_process shell=true heuristic to blocking in PRE_PUSH a
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes vm dynamic code execution heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes vm dynamic code execution heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const vmDynamicCodeExecutionFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.vm-dynamic-code-execution.ast',
@@ -376,7 +376,7 @@ test('gate promotes vm dynamic code execution heuristic to blocking in PRE_PUSH 
     [vmDynamicCodeExecutionFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -393,7 +393,7 @@ test('gate promotes vm dynamic code execution heuristic to blocking in PRE_PUSH 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes crypto.randomUUID token heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes crypto.randomUUID token heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const weakTokenRandomUuidFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.weak-token-randomuuid.ast',
@@ -408,7 +408,7 @@ test('gate promotes crypto.randomUUID token heuristic to blocking in PRE_PUSH an
     [weakTokenRandomUuidFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -425,7 +425,7 @@ test('gate promotes crypto.randomUUID token heuristic to blocking in PRE_PUSH an
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes Buffer.allocUnsafeSlow heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes Buffer.allocUnsafeSlow heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const bufferAllocUnsafeSlowFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.buffer-alloc-unsafe-slow.ast',
@@ -440,7 +440,7 @@ test('gate promotes Buffer.allocUnsafeSlow heuristic to blocking in PRE_PUSH and
     [bufferAllocUnsafeSlowFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-second-child-process.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-second-child-process.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush,
 } from './stagePoliciesFixtures';
 
-test('gate promotes execSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes execSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const execSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-exec-sync.ast',
@@ -25,7 +25,7 @@ test('gate promotes execSync heuristic to blocking in PRE_PUSH and CI only', () 
     [execSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes execSync heuristic to blocking in PRE_PUSH and CI only', () 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes exec heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes exec heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const execFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-exec.ast',
@@ -57,7 +57,7 @@ test('gate promotes exec heuristic to blocking in PRE_PUSH and CI only', () => {
     [execFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes exec heuristic to blocking in PRE_PUSH and CI only', () => {
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes spawnSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes spawnSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const spawnSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-spawn-sync.ast',
@@ -89,7 +89,7 @@ test('gate promotes spawnSync heuristic to blocking in PRE_PUSH and CI only', ()
     [spawnSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes spawnSync heuristic to blocking in PRE_PUSH and CI only', ()
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes spawn heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes spawn heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const spawnFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-spawn.ast',
@@ -121,7 +121,7 @@ test('gate promotes spawn heuristic to blocking in PRE_PUSH and CI only', () => 
     [spawnFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes spawn heuristic to blocking in PRE_PUSH and CI only', () => 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fork heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fork heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const forkFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-fork.ast',
@@ -153,7 +153,7 @@ test('gate promotes fork heuristic to blocking in PRE_PUSH and CI only', () => {
     [forkFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fork heuristic to blocking in PRE_PUSH and CI only', () => {
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes execFileSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes execFileSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const execFileSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-exec-file-sync.ast',
@@ -185,7 +185,7 @@ test('gate promotes execFileSync heuristic to blocking in PRE_PUSH and CI only',
     [execFileSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes execFileSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes execFile heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes execFile heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const execFileFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-exec-file.ast',
@@ -217,7 +217,7 @@ test('gate promotes execFile heuristic to blocking in PRE_PUSH and CI only', () 
     [execFileFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes execFile heuristic to blocking in PRE_PUSH and CI only', () 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes execFile untrusted args heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes execFile untrusted args heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const execFileUntrustedArgsFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.child-process-exec-file-untrusted-args.ast',
@@ -249,7 +249,7 @@ test('gate promotes execFile untrusted args heuristic to blocking in PRE_PUSH an
     [execFileUntrustedArgsFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-second-fs-promises-part1.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-second-fs-promises-part1.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush,
 } from './stagePoliciesFixtures';
 
-test('gate promotes fs.appendFileSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.appendFileSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsAppendFileSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-append-file-sync.ast',
@@ -25,7 +25,7 @@ test('gate promotes fs.appendFileSync heuristic to blocking in PRE_PUSH and CI o
     [fsAppendFileSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes fs.appendFileSync heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.writeFile heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.writeFile heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesWriteFileFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-write-file.ast',
@@ -57,7 +57,7 @@ test('gate promotes fs.promises.writeFile heuristic to blocking in PRE_PUSH and 
     [fsPromisesWriteFileFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes fs.promises.writeFile heuristic to blocking in PRE_PUSH and 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.appendFile heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.appendFile heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesAppendFileFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-append-file.ast',
@@ -89,7 +89,7 @@ test('gate promotes fs.promises.appendFile heuristic to blocking in PRE_PUSH and
     [fsPromisesAppendFileFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes fs.promises.appendFile heuristic to blocking in PRE_PUSH and
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.rm heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.rm heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesRmFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-rm.ast',
@@ -121,7 +121,7 @@ test('gate promotes fs.promises.rm heuristic to blocking in PRE_PUSH and CI only
     [fsPromisesRmFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes fs.promises.rm heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.unlink heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.unlink heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesUnlinkFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-unlink.ast',
@@ -153,7 +153,7 @@ test('gate promotes fs.promises.unlink heuristic to blocking in PRE_PUSH and CI 
     [fsPromisesUnlinkFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fs.promises.unlink heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.readFile heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.readFile heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesReadFileFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-read-file.ast',
@@ -185,7 +185,7 @@ test('gate promotes fs.promises.readFile heuristic to blocking in PRE_PUSH and C
     [fsPromisesReadFileFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes fs.promises.readFile heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.readdir heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.readdir heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesReaddirFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-readdir.ast',
@@ -217,7 +217,7 @@ test('gate promotes fs.promises.readdir heuristic to blocking in PRE_PUSH and CI
     [fsPromisesReaddirFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes fs.promises.readdir heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.mkdir heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.mkdir heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesMkdirFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-mkdir.ast',
@@ -249,7 +249,7 @@ test('gate promotes fs.promises.mkdir heuristic to blocking in PRE_PUSH and CI o
     [fsPromisesMkdirFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-second-fs-promises-part2.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-second-fs-promises-part2.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush,
 } from './stagePoliciesFixtures';
 
-test('gate promotes fs.promises.stat heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.stat heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesStatFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-stat.ast',
@@ -25,7 +25,7 @@ test('gate promotes fs.promises.stat heuristic to blocking in PRE_PUSH and CI on
     [fsPromisesStatFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes fs.promises.stat heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.copyFile heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.copyFile heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesCopyFileFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-copy-file.ast',
@@ -57,7 +57,7 @@ test('gate promotes fs.promises.copyFile heuristic to blocking in PRE_PUSH and C
     [fsPromisesCopyFileFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes fs.promises.copyFile heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.rename heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.rename heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesRenameFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-rename.ast',
@@ -89,7 +89,7 @@ test('gate promotes fs.promises.rename heuristic to blocking in PRE_PUSH and CI 
     [fsPromisesRenameFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes fs.promises.rename heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.access heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.access heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesAccessFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-access.ast',
@@ -121,7 +121,7 @@ test('gate promotes fs.promises.access heuristic to blocking in PRE_PUSH and CI 
     [fsPromisesAccessFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes fs.promises.access heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.chmod heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.chmod heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesChmodFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-chmod.ast',
@@ -153,7 +153,7 @@ test('gate promotes fs.promises.chmod heuristic to blocking in PRE_PUSH and CI o
     [fsPromisesChmodFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fs.promises.chmod heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.chown heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.chown heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesChownFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-chown.ast',
@@ -185,7 +185,7 @@ test('gate promotes fs.promises.chown heuristic to blocking in PRE_PUSH and CI o
     [fsPromisesChownFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes fs.promises.chown heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.utimes heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.utimes heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesUtimesFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-utimes.ast',
@@ -217,7 +217,7 @@ test('gate promotes fs.promises.utimes heuristic to blocking in PRE_PUSH and CI 
     [fsPromisesUtimesFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes fs.promises.utimes heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.lstat heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.lstat heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesLstatFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-lstat.ast',
@@ -249,7 +249,7 @@ test('gate promotes fs.promises.lstat heuristic to blocking in PRE_PUSH and CI o
     [fsPromisesLstatFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-second-fs-promises-part3.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-second-fs-promises-part3.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush,
 } from './stagePoliciesFixtures';
 
-test('gate promotes fs.promises.realpath heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.realpath heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesRealpathFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-realpath.ast',
@@ -25,7 +25,7 @@ test('gate promotes fs.promises.realpath heuristic to blocking in PRE_PUSH and C
     [fsPromisesRealpathFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes fs.promises.realpath heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.symlink heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.symlink heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesSymlinkFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-symlink.ast',
@@ -57,7 +57,7 @@ test('gate promotes fs.promises.symlink heuristic to blocking in PRE_PUSH and CI
     [fsPromisesSymlinkFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes fs.promises.symlink heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.link heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.link heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesLinkFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-link.ast',
@@ -89,7 +89,7 @@ test('gate promotes fs.promises.link heuristic to blocking in PRE_PUSH and CI on
     [fsPromisesLinkFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes fs.promises.link heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.readlink heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.readlink heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesReadlinkFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-readlink.ast',
@@ -121,7 +121,7 @@ test('gate promotes fs.promises.readlink heuristic to blocking in PRE_PUSH and C
     [fsPromisesReadlinkFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes fs.promises.readlink heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.open heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.open heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesOpenFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-open.ast',
@@ -153,7 +153,7 @@ test('gate promotes fs.promises.open heuristic to blocking in PRE_PUSH and CI on
     [fsPromisesOpenFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fs.promises.open heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.opendir heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.opendir heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesOpendirFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-opendir.ast',
@@ -185,7 +185,7 @@ test('gate promotes fs.promises.opendir heuristic to blocking in PRE_PUSH and CI
     [fsPromisesOpendirFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes fs.promises.opendir heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.cp heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.cp heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesCpFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-cp.ast',
@@ -217,7 +217,7 @@ test('gate promotes fs.promises.cp heuristic to blocking in PRE_PUSH and CI only
     [fsPromisesCpFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes fs.promises.cp heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.promises.mkdtemp heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.promises.mkdtemp heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsPromisesMkdtempFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-promises-mkdtemp.ast',
@@ -249,7 +249,7 @@ test('gate promotes fs.promises.mkdtemp heuristic to blocking in PRE_PUSH and CI
     [fsPromisesMkdtempFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-second-fs-sync.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-second-fs-sync.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate promotes fs.fsyncSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fsyncSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFsyncSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fsync-sync.ast',
@@ -24,7 +24,7 @@ test('gate promotes fs.fsyncSync heuristic to blocking in PRE_PUSH and CI only',
     [fsFsyncSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate promotes fs.fsyncSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fdatasyncSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fdatasyncSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFdatasyncSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fdatasync-sync.ast',
@@ -56,7 +56,7 @@ test('gate promotes fs.fdatasyncSync heuristic to blocking in PRE_PUSH and CI on
     [fsFdatasyncSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes fs.fdatasyncSync heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.closeSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.closeSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsCloseSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-close-sync.ast',
@@ -88,7 +88,7 @@ test('gate promotes fs.closeSync heuristic to blocking in PRE_PUSH and CI only',
     [fsCloseSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -104,7 +104,7 @@ test('gate promotes fs.closeSync heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-read-sync.ast',
@@ -119,7 +119,7 @@ test('gate promotes fs.readSync heuristic to blocking in PRE_PUSH and CI only', 
     [fsReadSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -135,7 +135,7 @@ test('gate promotes fs.readSync heuristic to blocking in PRE_PUSH and CI only', 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readlinkSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readlinkSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadlinkSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-readlink-sync.ast',
@@ -150,7 +150,7 @@ test('gate promotes fs.readlinkSync heuristic to blocking in PRE_PUSH and CI onl
     [fsReadlinkSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -166,7 +166,7 @@ test('gate promotes fs.readlinkSync heuristic to blocking in PRE_PUSH and CI onl
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.symlinkSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.symlinkSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsSymlinkSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-symlink-sync.ast',
@@ -181,7 +181,7 @@ test('gate promotes fs.symlinkSync heuristic to blocking in PRE_PUSH and CI only
     [fsSymlinkSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -197,7 +197,7 @@ test('gate promotes fs.symlinkSync heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.linkSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.linkSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLinkSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-link-sync.ast',
@@ -212,7 +212,7 @@ test('gate promotes fs.linkSync heuristic to blocking in PRE_PUSH and CI only', 
     [fsLinkSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -228,7 +228,7 @@ test('gate promotes fs.linkSync heuristic to blocking in PRE_PUSH and CI only', 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.cpSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.cpSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsCpSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-cp-sync.ast',
@@ -243,7 +243,7 @@ test('gate promotes fs.cpSync heuristic to blocking in PRE_PUSH and CI only', ()
     [fsCpSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -259,7 +259,7 @@ test('gate promotes fs.cpSync heuristic to blocking in PRE_PUSH and CI only', ()
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.openSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.openSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsOpenSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-open-sync.ast',
@@ -274,7 +274,7 @@ test('gate promotes fs.openSync heuristic to blocking in PRE_PUSH and CI only', 
     [fsOpenSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -290,7 +290,7 @@ test('gate promotes fs.openSync heuristic to blocking in PRE_PUSH and CI only', 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.opendirSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.opendirSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsOpendirSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-opendir-sync.ast',
@@ -305,7 +305,7 @@ test('gate promotes fs.opendirSync heuristic to blocking in PRE_PUSH and CI only
     [fsOpendirSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -321,7 +321,7 @@ test('gate promotes fs.opendirSync heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.mkdtempSync heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.mkdtempSync heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsMkdtempSyncFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-mkdtemp-sync.ast',
@@ -336,7 +336,7 @@ test('gate promotes fs.mkdtempSync heuristic to blocking in PRE_PUSH and CI only
     [fsMkdtempSyncFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-third-callback-fs.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-third-callback-fs.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush,
 } from './stagePoliciesFixtures';
 
-test('gate promotes fs.mkdtemp callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.mkdtemp callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsMkdtempCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-mkdtemp-callback.ast',
@@ -25,7 +25,7 @@ test('gate promotes fs.mkdtemp callback heuristic to blocking in PRE_PUSH and CI
     [fsMkdtempCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes fs.mkdtemp callback heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.opendir callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.opendir callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsOpendirCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-opendir-callback.ast',
@@ -57,7 +57,7 @@ test('gate promotes fs.opendir callback heuristic to blocking in PRE_PUSH and CI
     [fsOpendirCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes fs.opendir callback heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.open callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.open callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsOpenCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-open-callback.ast',
@@ -89,7 +89,7 @@ test('gate promotes fs.open callback heuristic to blocking in PRE_PUSH and CI on
     [fsOpenCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes fs.open callback heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.cp callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.cp callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsCpCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-cp-callback.ast',
@@ -121,7 +121,7 @@ test('gate promotes fs.cp callback heuristic to blocking in PRE_PUSH and CI only
     [fsCpCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes fs.cp callback heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.close callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.close callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsCloseCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-close-callback.ast',
@@ -153,7 +153,7 @@ test('gate promotes fs.close callback heuristic to blocking in PRE_PUSH and CI o
     [fsCloseCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fs.close callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.read callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.read callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-read-callback.ast',
@@ -185,7 +185,7 @@ test('gate promotes fs.read callback heuristic to blocking in PRE_PUSH and CI on
     [fsReadCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes fs.read callback heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readv callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readv callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadvCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-readv-callback.ast',
@@ -217,7 +217,7 @@ test('gate promotes fs.readv callback heuristic to blocking in PRE_PUSH and CI o
     [fsReadvCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes fs.readv callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.writev callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.writev callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWritevCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-writev-callback.ast',
@@ -249,7 +249,7 @@ test('gate promotes fs.writev callback heuristic to blocking in PRE_PUSH and CI 
     [fsWritevCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -266,7 +266,7 @@ test('gate promotes fs.writev callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.write callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.write callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWriteCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-write-callback.ast',
@@ -281,7 +281,7 @@ test('gate promotes fs.write callback heuristic to blocking in PRE_PUSH and CI o
     [fsWriteCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -298,7 +298,7 @@ test('gate promotes fs.write callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fsync callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fsync callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFsyncCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fsync-callback.ast',
@@ -313,7 +313,7 @@ test('gate promotes fs.fsync callback heuristic to blocking in PRE_PUSH and CI o
     [fsFsyncCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -330,7 +330,7 @@ test('gate promotes fs.fsync callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fdatasync callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fdatasync callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFdatasyncCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fdatasync-callback.ast',
@@ -345,7 +345,7 @@ test('gate promotes fs.fdatasync callback heuristic to blocking in PRE_PUSH and 
     [fsFdatasyncCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -362,7 +362,7 @@ test('gate promotes fs.fdatasync callback heuristic to blocking in PRE_PUSH and 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fchown callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fchown callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFchownCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fchown-callback.ast',
@@ -377,7 +377,7 @@ test('gate promotes fs.fchown callback heuristic to blocking in PRE_PUSH and CI 
     [fsFchownCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -394,7 +394,7 @@ test('gate promotes fs.fchown callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.fchmod callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fchmod callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFchmodCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fchmod-callback.ast',
@@ -409,7 +409,7 @@ test('gate promotes fs.fchmod callback heuristic to blocking in PRE_PUSH and CI 
     [fsFchmodCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-third-callback-io-part2.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-third-callback-io-part2.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush,
 } from './stagePoliciesFixtures';
 
-test('gate promotes fs.copyFile callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.copyFile callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsCopyFileCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-copy-file-callback.ast',
@@ -25,7 +25,7 @@ test('gate promotes fs.copyFile callback heuristic to blocking in PRE_PUSH and C
     [fsCopyFileCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes fs.copyFile callback heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.stat callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.stat callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsStatCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-stat-callback.ast',
@@ -57,7 +57,7 @@ test('gate promotes fs.stat callback heuristic to blocking in PRE_PUSH and CI on
     [fsStatCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes fs.stat callback heuristic to blocking in PRE_PUSH and CI on
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.statfs callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.statfs callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsStatfsCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-statfs-callback.ast',
@@ -89,7 +89,7 @@ test('gate promotes fs.statfs callback heuristic to blocking in PRE_PUSH and CI 
     [fsStatfsCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes fs.statfs callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.lstat callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.lstat callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLstatCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-lstat-callback.ast',
@@ -121,7 +121,7 @@ test('gate promotes fs.lstat callback heuristic to blocking in PRE_PUSH and CI o
     [fsLstatCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes fs.lstat callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.realpath callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.realpath callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRealpathCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-realpath-callback.ast',
@@ -153,7 +153,7 @@ test('gate promotes fs.realpath callback heuristic to blocking in PRE_PUSH and C
     [fsRealpathCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fs.realpath callback heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.access callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.access callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsAccessCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-access-callback.ast',
@@ -185,7 +185,7 @@ test('gate promotes fs.access callback heuristic to blocking in PRE_PUSH and CI 
     [fsAccessCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes fs.access callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.chmod callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.chmod callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsChmodCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-chmod-callback.ast',
@@ -217,7 +217,7 @@ test('gate promotes fs.chmod callback heuristic to blocking in PRE_PUSH and CI o
     [fsChmodCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes fs.chmod callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.chown callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.chown callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsChownCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-chown-callback.ast',
@@ -249,7 +249,7 @@ test('gate promotes fs.chown callback heuristic to blocking in PRE_PUSH and CI o
     [fsChownCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -266,7 +266,7 @@ test('gate promotes fs.chown callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.lchown callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.lchown callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLchownCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-lchown-callback.ast',
@@ -281,7 +281,7 @@ test('gate promotes fs.lchown callback heuristic to blocking in PRE_PUSH and CI 
     [fsLchownCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -298,7 +298,7 @@ test('gate promotes fs.lchown callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.lchmod callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.lchmod callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLchmodCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-lchmod-callback.ast',
@@ -313,7 +313,7 @@ test('gate promotes fs.lchmod callback heuristic to blocking in PRE_PUSH and CI 
     [fsLchmodCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -330,7 +330,7 @@ test('gate promotes fs.lchmod callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.unlink callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.unlink callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsUnlinkCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-unlink-callback.ast',
@@ -345,7 +345,7 @@ test('gate promotes fs.unlink callback heuristic to blocking in PRE_PUSH and CI 
     [fsUnlinkCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -362,7 +362,7 @@ test('gate promotes fs.unlink callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readlink callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readlink callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadlinkCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-readlink-callback.ast',
@@ -377,7 +377,7 @@ test('gate promotes fs.readlink callback heuristic to blocking in PRE_PUSH and C
     [fsReadlinkCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -394,7 +394,7 @@ test('gate promotes fs.readlink callback heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.symlink callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.symlink callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsSymlinkCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-symlink-callback.ast',
@@ -409,7 +409,7 @@ test('gate promotes fs.symlink callback heuristic to blocking in PRE_PUSH and CI
     [fsSymlinkCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -426,7 +426,7 @@ test('gate promotes fs.symlink callback heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.link callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.link callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLinkCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-link-callback.ast',
@@ -441,7 +441,7 @@ test('gate promotes fs.link callback heuristic to blocking in PRE_PUSH and CI on
     [fsLinkCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-third-callback-io.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-third-callback-io.test.ts
@@ -9,7 +9,7 @@ import {
   policyForPreCommit,
   policyForPrePush,
 } from './stagePoliciesFixtures';
-test('gate promotes fs.utimes callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.utimes callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsUtimesCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-utimes-callback.ast',
@@ -24,7 +24,7 @@ test('gate promotes fs.utimes callback heuristic to blocking in PRE_PUSH and CI 
     [fsUtimesCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -41,7 +41,7 @@ test('gate promotes fs.utimes callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.watch callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.watch callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWatchCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-watch-callback.ast',
@@ -56,7 +56,7 @@ test('gate promotes fs.watch callback heuristic to blocking in PRE_PUSH and CI o
     [fsWatchCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -73,7 +73,7 @@ test('gate promotes fs.watch callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.watchFile callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.watchFile callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWatchFileCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-watch-file-callback.ast',
@@ -88,7 +88,7 @@ test('gate promotes fs.watchFile callback heuristic to blocking in PRE_PUSH and 
     [fsWatchFileCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -105,7 +105,7 @@ test('gate promotes fs.watchFile callback heuristic to blocking in PRE_PUSH and 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.unwatchFile callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.unwatchFile callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsUnwatchFileCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-unwatch-file-callback.ast',
@@ -120,7 +120,7 @@ test('gate promotes fs.unwatchFile callback heuristic to blocking in PRE_PUSH an
     [fsUnwatchFileCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -137,7 +137,7 @@ test('gate promotes fs.unwatchFile callback heuristic to blocking in PRE_PUSH an
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readFile callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readFile callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReadFileCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-read-file-callback.ast',
@@ -152,7 +152,7 @@ test('gate promotes fs.readFile callback heuristic to blocking in PRE_PUSH and C
     [fsReadFileCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -169,7 +169,7 @@ test('gate promotes fs.readFile callback heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.exists callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.exists callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsExistsCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-exists-callback.ast',
@@ -184,7 +184,7 @@ test('gate promotes fs.exists callback heuristic to blocking in PRE_PUSH and CI 
     [fsExistsCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -201,7 +201,7 @@ test('gate promotes fs.exists callback heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.writeFile callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.writeFile callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsWriteFileCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-write-file-callback.ast',
@@ -216,7 +216,7 @@ test('gate promotes fs.writeFile callback heuristic to blocking in PRE_PUSH and 
     [fsWriteFileCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -233,7 +233,7 @@ test('gate promotes fs.writeFile callback heuristic to blocking in PRE_PUSH and 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.appendFile callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.appendFile callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsAppendFileCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-append-file-callback.ast',
@@ -248,7 +248,7 @@ test('gate promotes fs.appendFile callback heuristic to blocking in PRE_PUSH and
     [fsAppendFileCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -265,7 +265,7 @@ test('gate promotes fs.appendFile callback heuristic to blocking in PRE_PUSH and
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.readdir callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.readdir callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsReaddirCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-readdir-callback.ast',
@@ -280,7 +280,7 @@ test('gate promotes fs.readdir callback heuristic to blocking in PRE_PUSH and CI
     [fsReaddirCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -297,7 +297,7 @@ test('gate promotes fs.readdir callback heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.mkdir callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.mkdir callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsMkdirCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-mkdir-callback.ast',
@@ -312,7 +312,7 @@ test('gate promotes fs.mkdir callback heuristic to blocking in PRE_PUSH and CI o
     [fsMkdirCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -329,7 +329,7 @@ test('gate promotes fs.mkdir callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.rmdir callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.rmdir callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRmdirCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-rmdir-callback.ast',
@@ -344,7 +344,7 @@ test('gate promotes fs.rmdir callback heuristic to blocking in PRE_PUSH and CI o
     [fsRmdirCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -361,7 +361,7 @@ test('gate promotes fs.rmdir callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.rm callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.rm callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRmCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-rm-callback.ast',
@@ -376,7 +376,7 @@ test('gate promotes fs.rm callback heuristic to blocking in PRE_PUSH and CI only
     [fsRmCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -393,7 +393,7 @@ test('gate promotes fs.rm callback heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.rename callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.rename callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsRenameCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-rename-callback.ast',
@@ -408,7 +408,7 @@ test('gate promotes fs.rename callback heuristic to blocking in PRE_PUSH and CI 
     [fsRenameCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies-promotions-third-platform-heuristics.test.ts
+++ b/integrations/gate/__tests__/stagePolicies-promotions-third-platform-heuristics.test.ts
@@ -10,7 +10,7 @@ import {
   policyForPrePush
 } from './stagePoliciesFixtures';
 
-test('gate promotes fs.fstat callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.fstat callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFstatCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-fstat-callback.ast',
@@ -25,7 +25,7 @@ test('gate promotes fs.fstat callback heuristic to blocking in PRE_PUSH and CI o
     [fsFstatCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -42,7 +42,7 @@ test('gate promotes fs.fstat callback heuristic to blocking in PRE_PUSH and CI o
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.ftruncate callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.ftruncate callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFtruncateCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-ftruncate-callback.ast',
@@ -57,7 +57,7 @@ test('gate promotes fs.ftruncate callback heuristic to blocking in PRE_PUSH and 
     [fsFtruncateCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -74,7 +74,7 @@ test('gate promotes fs.ftruncate callback heuristic to blocking in PRE_PUSH and 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.truncate callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.truncate callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsTruncateCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-truncate-callback.ast',
@@ -89,7 +89,7 @@ test('gate promotes fs.truncate callback heuristic to blocking in PRE_PUSH and C
     [fsTruncateCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -106,7 +106,7 @@ test('gate promotes fs.truncate callback heuristic to blocking in PRE_PUSH and C
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.futimes callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.futimes callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsFutimesCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-futimes-callback.ast',
@@ -121,7 +121,7 @@ test('gate promotes fs.futimes callback heuristic to blocking in PRE_PUSH and CI
     [fsFutimesCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -138,7 +138,7 @@ test('gate promotes fs.futimes callback heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes fs.lutimes callback heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes fs.lutimes callback heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const fsLutimesCallbackFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.fs-lutimes-callback.ast',
@@ -153,7 +153,7 @@ test('gate promotes fs.lutimes callback heuristic to blocking in PRE_PUSH and CI
     [fsLutimesCallbackFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -170,7 +170,7 @@ test('gate promotes fs.lutimes callback heuristic to blocking in PRE_PUSH and CI
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes debugger heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes debugger heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const debuggerFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.debugger.ast',
@@ -185,7 +185,7 @@ test('gate promotes debugger heuristic to blocking in PRE_PUSH and CI only', () 
     [debuggerFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -202,7 +202,7 @@ test('gate promotes debugger heuristic to blocking in PRE_PUSH and CI only', () 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes ios AnyView heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes ios AnyView heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const anyViewFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ios.anyview.ast',
@@ -217,7 +217,7 @@ test('gate promotes ios AnyView heuristic to blocking in PRE_PUSH and CI only', 
     [anyViewFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -234,7 +234,7 @@ test('gate promotes ios AnyView heuristic to blocking in PRE_PUSH and CI only', 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes explicit any heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes explicit any heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const explicitAnyFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.explicit-any.ast',
@@ -249,7 +249,7 @@ test('gate promotes explicit any heuristic to blocking in PRE_PUSH and CI only',
     [explicitAnyFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -266,7 +266,7 @@ test('gate promotes explicit any heuristic to blocking in PRE_PUSH and CI only',
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes iOS callback-style heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes iOS callback-style heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const callbackStyleFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ios.callback-style.ast',
@@ -281,7 +281,7 @@ test('gate promotes iOS callback-style heuristic to blocking in PRE_PUSH and CI 
     [callbackStyleFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -298,7 +298,7 @@ test('gate promotes iOS callback-style heuristic to blocking in PRE_PUSH and CI 
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes iOS force-try heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes iOS force-try heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const forceTryFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ios.force-try.ast',
@@ -313,7 +313,7 @@ test('gate promotes iOS force-try heuristic to blocking in PRE_PUSH and CI only'
     [forceTryFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -330,7 +330,7 @@ test('gate promotes iOS force-try heuristic to blocking in PRE_PUSH and CI only'
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes iOS force-cast heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes iOS force-cast heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const forceCastFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ios.force-cast.ast',
@@ -345,7 +345,7 @@ test('gate promotes iOS force-cast heuristic to blocking in PRE_PUSH and CI only
     [forceCastFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),
@@ -362,7 +362,7 @@ test('gate promotes iOS force-cast heuristic to blocking in PRE_PUSH and CI only
   assert.equal(ciDecision.outcome, 'BLOCK');
 });
 
-test('gate promotes SOLID DIP concrete-instantiation heuristic to blocking in PRE_PUSH and CI only', () => {
+test('gate promotes SOLID DIP concrete-instantiation heuristic to blocking in PRE_COMMIT, PRE_PUSH y CI', () => {
   const solidDipFact = {
     kind: 'Heuristic' as const,
     ruleId: 'heuristics.ts.solid.dip.concrete-instantiation.ast',
@@ -377,7 +377,7 @@ test('gate promotes SOLID DIP concrete-instantiation heuristic to blocking in PR
     [solidDipFact]
   );
   const preCommitDecision = evaluateGate([...preCommitFindings], policyForPreCommit());
-  assert.equal(preCommitDecision.outcome, 'PASS');
+  assert.equal(preCommitDecision.outcome, 'BLOCK');
 
   const prePushFindings = evaluateRules(
     applyHeuristicSeverityForStage(astHeuristicsRuleSet, 'PRE_PUSH'),

--- a/integrations/gate/__tests__/stagePolicies.test.ts
+++ b/integrations/gate/__tests__/stagePolicies.test.ts
@@ -30,7 +30,7 @@ test('resolvePolicyForStage applies PRE_PUSH override from skills.policy.json', 
       version: '1.0',
       defaultBundleEnabled: true,
       stages: {
-        PRE_COMMIT: { blockOnOrAbove: 'CRITICAL', warnOnOrAbove: 'ERROR' },
+        PRE_COMMIT: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
         PRE_PUSH: { blockOnOrAbove: 'CRITICAL', warnOnOrAbove: 'ERROR' },
         CI: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
       },
@@ -55,7 +55,7 @@ test('resolvePolicyForStage applies PRE_PUSH override from skills.policy.json', 
   });
 });
 
-test('applyHeuristicSeverityForStage promueve heurísticas a ERROR solo en PRE_PUSH/CI', () => {
+test('applyHeuristicSeverityForStage promueve heurísticas a ERROR en PRE_COMMIT/PRE_PUSH/CI', () => {
   const rules: RuleSet = [
     {
       id: 'heuristics.ts.eval.ast',
@@ -98,7 +98,7 @@ test('applyHeuristicSeverityForStage promueve heurísticas a ERROR solo en PRE_P
   assert.equal(promoted[0]?.severity, 'ERROR');
   assert.equal(promoted[1]?.severity, 'WARN');
   assert.equal(promoted[2]?.severity, 'WARN');
-  assert.equal(preCommit[0]?.severity, 'WARN');
+  assert.equal(preCommit[0]?.severity, 'ERROR');
   assert.equal(preCommit[1]?.severity, 'WARN');
   assert.equal(preCommit[2]?.severity, 'WARN');
   assert.equal(rules[0]?.severity, 'WARN');

--- a/integrations/gate/stagePolicies.ts
+++ b/integrations/gate/stagePolicies.ts
@@ -11,7 +11,11 @@ import {
 } from '../config/skillsPolicy';
 import type { SkillsStage } from '../config/skillsLock';
 
-const heuristicsPromotionStageAllowList = new Set<GateStage>(['PRE_PUSH', 'CI']);
+const heuristicsPromotionStageAllowList = new Set<GateStage>([
+  'PRE_COMMIT',
+  'PRE_PUSH',
+  'CI',
+]);
 const heuristicsPromotionIgnoreSet = new Set<string>([
   'heuristics.ts.empty-catch.ast',
 ]);
@@ -93,8 +97,8 @@ const toGatePolicyRecordFromEnterpriseThresholds = (
 const defaultPolicyByStage: Record<SkillsStage, GatePolicy> = {
   PRE_COMMIT: {
     stage: 'PRE_COMMIT',
-    blockOnOrAbove: 'CRITICAL',
-    warnOnOrAbove: 'ERROR',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
   },
   PRE_PUSH: {
     stage: 'PRE_PUSH',

--- a/integrations/git/__tests__/stageRunners.test.ts
+++ b/integrations/git/__tests__/stageRunners.test.ts
@@ -59,7 +59,7 @@ const writeSkillsPolicy = (
   overrides: Partial<Record<StageName, StageThreshold>>
 ): void => {
   const defaults: Record<StageName, StageThreshold> = {
-    PRE_COMMIT: { blockOnOrAbove: 'CRITICAL', warnOnOrAbove: 'ERROR' },
+    PRE_COMMIT: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
     PRE_PUSH: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
     CI: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
   };
@@ -169,7 +169,7 @@ test('runPreCommitStage keeps default policy thresholds when skills policy is ab
     const evidence = readEvidence(repoRoot);
     assert.equal(evidence.version, '2.1');
     assert.equal(evidence.snapshot.stage, 'PRE_COMMIT');
-    assert.equal(evidence.snapshot.outcome, 'PASS');
+    assert.equal(evidence.snapshot.outcome, 'WARN');
     assert.equal(
       evidence.snapshot.findings.some(
         (finding) => finding.ruleId === 'backend.avoid-explicit-any'

--- a/integrations/git/evaluateStagedIOS.ts
+++ b/integrations/git/evaluateStagedIOS.ts
@@ -110,8 +110,8 @@ export function evaluateStagedIOS(params?: {
     params?.policy ??
     {
       stage: params?.stage ?? 'PRE_COMMIT',
-      blockOnOrAbove: 'CRITICAL',
-      warnOnOrAbove: 'ERROR',
+      blockOnOrAbove: 'ERROR',
+      warnOnOrAbove: 'WARN',
     };
 
   const facts = createFacts(changes);

--- a/scripts/__tests__/framework-menu-gate-lib.test.ts
+++ b/scripts/__tests__/framework-menu-gate-lib.test.ts
@@ -38,7 +38,12 @@ test('runRepoGateSilent no inyecta sdd.policy.blocked en modo auditoria de menu'
       const ruleIds = findings.map((finding) => finding.ruleId ?? '');
 
       assert.equal(ruleIds.includes('sdd.policy.blocked'), false);
-      assert.equal(ruleIds.includes('heuristics.ts.console-log.ast'), true);
+      assert.equal(
+        ruleIds.includes('skills.backend.no-console-log') ||
+          ruleIds.includes('skills.frontend.no-console-log') ||
+          ruleIds.includes('heuristics.ts.console-log.ast'),
+        true
+      );
     } finally {
       process.chdir(previousCwd);
     }


### PR DESCRIPTION
## Summary
- merge completed cycle ALL_SKILLS_AST_ENFORCEMENT into main
- includes skills AUTO mapping hardening, dynamic file scope, stage parity checks and full-repo audit report refresh

## Validation
- npm run test:stage-gates
- npm run typecheck

## Tracking
- docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md
- docs/REFRACTOR_PROGRESS.md
- docs/FULL_REPO_RULES_AUDIT_REPORT.md