### PR TITLE
chore: sync cycle closeout docs to main

### DIFF
--- a/docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md
+++ b/docs/ALL_SKILLS_AST_ENFORCEMENT_CYCLE.md
@@ -2,7 +2,7 @@
 
 Plan operativo unico para asegurar que Pumuki aplique SIEMPRE todas las skills del core con detectores AST reales, sin fallback declarativo silencioso.
 
-Estado del plan: `ACTIVO`
+Estado del plan: `CERRADO`
 
 ## Leyenda
 - ✅ Hecho
@@ -48,7 +48,11 @@ Garantizar que todas las reglas derivadas de skills se apliquen por plataforma y
 - ✅ F4.T1 RED/GREEN/REFACTOR de suites `skillsRuleSet`, `runPlatformGateEvaluation`, `runPlatformGate`.
 - ✅ F4.T2 Validacion funcional en menu opcion `1` y evidencia runtime con coverage consistente.
 - ✅ F4.T3 Auditoria full-repo de Pumuki con skills activas y reporte por severidad.
-- 🚧 F4.T4 Cierre Git Flow end-to-end (`feature -> develop -> main`) con tracker final actualizado.
+- ✅ F4.T4 Cierre Git Flow end-to-end (`feature -> develop -> main`) con tracker final actualizado.
+
+## Cierre del ciclo
+- Merge `feature -> develop`: PR `#346`
+- Merge `develop -> main`: PR `#347` (admin merge por policy de rama)
 
 ## Politica cerrada del ciclo
 - No se permite una regla de skill `AUTO` sin detector AST.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -141,10 +141,11 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F4.T1` completada en `ALL_SKILLS_AST_ENFORCEMENT`: TDD integral de `skillsRuleSet`, `runPlatformGateEvaluation` y `runPlatformGate` en verde.
 - ✅ `F4.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: validacion funcional de menu opcion `1` ejecutada con evidencia runtime consistente (`active=409`, `evaluated=409`, `unevaluated=0`, `coverage_ratio=1`).
 - ✅ `F4.T3` completada en `ALL_SKILLS_AST_ENFORCEMENT`: auditoria full-repo publicada en `docs/FULL_REPO_RULES_AUDIT_REPORT.md` con severidad actualizada (`ERROR/HIGH=3`, gate `BLOCKED`).
+- ✅ `F4.T4` completada en `ALL_SKILLS_AST_ENFORCEMENT`: cierre Git Flow ejecutado end-to-end (PR `#346` `feature -> develop`, PR `#347` `develop -> main`).
 - ⏳ Post-cierre anterior pendiente: exponer `PRE_WRITE` de forma visible en la matriz de diagnostico del menu sin romper contratos existentes.
 - ✅ `F0.T2` completada en `ALL_SKILLS_AST_ENFORCEMENT`: tracker sincronizado y tarea activa unica garantizada.
-- 🚧 Ciclo `ALL_SKILLS_AST_ENFORCEMENT` en ejecucion: `F4.T4` cierre Git Flow end-to-end (`feature -> develop -> main`).
-- Estado activo: ciclo `ALL_SKILLS_AST_ENFORCEMENT` en curso.
+- ✅ Ciclo `ALL_SKILLS_AST_ENFORCEMENT` cerrado con trazabilidad completa de reglas, evidencia y merge a `main`.
+- Estado activo: ciclo `ALL_SKILLS_AST_ENFORCEMENT` cerrado.
 
 ## Siguiente paso operativo
-- ⏳ Ejecutar cierre de PRs y merge secuencial (`feature -> develop -> main`) con verificacion final de ramas.
+- ⏳ Retomar post-cierre previo: exponer `PRE_WRITE` de forma visible en la matriz de diagnostico del menu sin romper contratos existentes.


### PR DESCRIPTION
## Summary
- propagate ALL_SKILLS_AST_ENFORCEMENT cycle closeout to main
- mark F4.T4 complete and cycle status CERRADO in tracking docs

## PR lineage
- #348 (feature/all-skills-cycle-closeout -> develop)