### PR TITLE
chore: close forensic recovery cycle docs on main

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -186,8 +186,9 @@ Estado operativo consolidado del repositorio y del ciclo activo.
 - ✅ `F4.T3` completada en `SKILLS_ENGINE_FORENSIC_RECOVERY`: verificación visual runtime de menú consumer/advanced v2 con severidad enterprise+legacy.
 - ✅ `F5.T1` completada en `SKILLS_ENGINE_FORENSIC_RECOVERY`: documentación sincronizada (`README`, `docs/USAGE.md`, `docs/API_REFERENCE.md`, `docs/evidence-v2.1.md`).
 - ✅ `F5.T2` completada en `SKILLS_ENGINE_FORENSIC_RECOVERY`: informe reproducible publicado en `docs/SKILLS_ENGINE_FORENSIC_COMPLIANCE_REPORT.md`.
-- 🚧 `F5.T3` en construccion en `SKILLS_ENGINE_FORENSIC_RECOVERY`: cierre Git Flow end-to-end (`feature -> develop -> main`).
-- Estado activo: ciclo `SKILLS_ENGINE_FORENSIC_RECOVERY` en ejecucion.
+- ✅ `F5.T3` completada en `SKILLS_ENGINE_FORENSIC_RECOVERY`: cierre Git Flow end-to-end (`feature -> develop` PR `#354`, `develop -> main` PR `#355`).
+- ✅ Ciclo `SKILLS_ENGINE_FORENSIC_RECOVERY` cerrado con validación técnica, funcional y visual en verde.
+- Estado activo: sin ciclo en construcción.
 
 ## Siguiente paso operativo
-- ⏳ Ejecutar cierre de ciclo: abrir PR a `develop`, merge y sincronizar `develop -> main`.
+- ⏳ Definir próximo ciclo operativo y crear su plan de fase con una única tarea activa.

--- a/docs/SKILLS_ENGINE_FORENSIC_RECOVERY_CYCLE.md
+++ b/docs/SKILLS_ENGINE_FORENSIC_RECOVERY_CYCLE.md
@@ -2,7 +2,7 @@
 
 Plan operativo para recuperar el motor de skills con analisis forense previo, eliminacion de regresiones y contrato enterprise estable.
 
-Estado del plan: `ACTIVO`
+Estado del plan: `CERRADO`
 
 ## Leyenda
 - ✅ Hecho
@@ -49,4 +49,4 @@ Restaurar el comportamiento enterprise del motor para que audite skills sin caja
 ## Fase 5 - Cierre de ciclo
 - ✅ F5.T1 Actualizar documentacion (`README`, `USAGE`, `API_REFERENCE`, `evidence-v2.1`).
 - ✅ F5.T2 Generar informe final de cumplimiento con resultados reproducibles.
-- 🚧 F5.T3 Cierre Git Flow end-to-end (PR a `develop`, merge, sync `develop -> main`).
+- ✅ F5.T3 Cierre Git Flow end-to-end (PR a `develop`, merge, sync `develop -> main`).


### PR DESCRIPTION
## Summary\n- mark SKILLS_ENGINE_FORENSIC_RECOVERY cycle as closed in cycle plan and progress tracker\n- align final tracker state after merges #354 and #355\n\n## Validation\n- docs-only closure update\n