### PR TITLE
docs: close enterprise AST superiority tracking

### DIFF
--- a/docs/ENTERPRISE_AST_DETECTION_SUPERIORITY_CYCLE.md
+++ b/docs/ENTERPRISE_AST_DETECTION_SUPERIORITY_CYCLE.md
@@ -2,7 +2,7 @@
 
 Plan operativo unico para llevar Pumuki a deteccion enterprise de violaciones superando siempre a legacy y aplicando TODAS las skills sin excepcion.
 
-Estado del plan: `ACTIVO`
+Estado del plan: `CERRADO`
 
 ## Leyenda
 - ✅ Hecho
@@ -51,4 +51,9 @@ Garantizar que Pumuki aplique siempre TODAS las skills (core + custom de develop
 - ✅ F5.T1 Completar TDD RED/GREEN/REFACTOR de los cambios del motor.
 - ✅ F5.T2 Ejecutar validacion funcional (gate, menu, evidencia, stages) y revisar salida visual.
 - ✅ F5.T3 Actualizar documentacion de uso/arquitectura/contratos.
-- 🚧 F5.T4 Cierre Git Flow end-to-end (PR a `develop`, merge, sync `develop -> main`).
+- ✅ F5.T4 Cierre Git Flow end-to-end (PR `#350` a `develop`, merge, sync `develop -> main` con PR `#351`).
+
+## Cierre del ciclo
+- ✅ Objetivo cumplido: enforcement ejecutable de skills `AUTO`, SDD estricto visible por stage y trazabilidad de cobertura con reglas no soportadas.
+- ✅ Dominancia sobre baseline legacy documentada en `docs/LEGACY_PARITY_REPORT.md`.
+- ✅ Flujo Git completado: `feature -> develop -> main`.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -166,8 +166,9 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F5.T1` completada en `ENTERPRISE_AST_DETECTION_SUPERIORITY`: TDD RED/GREEN/REFACTOR completado en motor/config/gate.
 - ✅ `F5.T2` completada en `ENTERPRISE_AST_DETECTION_SUPERIORITY`: validacion funcional/menu/evidencia en verde.
 - ✅ `F5.T3` completada en `ENTERPRISE_AST_DETECTION_SUPERIORITY`: documentacion enterprise sincronizada (`README`, `USAGE`, `API_REFERENCE`, `evidence-v2.1`).
-- 🚧 `F5.T4` en construccion en `ENTERPRISE_AST_DETECTION_SUPERIORITY`: cierre Git Flow end-to-end (`feature -> develop -> main`).
-- Estado activo: ciclo `ENTERPRISE_AST_DETECTION_SUPERIORITY` en ejecucion.
+- ✅ `F5.T4` completada en `ENTERPRISE_AST_DETECTION_SUPERIORITY`: cierre Git Flow end-to-end (`feature -> develop` PR `#350`, `develop -> main` PR `#351`).
+- ✅ Ciclo `ENTERPRISE_AST_DETECTION_SUPERIORITY` cerrado con verificacion tecnica, funcional y visual en verde.
+- Estado activo: sin tareas en construccion (ciclo cerrado).
 
 ## Siguiente paso operativo
-- ⏳ Completar `F5.T4`: cerrar PR `feature -> develop` y PR `develop -> main`, y dejar ramas sincronizadas.
+- ⏳ Definir proximo ciclo activo y reabrir seguimiento con una unica tarea `🚧`.


### PR DESCRIPTION
## Summary\n- propagate cycle closeout docs from develop to main\n- keep tracker and cycle document aligned after PR #350/#351\n\n## Scope\n- documentation only