### PR TITLE
feat: recover enterprise detection traceability and cycle closure

### DIFF
--- a/core/facts/detectors/browser/index.test.ts
+++ b/core/facts/detectors/browser/index.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  findDocumentWriteCallLines,
+  findInnerHtmlAssignmentLines,
+  findInsertAdjacentHtmlCallLines,
   hasDocumentWriteCall,
   hasInnerHtmlAssignment,
   hasInsertAdjacentHtmlCall,
@@ -128,4 +131,49 @@ test('hasInsertAdjacentHtmlCall no detecta metodos distintos', () => {
   };
 
   assert.equal(hasInsertAdjacentHtmlCall(ast), false);
+});
+
+test('find*Lines de browser retornan lineas de coincidencia', () => {
+  const ast = {
+    type: 'Program',
+    body: [
+      {
+        type: 'AssignmentExpression',
+        loc: { start: { line: 6 } },
+        left: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'element' },
+          property: { type: 'Identifier', name: 'innerHTML' },
+        },
+        right: { type: 'Identifier', name: 'payload' },
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 10 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'document' },
+          property: { type: 'Identifier', name: 'write' },
+        },
+        arguments: [],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 14 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'target' },
+          property: { type: 'Identifier', name: 'insertAdjacentHTML' },
+        },
+        arguments: [],
+      },
+    ],
+  };
+
+  assert.deepEqual(findInnerHtmlAssignmentLines(ast), [6]);
+  assert.deepEqual(findDocumentWriteCallLines(ast), [10]);
+  assert.deepEqual(findInsertAdjacentHtmlCallLines(ast), [14]);
 });

--- a/core/facts/detectors/browser/index.ts
+++ b/core/facts/detectors/browser/index.ts
@@ -1,67 +1,85 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
+
+const isInnerHtmlAssignmentNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'AssignmentExpression') {
+    return false;
+  }
+  const left = value.left;
+  if (!isObject(left) || left.type !== 'MemberExpression') {
+    return false;
+  }
+  const propertyNode = left.property;
+  if (!isObject(propertyNode)) {
+    return false;
+  }
+  if (left.computed === true) {
+    return propertyNode.type === 'StringLiteral' && propertyNode.value === 'innerHTML';
+  }
+  return propertyNode.type === 'Identifier' && propertyNode.name === 'innerHTML';
+};
+
+const isDocumentWriteCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  return (
+    isObject(objectNode) &&
+    objectNode.type === 'Identifier' &&
+    objectNode.name === 'document' &&
+    isObject(propertyNode) &&
+    propertyNode.type === 'Identifier' &&
+    propertyNode.name === 'write'
+  );
+};
+
+const isInsertAdjacentHtmlCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression') {
+    return false;
+  }
+
+  const propertyNode = callee.property;
+  if (!isObject(propertyNode)) {
+    return false;
+  }
+  if (callee.computed === true) {
+    return propertyNode.type === 'StringLiteral' && propertyNode.value === 'insertAdjacentHTML';
+  }
+  return propertyNode.type === 'Identifier' && propertyNode.name === 'insertAdjacentHTML';
+};
 
 export const hasInnerHtmlAssignment = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'AssignmentExpression') {
-      return false;
-    }
-    const left = value.left;
-    if (!isObject(left) || left.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = left.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (left.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'innerHTML';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'innerHTML';
-  });
+  return hasNode(node, isInnerHtmlAssignmentNode);
+};
+
+export const findInnerHtmlAssignmentLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isInnerHtmlAssignmentNode);
 };
 
 export const hasDocumentWriteCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isDocumentWriteCallNode);
+};
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    return (
-      isObject(objectNode) &&
-      objectNode.type === 'Identifier' &&
-      objectNode.name === 'document' &&
-      isObject(propertyNode) &&
-      propertyNode.type === 'Identifier' &&
-      propertyNode.name === 'write'
-    );
-  });
+export const findDocumentWriteCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isDocumentWriteCallNode);
 };
 
 export const hasInsertAdjacentHtmlCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isInsertAdjacentHtmlCallNode);
+};
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'insertAdjacentHTML';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'insertAdjacentHTML';
-  });
+export const findInsertAdjacentHtmlCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isInsertAdjacentHtmlCallNode);
 };

--- a/core/facts/detectors/process/core.ts
+++ b/core/facts/detectors/process/core.ts
@@ -1,120 +1,147 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
+
+const isProcessExitCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  return (
+    isObject(objectNode) &&
+    objectNode.type === 'Identifier' &&
+    objectNode.name === 'process' &&
+    isObject(propertyNode) &&
+    propertyNode.type === 'Identifier' &&
+    propertyNode.name === 'exit'
+  );
+};
+
+const isChildProcessImportNode = (value: Record<string, unknown>): boolean => {
+  if (value.type === 'ImportDeclaration') {
+    const source = value.source;
+    return (
+      isObject(source) &&
+      ((source.type === 'StringLiteral' && source.value === 'child_process') ||
+        (source.type === 'Literal' && source.value === 'child_process'))
+    );
+  }
+
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'Identifier' || callee.name !== 'require') {
+    return false;
+  }
+  const args = value.arguments as unknown[];
+  const firstArg = Array.isArray(args) ? args[0] : undefined;
+  return (
+    isObject(firstArg) &&
+    ((firstArg.type === 'StringLiteral' && firstArg.value === 'child_process') ||
+      (firstArg.type === 'Literal' && firstArg.value === 'child_process'))
+  );
+};
+
+const isProcessEnvMutationNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'AssignmentExpression') {
+    return false;
+  }
+  const left = value.left;
+  if (!isObject(left) || left.type !== 'MemberExpression') {
+    return false;
+  }
+  const outerObjectNode = left.object;
+  if (!isObject(outerObjectNode) || outerObjectNode.type !== 'MemberExpression') {
+    return false;
+  }
+  const processNode = outerObjectNode.object;
+  const envNode = outerObjectNode.property;
+  return (
+    isObject(processNode) &&
+    processNode.type === 'Identifier' &&
+    processNode.name === 'process' &&
+    isObject(envNode) &&
+    envNode.type === 'Identifier' &&
+    envNode.name === 'env'
+  );
+};
+
+const isExecSyncCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+  const callee = value.callee;
+  if (!isObject(callee)) {
+    return false;
+  }
+
+  if (callee.type === 'MemberExpression' && !callee.computed) {
+    const property = callee.property;
+    return isObject(property) && property.type === 'Identifier' && property.name === 'execSync';
+  }
+
+  return callee.type === 'Identifier' && callee.name === 'execSync';
+};
+
+const isExecCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+  const callee = value.callee;
+  if (!isObject(callee)) {
+    return false;
+  }
+
+  if (callee.type === 'MemberExpression' && !callee.computed) {
+    const property = callee.property;
+    return isObject(property) && property.type === 'Identifier' && property.name === 'exec';
+  }
+
+  return callee.type === 'Identifier' && callee.name === 'exec';
+};
 
 export const hasProcessExitCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isProcessExitCallNode);
+};
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    return (
-      isObject(objectNode) &&
-      objectNode.type === 'Identifier' &&
-      objectNode.name === 'process' &&
-      isObject(propertyNode) &&
-      propertyNode.type === 'Identifier' &&
-      propertyNode.name === 'exit'
-    );
-  });
+export const findProcessExitCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isProcessExitCallNode);
 };
 
 export const hasChildProcessImport = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type === 'ImportDeclaration') {
-      const source = value.source;
-      return (
-        isObject(source) &&
-        ((source.type === 'StringLiteral' && source.value === 'child_process') ||
-          (source.type === 'Literal' && source.value === 'child_process'))
-      );
-    }
+  return hasNode(node, isChildProcessImportNode);
+};
 
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'Identifier' || callee.name !== 'require') {
-      return false;
-    }
-    const args = value.arguments as unknown[];
-    const firstArg = Array.isArray(args) ? args[0] : undefined;
-    return (
-      isObject(firstArg) &&
-      ((firstArg.type === 'StringLiteral' && firstArg.value === 'child_process') ||
-        (firstArg.type === 'Literal' && firstArg.value === 'child_process'))
-    );
-  });
+export const findChildProcessImportLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isChildProcessImportNode);
 };
 
 export const hasProcessEnvMutation = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'AssignmentExpression') {
-      return false;
-    }
-    const left = value.left;
-    if (!isObject(left) || left.type !== 'MemberExpression') {
-      return false;
-    }
-    const outerObjectNode = left.object;
-    if (!isObject(outerObjectNode) || outerObjectNode.type !== 'MemberExpression') {
-      return false;
-    }
-    const processNode = outerObjectNode.object;
-    const envNode = outerObjectNode.property;
-    return (
-      isObject(processNode) &&
-      processNode.type === 'Identifier' &&
-      processNode.name === 'process' &&
-      isObject(envNode) &&
-      envNode.type === 'Identifier' &&
-      envNode.name === 'env'
-    );
-  });
+  return hasNode(node, isProcessEnvMutationNode);
+};
+
+export const findProcessEnvMutationLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isProcessEnvMutationNode);
 };
 
 export const hasExecSyncCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-    const callee = value.callee;
-    if (!isObject(callee)) {
-      return false;
-    }
+  return hasNode(node, isExecSyncCallNode);
+};
 
-    // child_process.execSync() or execSync()
-    if (callee.type === 'MemberExpression' && !callee.computed) {
-      const property = callee.property;
-      return isObject(property) && property.type === 'Identifier' && property.name === 'execSync';
-    }
-
-    return callee.type === 'Identifier' && callee.name === 'execSync';
-  });
+export const findExecSyncCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isExecSyncCallNode);
 };
 
 export const hasExecCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-    const callee = value.callee;
-    if (!isObject(callee)) {
-      return false;
-    }
-
-    // child_process.exec() or exec()
-    if (callee.type === 'MemberExpression' && !callee.computed) {
-      const property = callee.property;
-      return isObject(property) && property.type === 'Identifier' && property.name === 'exec';
-    }
-
-    return callee.type === 'Identifier' && callee.name === 'exec';
-  });
+  return hasNode(node, isExecCallNode);
 };
 
+export const findExecCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isExecCallNode);
+};

--- a/core/facts/detectors/process/shell.ts
+++ b/core/facts/detectors/process/shell.ts
@@ -1,170 +1,184 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
+
+const targetChildProcessCalls = new Set(['spawn', 'spawnSync', 'execFile', 'execFileSync']);
+
+const isDynamicCommandArgument = (candidate: unknown): boolean => {
+  if (!isObject(candidate)) {
+    return true;
+  }
+  if (candidate.type === 'StringLiteral') {
+    return false;
+  }
+  if (
+    candidate.type === 'TemplateLiteral' &&
+    Array.isArray(candidate.expressions) &&
+    candidate.expressions.length === 0
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const isStaticStringLike = (candidate: unknown): boolean => {
+  if (!isObject(candidate)) {
+    return false;
+  }
+  if (candidate.type === 'StringLiteral') {
+    return true;
+  }
+  if (
+    candidate.type === 'TemplateLiteral' &&
+    Array.isArray(candidate.expressions) &&
+    candidate.expressions.length === 0
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const hasShellTrueOption = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'ObjectProperty') {
+      return false;
+    }
+    const keyNode = value.key;
+    const valueNode = value.value;
+    const keyMatches =
+      (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'shell') ||
+      (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'shell');
+    return keyMatches && isObject(valueNode) && valueNode.type === 'BooleanLiteral' && valueNode.value === true;
+  });
+};
+
+const isTargetChildProcessCall = (callee: unknown): boolean => {
+  if (isObject(callee) && callee.type === 'Identifier') {
+    return targetChildProcessCalls.has(callee.name as string);
+  }
+  if (!isObject(callee) || callee.type !== 'MemberExpression') {
+    return false;
+  }
+  const propertyNode = callee.property;
+  if (!isObject(propertyNode)) {
+    return false;
+  }
+  if (callee.computed === true) {
+    return propertyNode.type === 'StringLiteral' && targetChildProcessCalls.has(propertyNode.value as string);
+  }
+  return propertyNode.type === 'Identifier' && targetChildProcessCalls.has(propertyNode.name as string);
+};
+
+const isExecLikeCall = (callee: unknown): boolean => {
+  if (isObject(callee) && callee.type === 'Identifier') {
+    return callee.name === 'exec' || callee.name === 'execSync';
+  }
+  if (!isObject(callee) || callee.type !== 'MemberExpression') {
+    return false;
+  }
+  const propertyNode = callee.property;
+  if (!isObject(propertyNode)) {
+    return false;
+  }
+  if (callee.computed === true) {
+    return propertyNode.type === 'StringLiteral' && (propertyNode.value === 'exec' || propertyNode.value === 'execSync');
+  }
+  return propertyNode.type === 'Identifier' && (propertyNode.name === 'exec' || propertyNode.name === 'execSync');
+};
+
+const isExecFileCall = (callee: unknown): boolean => {
+  if (isObject(callee) && callee.type === 'Identifier') {
+    return callee.name === 'execFile' || callee.name === 'execFileSync';
+  }
+  if (!isObject(callee) || callee.type !== 'MemberExpression') {
+    return false;
+  }
+  const propertyNode = callee.property;
+  if (!isObject(propertyNode)) {
+    return false;
+  }
+  if (callee.computed === true) {
+    return propertyNode.type === 'StringLiteral' && (propertyNode.value === 'execFile' || propertyNode.value === 'execFileSync');
+  }
+  return propertyNode.type === 'Identifier' && (propertyNode.name === 'execFile' || propertyNode.name === 'execFileSync');
+};
+
+const isTrustedArgsArrayLiteral = (candidate: unknown): boolean => {
+  if (!isObject(candidate) || candidate.type !== 'ArrayExpression' || !Array.isArray(candidate.elements)) {
+    return false;
+  }
+  return candidate.elements.every((element) => isStaticStringLike(element));
+};
+
+const isDynamicShellInvocationCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  if (!isExecLikeCall(value.callee)) {
+    return false;
+  }
+
+  const args = value.arguments;
+  if (!Array.isArray(args) || args.length === 0) {
+    return false;
+  }
+  return isDynamicCommandArgument(args[0]);
+};
+
+const isChildProcessShellTrueCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+  if (!isTargetChildProcessCall(value.callee)) {
+    return false;
+  }
+  const args = value.arguments;
+  if (!Array.isArray(args) || args.length === 0) {
+    return false;
+  }
+  return args.some((arg) => hasShellTrueOption(arg));
+};
+
+const isExecFileUntrustedArgsCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  if (!isExecFileCall(value.callee)) {
+    return false;
+  }
+
+  const args = value.arguments;
+  if (!Array.isArray(args) || args.length < 2) {
+    return false;
+  }
+  const fileArg = args[0];
+  const commandArgs = args[1];
+  if (!isStaticStringLike(fileArg)) {
+    return false;
+  }
+  return !isTrustedArgsArrayLiteral(commandArgs);
+};
 
 export const hasDynamicShellInvocationCall = (node: unknown): boolean => {
-  const isDynamicCommandArgument = (candidate: unknown): boolean => {
-    if (!isObject(candidate)) {
-      return true;
-    }
-    if (candidate.type === 'StringLiteral') {
-      return false;
-    }
-    if (
-      candidate.type === 'TemplateLiteral' &&
-      Array.isArray(candidate.expressions) &&
-      candidate.expressions.length === 0
-    ) {
-      return false;
-    }
-    return true;
-  };
+  return hasNode(node, isDynamicShellInvocationCallNode);
+};
 
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-
-    const callee = value.callee;
-    let isExecLikeCall = false;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      isExecLikeCall = callee.name === 'exec' || callee.name === 'execSync';
-    } else if (isObject(callee) && callee.type === 'MemberExpression') {
-      const propertyNode = callee.property;
-      if (isObject(propertyNode)) {
-        if (callee.computed === true) {
-          isExecLikeCall =
-            propertyNode.type === 'StringLiteral' &&
-            (propertyNode.value === 'exec' || propertyNode.value === 'execSync');
-        } else {
-          isExecLikeCall =
-            propertyNode.type === 'Identifier' &&
-            (propertyNode.name === 'exec' || propertyNode.name === 'execSync');
-        }
-      }
-    }
-
-    if (!isExecLikeCall) {
-      return false;
-    }
-
-    const args = value.arguments;
-    if (!Array.isArray(args) || args.length === 0) {
-      return false;
-    }
-    return isDynamicCommandArgument(args[0]);
-  });
+export const findDynamicShellInvocationCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isDynamicShellInvocationCallNode);
 };
 
 export const hasChildProcessShellTrueCall = (node: unknown): boolean => {
-  const hasShellTrueOption = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'ObjectProperty') {
-        return false;
-      }
-      const keyNode = value.key;
-      const valueNode = value.value;
-      const keyMatches =
-        (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'shell') ||
-        (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'shell');
-      return keyMatches && isObject(valueNode) && valueNode.type === 'BooleanLiteral' && valueNode.value === true;
-    });
-  };
+  return hasNode(node, isChildProcessShellTrueCallNode);
+};
 
-  const isTargetCall = (callee: unknown): boolean => {
-    const targetNames = new Set(['spawn', 'spawnSync', 'execFile', 'execFileSync']);
-    if (isObject(callee) && callee.type === 'Identifier') {
-      return targetNames.has(callee.name as string);
-    }
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && targetNames.has(propertyNode.value as string);
-    }
-    return propertyNode.type === 'Identifier' && targetNames.has(propertyNode.name as string);
-  };
-
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-    if (!isTargetCall(value.callee)) {
-      return false;
-    }
-    const args = value.arguments;
-    if (!Array.isArray(args) || args.length === 0) {
-      return false;
-    }
-    return args.some((arg) => hasShellTrueOption(arg));
-  });
+export const findChildProcessShellTrueCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isChildProcessShellTrueCallNode);
 };
 
 export const hasExecFileUntrustedArgsCall = (node: unknown): boolean => {
-  const isStaticStringLike = (candidate: unknown): boolean => {
-    if (!isObject(candidate)) {
-      return false;
-    }
-    if (candidate.type === 'StringLiteral') {
-      return true;
-    }
-    if (
-      candidate.type === 'TemplateLiteral' &&
-      Array.isArray(candidate.expressions) &&
-      candidate.expressions.length === 0
-    ) {
-      return true;
-    }
-    return false;
-  };
-
-  const isTrustedArgsArrayLiteral = (candidate: unknown): boolean => {
-    if (!isObject(candidate) || candidate.type !== 'ArrayExpression' || !Array.isArray(candidate.elements)) {
-      return false;
-    }
-    return candidate.elements.every((element) => isStaticStringLike(element));
-  };
-
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-
-    const callee = value.callee;
-    let isExecFileCall = false;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      isExecFileCall = callee.name === 'execFile' || callee.name === 'execFileSync';
-    } else if (isObject(callee) && callee.type === 'MemberExpression') {
-      const propertyNode = callee.property;
-      if (isObject(propertyNode)) {
-        if (callee.computed === true) {
-          isExecFileCall =
-            propertyNode.type === 'StringLiteral' &&
-            (propertyNode.value === 'execFile' || propertyNode.value === 'execFileSync');
-        } else {
-          isExecFileCall =
-            propertyNode.type === 'Identifier' &&
-            (propertyNode.name === 'execFile' || propertyNode.name === 'execFileSync');
-        }
-      }
-    }
-
-    if (!isExecFileCall) {
-      return false;
-    }
-
-    const args = value.arguments;
-    if (!Array.isArray(args) || args.length < 2) {
-      return false;
-    }
-    const fileArg = args[0];
-    const commandArgs = args[1];
-    if (!isStaticStringLike(fileArg)) {
-      return false;
-    }
-    return !isTrustedArgsArrayLiteral(commandArgs);
-  });
+  return hasNode(node, isExecFileUntrustedArgsCallNode);
 };
 
+export const findExecFileUntrustedArgsCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isExecFileUntrustedArgsCallNode);
+};

--- a/core/facts/detectors/process/spawn.test.ts
+++ b/core/facts/detectors/process/spawn.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  findExecFileCallLines,
+  findExecFileSyncCallLines,
+  findForkCallLines,
+  findSpawnCallLines,
+  findSpawnSyncCallLines,
   hasExecFileCall,
   hasExecFileSyncCall,
   hasForkCall,
@@ -152,4 +157,48 @@ test('hasExecFileCall detecta execFile y descarta execFileSync', () => {
   assert.equal(hasExecFileCall(directAst), true);
   assert.equal(hasExecFileCall(memberAst), true);
   assert.equal(hasExecFileCall(otherAst), false);
+});
+
+test('find*Lines de spawn retornan lineas de coincidencia', () => {
+  const ast = {
+    type: 'Program',
+    body: [
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 4 } },
+        callee: { type: 'Identifier', name: 'spawnSync' },
+        arguments: [],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 8 } },
+        callee: { type: 'Identifier', name: 'spawn' },
+        arguments: [],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 12 } },
+        callee: { type: 'Identifier', name: 'fork' },
+        arguments: [],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 16 } },
+        callee: { type: 'Identifier', name: 'execFileSync' },
+        arguments: [],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 20 } },
+        callee: { type: 'Identifier', name: 'execFile' },
+        arguments: [],
+      },
+    ],
+  };
+
+  assert.deepEqual(findSpawnSyncCallLines(ast), [4]);
+  assert.deepEqual(findSpawnCallLines(ast), [8]);
+  assert.deepEqual(findForkCallLines(ast), [12]);
+  assert.deepEqual(findExecFileSyncCallLines(ast), [16]);
+  assert.deepEqual(findExecFileCallLines(ast), [20]);
 });

--- a/core/facts/detectors/process/spawn.ts
+++ b/core/facts/detectors/process/spawn.ts
@@ -1,121 +1,83 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
+
+const isCallByName = (value: Record<string, unknown>, expectedName: string): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (isObject(callee) && callee.type === 'Identifier') {
+    return callee.name === expectedName;
+  }
+  if (!isObject(callee) || callee.type !== 'MemberExpression') {
+    return false;
+  }
+  const propertyNode = callee.property;
+  if (!isObject(propertyNode)) {
+    return false;
+  }
+  if (callee.computed === true) {
+    return propertyNode.type === 'StringLiteral' && propertyNode.value === expectedName;
+  }
+  return propertyNode.type === 'Identifier' && propertyNode.name === expectedName;
+};
+
+const isSpawnSyncCallNode = (value: Record<string, unknown>): boolean => {
+  return isCallByName(value, 'spawnSync');
+};
+
+const isSpawnCallNode = (value: Record<string, unknown>): boolean => {
+  return isCallByName(value, 'spawn');
+};
+
+const isForkCallNode = (value: Record<string, unknown>): boolean => {
+  return isCallByName(value, 'fork');
+};
+
+const isExecFileSyncCallNode = (value: Record<string, unknown>): boolean => {
+  return isCallByName(value, 'execFileSync');
+};
+
+const isExecFileCallNode = (value: Record<string, unknown>): boolean => {
+  return isCallByName(value, 'execFile');
+};
 
 export const hasSpawnSyncCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isSpawnSyncCallNode);
+};
 
-    const callee = value.callee;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      return callee.name === 'spawnSync';
-    }
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'spawnSync';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'spawnSync';
-  });
+export const findSpawnSyncCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isSpawnSyncCallNode);
 };
 
 export const hasSpawnCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isSpawnCallNode);
+};
 
-    const callee = value.callee;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      return callee.name === 'spawn';
-    }
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'spawn';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'spawn';
-  });
+export const findSpawnCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isSpawnCallNode);
 };
 
 export const hasForkCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isForkCallNode);
+};
 
-    const callee = value.callee;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      return callee.name === 'fork';
-    }
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'fork';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'fork';
-  });
+export const findForkCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isForkCallNode);
 };
 
 export const hasExecFileSyncCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isExecFileSyncCallNode);
+};
 
-    const callee = value.callee;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      return callee.name === 'execFileSync';
-    }
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'execFileSync';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'execFileSync';
-  });
+export const findExecFileSyncCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isExecFileSyncCallNode);
 };
 
 export const hasExecFileCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isExecFileCallNode);
+};
 
-    const callee = value.callee;
-    if (isObject(callee) && callee.type === 'Identifier') {
-      return callee.name === 'execFile';
-    }
-    if (!isObject(callee) || callee.type !== 'MemberExpression') {
-      return false;
-    }
-    const propertyNode = callee.property;
-    if (!isObject(propertyNode)) {
-      return false;
-    }
-    if (callee.computed === true) {
-      return propertyNode.type === 'StringLiteral' && propertyNode.value === 'execFile';
-    }
-    return propertyNode.type === 'Identifier' && propertyNode.name === 'execFile';
-  });
+export const findExecFileCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isExecFileCallNode);
 };

--- a/core/facts/detectors/security/index.ts
+++ b/core/facts/detectors/security/index.ts
@@ -1,4 +1,8 @@
 export {
+  findHardcodedSecretTokenLiteralLines,
+  findInsecureTokenGenerationWithDateNowLines,
+  findInsecureTokenGenerationWithMathRandomLines,
+  findWeakTokenGenerationWithCryptoRandomUuidLines,
   hasHardcodedSecretTokenLiteral,
   hasInsecureTokenGenerationWithMathRandom,
   hasInsecureTokenGenerationWithDateNow,
@@ -6,11 +10,26 @@ export {
 } from './securityCredentials';
 
 export {
+  findBufferAllocUnsafeCallLines,
+  findBufferAllocUnsafeSlowCallLines,
+  findWeakCryptoHashCreateHashCallLines,
   hasWeakCryptoHashCreateHashCall,
   hasBufferAllocUnsafeCall,
   hasBufferAllocUnsafeSlowCall,
 } from './securityCrypto';
 
-export { hasJwtDecodeWithoutVerifyCall, hasJwtVerifyIgnoreExpirationCall, hasJwtSignWithoutExpirationCall } from './securityJwt';
+export {
+  findJwtDecodeWithoutVerifyCallLines,
+  findJwtSignWithoutExpirationCallLines,
+  findJwtVerifyIgnoreExpirationCallLines,
+  hasJwtDecodeWithoutVerifyCall,
+  hasJwtVerifyIgnoreExpirationCall,
+  hasJwtSignWithoutExpirationCall,
+} from './securityJwt';
 
-export { hasTlsRejectUnauthorizedFalseOption, hasTlsEnvRejectUnauthorizedZeroOverride } from './securityTls';
+export {
+  findTlsEnvRejectUnauthorizedZeroOverrideLines,
+  findTlsRejectUnauthorizedFalseOptionLines,
+  hasTlsRejectUnauthorizedFalseOption,
+  hasTlsEnvRejectUnauthorizedZeroOverride,
+} from './securityTls';

--- a/core/facts/detectors/security/securityCredentials.ts
+++ b/core/facts/detectors/security/securityCredentials.ts
@@ -1,31 +1,119 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
 
-export const hasHardcodedSecretTokenLiteral = (node: unknown): boolean => {
-  const sensitiveIdentifierPattern = /(secret|token|password|api[_-]?key)/i;
-  const hasStrongLiteralValue = (value: unknown): boolean => {
-    if (!isObject(value)) {
-      return false;
-    }
-    if (value.type === 'StringLiteral') {
-      return typeof value.value === 'string' && value.value.trim().length >= 12;
-    }
-    if (
-      value.type === 'TemplateLiteral' &&
-      Array.isArray(value.expressions) &&
-      value.expressions.length === 0 &&
-      Array.isArray(value.quasis) &&
-      value.quasis.length === 1
-    ) {
-      const cooked = value.quasis[0]?.value?.cooked;
-      return typeof cooked === 'string' && cooked.trim().length >= 12;
-    }
+const sensitiveIdentifierPattern = /(secret|token|password|api[_-]?key)/i;
+
+const hasStrongLiteralValue = (value: unknown): boolean => {
+  if (!isObject(value)) {
     return false;
-  };
+  }
+  if (value.type === 'StringLiteral') {
+    return typeof value.value === 'string' && value.value.trim().length >= 12;
+  }
+  if (
+    value.type === 'TemplateLiteral' &&
+    Array.isArray(value.expressions) &&
+    value.expressions.length === 0 &&
+    Array.isArray(value.quasis) &&
+    value.quasis.length === 1
+  ) {
+    const cooked = value.quasis[0]?.value?.cooked;
+    return typeof cooked === 'string' && cooked.trim().length >= 12;
+  }
+  return false;
+};
 
-  return hasNode(node, (value) => {
-    if (value.type !== 'VariableDeclarator') {
+const containsMathRandomCall = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'CallExpression') {
       return false;
     }
+    const callee = value.callee;
+    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+      return false;
+    }
+    const objectNode = callee.object;
+    const propertyNode = callee.property;
+    return (
+      isObject(objectNode) &&
+      objectNode.type === 'Identifier' &&
+      objectNode.name === 'Math' &&
+      isObject(propertyNode) &&
+      propertyNode.type === 'Identifier' &&
+      propertyNode.name === 'random'
+    );
+  });
+};
+
+const containsDateNowCall = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'CallExpression') {
+      return false;
+    }
+    const callee = value.callee;
+    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+      return false;
+    }
+    const objectNode = callee.object;
+    const propertyNode = callee.property;
+    return (
+      isObject(objectNode) &&
+      objectNode.type === 'Identifier' &&
+      objectNode.name === 'Date' &&
+      isObject(propertyNode) &&
+      propertyNode.type === 'Identifier' &&
+      propertyNode.name === 'now'
+    );
+  });
+};
+
+const containsCryptoRandomUuidCall = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'CallExpression') {
+      return false;
+    }
+
+    const callee = value.callee;
+    if (!isObject(callee)) {
+      return false;
+    }
+
+    if (callee.type === 'Identifier' && callee.name === 'randomUUID') {
+      return true;
+    }
+
+    if (callee.type !== 'MemberExpression' || callee.computed === true) {
+      return false;
+    }
+
+    const objectNode = callee.object;
+    const propertyNode = callee.property;
+    return (
+      isObject(objectNode) &&
+      objectNode.type === 'Identifier' &&
+      objectNode.name === 'crypto' &&
+      isObject(propertyNode) &&
+      propertyNode.type === 'Identifier' &&
+      propertyNode.name === 'randomUUID'
+    );
+  });
+};
+
+const isHardcodedSecretTokenLiteralNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'VariableDeclarator') {
+    return false;
+  }
+  const idNode = value.id;
+  if (!isObject(idNode) || idNode.type !== 'Identifier') {
+    return false;
+  }
+  if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
+    return false;
+  }
+  return hasStrongLiteralValue(value.init);
+};
+
+const isInsecureTokenGenerationWithMathRandomNode = (value: Record<string, unknown>): boolean => {
+  if (value.type === 'VariableDeclarator') {
     const idNode = value.id;
     if (!isObject(idNode) || idNode.type !== 'Identifier') {
       return false;
@@ -33,160 +121,94 @@ export const hasHardcodedSecretTokenLiteral = (node: unknown): boolean => {
     if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
       return false;
     }
-    return hasStrongLiteralValue(value.init);
-  });
+    return containsMathRandomCall(value.init);
+  }
+
+  if (value.type === 'AssignmentExpression') {
+    const left = value.left;
+    if (isObject(left) && left.type === 'Identifier' && sensitiveIdentifierPattern.test(left.name as string)) {
+      return containsMathRandomCall(value.right);
+    }
+    return false;
+  }
+
+  return false;
+};
+
+const isInsecureTokenGenerationWithDateNowNode = (value: Record<string, unknown>): boolean => {
+  if (value.type === 'VariableDeclarator') {
+    const idNode = value.id;
+    if (!isObject(idNode) || idNode.type !== 'Identifier') {
+      return false;
+    }
+    if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
+      return false;
+    }
+    return containsDateNowCall(value.init);
+  }
+
+  if (value.type === 'AssignmentExpression') {
+    const left = value.left;
+    if (isObject(left) && left.type === 'Identifier' && sensitiveIdentifierPattern.test(left.name as string)) {
+      return containsDateNowCall(value.right);
+    }
+    return false;
+  }
+
+  return false;
+};
+
+const isWeakTokenGenerationWithCryptoRandomUuidNode = (value: Record<string, unknown>): boolean => {
+  if (value.type === 'VariableDeclarator') {
+    const idNode = value.id;
+    if (!isObject(idNode) || idNode.type !== 'Identifier') {
+      return false;
+    }
+    if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
+      return false;
+    }
+    return containsCryptoRandomUuidCall(value.init);
+  }
+
+  if (value.type === 'AssignmentExpression') {
+    const left = value.left;
+    if (isObject(left) && left.type === 'Identifier' && sensitiveIdentifierPattern.test(left.name as string)) {
+      return containsCryptoRandomUuidCall(value.right);
+    }
+    return false;
+  }
+
+  return false;
+};
+
+export const hasHardcodedSecretTokenLiteral = (node: unknown): boolean => {
+  return hasNode(node, isHardcodedSecretTokenLiteralNode);
+};
+
+export const findHardcodedSecretTokenLiteralLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isHardcodedSecretTokenLiteralNode);
 };
 
 export const hasInsecureTokenGenerationWithMathRandom = (node: unknown): boolean => {
-  const sensitiveIdentifierPattern = /(secret|token|password|api[_-]?key)/i;
-  const containsMathRandomCall = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'CallExpression') {
-        return false;
-      }
-      const callee = value.callee;
-      if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-        return false;
-      }
-      const objectNode = callee.object;
-      const propertyNode = callee.property;
-      return (
-        isObject(objectNode) &&
-        objectNode.type === 'Identifier' &&
-        objectNode.name === 'Math' &&
-        isObject(propertyNode) &&
-        propertyNode.type === 'Identifier' &&
-        propertyNode.name === 'random'
-      );
-    });
-  };
+  return hasNode(node, isInsecureTokenGenerationWithMathRandomNode);
+};
 
-  return hasNode(node, (value) => {
-    if (value.type === 'VariableDeclarator') {
-      const idNode = value.id;
-      if (!isObject(idNode) || idNode.type !== 'Identifier') {
-        return false;
-      }
-      if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
-        return false;
-      }
-      return containsMathRandomCall(value.init);
-    }
-
-    if (value.type === 'AssignmentExpression') {
-      const left = value.left;
-      if (isObject(left) && left.type === 'Identifier' && sensitiveIdentifierPattern.test(left.name as string)) {
-        return containsMathRandomCall(value.right);
-      }
-      return false;
-    }
-
-    return false;
-  });
+export const findInsecureTokenGenerationWithMathRandomLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isInsecureTokenGenerationWithMathRandomNode);
 };
 
 export const hasInsecureTokenGenerationWithDateNow = (node: unknown): boolean => {
-  const sensitiveIdentifierPattern = /(secret|token|password|api[_-]?key)/i;
-  const containsDateNowCall = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'CallExpression') {
-        return false;
-      }
-      const callee = value.callee;
-      if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-        return false;
-      }
-      const objectNode = callee.object;
-      const propertyNode = callee.property;
-      return (
-        isObject(objectNode) &&
-        objectNode.type === 'Identifier' &&
-        objectNode.name === 'Date' &&
-        isObject(propertyNode) &&
-        propertyNode.type === 'Identifier' &&
-        propertyNode.name === 'now'
-      );
-    });
-  };
+  return hasNode(node, isInsecureTokenGenerationWithDateNowNode);
+};
 
-  return hasNode(node, (value) => {
-    if (value.type === 'VariableDeclarator') {
-      const idNode = value.id;
-      if (!isObject(idNode) || idNode.type !== 'Identifier') {
-        return false;
-      }
-      if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
-        return false;
-      }
-      return containsDateNowCall(value.init);
-    }
-
-    if (value.type === 'AssignmentExpression') {
-      const left = value.left;
-      if (isObject(left) && left.type === 'Identifier' && sensitiveIdentifierPattern.test(left.name as string)) {
-        return containsDateNowCall(value.right);
-      }
-      return false;
-    }
-
-    return false;
-  });
+export const findInsecureTokenGenerationWithDateNowLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isInsecureTokenGenerationWithDateNowNode);
 };
 
 export const hasWeakTokenGenerationWithCryptoRandomUuid = (node: unknown): boolean => {
-  const sensitiveIdentifierPattern = /(secret|token|password|api[_-]?key)/i;
-  const containsCryptoRandomUuidCall = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'CallExpression') {
-        return false;
-      }
+  return hasNode(node, isWeakTokenGenerationWithCryptoRandomUuidNode);
+};
 
-      const callee = value.callee;
-      if (!isObject(callee)) {
-        return false;
-      }
-
-      if (callee.type === 'Identifier' && callee.name === 'randomUUID') {
-        return true;
-      }
-
-      if (callee.type !== 'MemberExpression' || callee.computed === true) {
-        return false;
-      }
-
-      const objectNode = callee.object;
-      const propertyNode = callee.property;
-      return (
-        isObject(objectNode) &&
-        objectNode.type === 'Identifier' &&
-        objectNode.name === 'crypto' &&
-        isObject(propertyNode) &&
-        propertyNode.type === 'Identifier' &&
-        propertyNode.name === 'randomUUID'
-      );
-    });
-  };
-
-  return hasNode(node, (value) => {
-    if (value.type === 'VariableDeclarator') {
-      const idNode = value.id;
-      if (!isObject(idNode) || idNode.type !== 'Identifier') {
-        return false;
-      }
-      if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
-        return false;
-      }
-      return containsCryptoRandomUuidCall(value.init);
-    }
-
-    if (value.type === 'AssignmentExpression') {
-      const left = value.left;
-      if (isObject(left) && left.type === 'Identifier' && sensitiveIdentifierPattern.test(left.name as string)) {
-        return containsCryptoRandomUuidCall(value.right);
-      }
-      return false;
-    }
-
-    return false;
-  });
+export const findWeakTokenGenerationWithCryptoRandomUuidLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isWeakTokenGenerationWithCryptoRandomUuidNode);
 };

--- a/core/facts/detectors/security/securityCrypto.test.ts
+++ b/core/facts/detectors/security/securityCrypto.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  findBufferAllocUnsafeCallLines,
+  findBufferAllocUnsafeSlowCallLines,
+  findWeakCryptoHashCreateHashCallLines,
   hasBufferAllocUnsafeCall,
   hasBufferAllocUnsafeSlowCall,
   hasWeakCryptoHashCreateHashCall,
@@ -119,4 +122,49 @@ test('hasBufferAllocUnsafeSlowCall detecta Buffer.allocUnsafeSlow y descarta otr
 
   assert.equal(hasBufferAllocUnsafeSlowCall(unsafeSlowAst), true);
   assert.equal(hasBufferAllocUnsafeSlowCall(safeAst), false);
+});
+
+test('find*Lines de securityCrypto retornan lineas de coincidencia', () => {
+  const ast = {
+    type: 'Program',
+    body: [
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 3 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'crypto' },
+          property: { type: 'Identifier', name: 'createHash' },
+        },
+        arguments: [{ type: 'StringLiteral', value: 'md5' }],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 7 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'Buffer' },
+          property: { type: 'Identifier', name: 'allocUnsafe' },
+        },
+        arguments: [{ type: 'NumericLiteral', value: 16 }],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 11 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'Buffer' },
+          property: { type: 'Identifier', name: 'allocUnsafeSlow' },
+        },
+        arguments: [{ type: 'NumericLiteral', value: 16 }],
+      },
+    ],
+  };
+
+  assert.deepEqual(findWeakCryptoHashCreateHashCallLines(ast), [3]);
+  assert.deepEqual(findBufferAllocUnsafeCallLines(ast), [7]);
+  assert.deepEqual(findBufferAllocUnsafeSlowCallLines(ast), [11]);
 });

--- a/core/facts/detectors/security/securityCrypto.ts
+++ b/core/facts/detectors/security/securityCrypto.ts
@@ -1,88 +1,106 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
+
+const isWeakCryptoHashCreateHashCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  if (
+    !isObject(objectNode) ||
+    objectNode.type !== 'Identifier' ||
+    objectNode.name !== 'crypto' ||
+    !isObject(propertyNode) ||
+    propertyNode.type !== 'Identifier' ||
+    propertyNode.name !== 'createHash'
+  ) {
+    return false;
+  }
+
+  const args = value.arguments;
+  if (!Array.isArray(args) || args.length === 0) {
+    return false;
+  }
+
+  const firstArg = args[0];
+  if (!isObject(firstArg) || firstArg.type !== 'StringLiteral') {
+    return false;
+  }
+
+  const algorithm = (firstArg.value as string).toLowerCase();
+  return algorithm === 'md5' || algorithm === 'sha1';
+};
+
+const isBufferAllocUnsafeCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  return (
+    isObject(objectNode) &&
+    objectNode.type === 'Identifier' &&
+    objectNode.name === 'Buffer' &&
+    isObject(propertyNode) &&
+    propertyNode.type === 'Identifier' &&
+    propertyNode.name === 'allocUnsafe'
+  );
+};
+
+const isBufferAllocUnsafeSlowCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  return (
+    isObject(objectNode) &&
+    objectNode.type === 'Identifier' &&
+    objectNode.name === 'Buffer' &&
+    isObject(propertyNode) &&
+    propertyNode.type === 'Identifier' &&
+    propertyNode.name === 'allocUnsafeSlow'
+  );
+};
 
 export const hasWeakCryptoHashCreateHashCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isWeakCryptoHashCreateHashCallNode);
+};
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    if (
-      !isObject(objectNode) ||
-      objectNode.type !== 'Identifier' ||
-      objectNode.name !== 'crypto' ||
-      !isObject(propertyNode) ||
-      propertyNode.type !== 'Identifier' ||
-      propertyNode.name !== 'createHash'
-    ) {
-      return false;
-    }
-
-    const args = value.arguments;
-    if (!Array.isArray(args) || args.length === 0) {
-      return false;
-    }
-
-    const firstArg = args[0];
-    if (!isObject(firstArg) || firstArg.type !== 'StringLiteral') {
-      return false;
-    }
-
-    const algorithm = (firstArg.value as string).toLowerCase();
-    return algorithm === 'md5' || algorithm === 'sha1';
-  });
+export const findWeakCryptoHashCreateHashCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isWeakCryptoHashCreateHashCallNode);
 };
 
 export const hasBufferAllocUnsafeCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isBufferAllocUnsafeCallNode);
+};
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    return (
-      isObject(objectNode) &&
-      objectNode.type === 'Identifier' &&
-      objectNode.name === 'Buffer' &&
-      isObject(propertyNode) &&
-      propertyNode.type === 'Identifier' &&
-      propertyNode.name === 'allocUnsafe'
-    );
-  });
+export const findBufferAllocUnsafeCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isBufferAllocUnsafeCallNode);
 };
 
 export const hasBufferAllocUnsafeSlowCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
+  return hasNode(node, isBufferAllocUnsafeSlowCallNode);
+};
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    return (
-      isObject(objectNode) &&
-      objectNode.type === 'Identifier' &&
-      objectNode.name === 'Buffer' &&
-      isObject(propertyNode) &&
-      propertyNode.type === 'Identifier' &&
-      propertyNode.name === 'allocUnsafeSlow'
-    );
-  });
+export const findBufferAllocUnsafeSlowCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isBufferAllocUnsafeSlowCallNode);
 };

--- a/core/facts/detectors/security/securityJwt.test.ts
+++ b/core/facts/detectors/security/securityJwt.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  findJwtDecodeWithoutVerifyCallLines,
+  findJwtSignWithoutExpirationCallLines,
+  findJwtVerifyIgnoreExpirationCallLines,
   hasJwtDecodeWithoutVerifyCall,
   hasJwtSignWithoutExpirationCall,
   hasJwtVerifyIgnoreExpirationCall,
@@ -184,4 +187,68 @@ test('hasJwtSignWithoutExpirationCall detecta sign sin exp ni expiresIn', () => 
   assert.equal(hasJwtSignWithoutExpirationCall(insecureSignAst), true);
   assert.equal(hasJwtSignWithoutExpirationCall(payloadWithExpAst), false);
   assert.equal(hasJwtSignWithoutExpirationCall(optionsWithExpiresInAst), false);
+});
+
+test('find*Lines de securityJwt retornan lineas de coincidencia', () => {
+  const ast = {
+    type: 'Program',
+    body: [
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 4 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'jwt' },
+          property: { type: 'Identifier', name: 'decode' },
+        },
+        arguments: [{ type: 'Identifier', name: 'token' }],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 8 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'jsonwebtoken' },
+          property: { type: 'Identifier', name: 'verify' },
+        },
+        arguments: [
+          { type: 'Identifier', name: 'token' },
+          { type: 'Identifier', name: 'secret' },
+          {
+            type: 'ObjectExpression',
+            properties: [
+              {
+                type: 'ObjectProperty',
+                key: { type: 'Identifier', name: 'ignoreExpiration' },
+                value: { type: 'BooleanLiteral', value: true },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'CallExpression',
+        loc: { start: { line: 12 } },
+        callee: {
+          type: 'MemberExpression',
+          computed: false,
+          object: { type: 'Identifier', name: 'jwt' },
+          property: { type: 'Identifier', name: 'sign' },
+        },
+        arguments: [
+          {
+            type: 'ObjectExpression',
+            properties: [],
+          },
+          { type: 'Identifier', name: 'secret' },
+        ],
+      },
+    ],
+  };
+
+  assert.deepEqual(findJwtDecodeWithoutVerifyCallLines(ast), [4]);
+  assert.deepEqual(findJwtVerifyIgnoreExpirationCallLines(ast), [8]);
+  assert.deepEqual(findJwtSignWithoutExpirationCallLines(ast), [12]);
 });

--- a/core/facts/detectors/security/securityJwt.ts
+++ b/core/facts/detectors/security/securityJwt.ts
@@ -1,134 +1,152 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
 
-export const hasJwtDecodeWithoutVerifyCall = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
+const hasIgnoreExpirationTrueOption = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'ObjectProperty') {
       return false;
     }
 
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    const keyNode = value.key;
+    const valueNode = value.value;
+    const keyMatches =
+      (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'ignoreExpiration') ||
+      (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'ignoreExpiration');
+    return keyMatches && isObject(valueNode) && valueNode.type === 'BooleanLiteral' && valueNode.value === true;
+  });
+};
+
+const hasExpClaim = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'ObjectProperty') {
       return false;
     }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
+    const keyNode = value.key;
     return (
-      isObject(objectNode) &&
-      objectNode.type === 'Identifier' &&
-      (objectNode.name === 'jwt' || objectNode.name === 'jsonwebtoken') &&
-      isObject(propertyNode) &&
-      propertyNode.type === 'Identifier' &&
-      propertyNode.name === 'decode'
+      (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'exp') ||
+      (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'exp')
     );
   });
 };
 
-export const hasJwtVerifyIgnoreExpirationCall = (node: unknown): boolean => {
-  const hasIgnoreExpirationTrueOption = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'ObjectProperty') {
-        return false;
-      }
-
-      const keyNode = value.key;
-      const valueNode = value.value;
-      const keyMatches =
-        (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'ignoreExpiration') ||
-        (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'ignoreExpiration');
-      return keyMatches && isObject(valueNode) && valueNode.type === 'BooleanLiteral' && valueNode.value === true;
-    });
-  };
-
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
+const hasExpiresInOption = (candidate: unknown): boolean => {
+  return hasNode(candidate, (value) => {
+    if (value.type !== 'ObjectProperty') {
       return false;
     }
-
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    if (
-      !isObject(objectNode) ||
-      objectNode.type !== 'Identifier' ||
-      (objectNode.name !== 'jwt' && objectNode.name !== 'jsonwebtoken') ||
-      !isObject(propertyNode) ||
-      propertyNode.type !== 'Identifier' ||
-      propertyNode.name !== 'verify'
-    ) {
-      return false;
-    }
-
-    const args = value.arguments;
-    if (!Array.isArray(args) || args.length < 3) {
-      return false;
-    }
-
-    return hasIgnoreExpirationTrueOption(args[2]);
+    const keyNode = value.key;
+    return (
+      (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'expiresIn') ||
+      (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'expiresIn')
+    );
   });
 };
 
+const isJwtDecodeWithoutVerifyCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  return (
+    isObject(objectNode) &&
+    objectNode.type === 'Identifier' &&
+    (objectNode.name === 'jwt' || objectNode.name === 'jsonwebtoken') &&
+    isObject(propertyNode) &&
+    propertyNode.type === 'Identifier' &&
+    propertyNode.name === 'decode'
+  );
+};
+
+const isJwtVerifyIgnoreExpirationCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  if (
+    !isObject(objectNode) ||
+    objectNode.type !== 'Identifier' ||
+    (objectNode.name !== 'jwt' && objectNode.name !== 'jsonwebtoken') ||
+    !isObject(propertyNode) ||
+    propertyNode.type !== 'Identifier' ||
+    propertyNode.name !== 'verify'
+  ) {
+    return false;
+  }
+
+  const args = value.arguments;
+  if (!Array.isArray(args) || args.length < 3) {
+    return false;
+  }
+
+  return hasIgnoreExpirationTrueOption(args[2]);
+};
+
+const isJwtSignWithoutExpirationCallNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = value.callee;
+  if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
+    return false;
+  }
+
+  const objectNode = callee.object;
+  const propertyNode = callee.property;
+  if (
+    !isObject(objectNode) ||
+    objectNode.type !== 'Identifier' ||
+    (objectNode.name !== 'jwt' && objectNode.name !== 'jsonwebtoken') ||
+    !isObject(propertyNode) ||
+    propertyNode.type !== 'Identifier' ||
+    propertyNode.name !== 'sign'
+  ) {
+    return false;
+  }
+
+  const args = value.arguments;
+  if (!Array.isArray(args) || args.length < 2) {
+    return false;
+  }
+
+  const payloadArg = args[0];
+  const optionsArg = args[2];
+  return !hasExpClaim(payloadArg) && !hasExpiresInOption(optionsArg);
+};
+
+export const hasJwtDecodeWithoutVerifyCall = (node: unknown): boolean => {
+  return hasNode(node, isJwtDecodeWithoutVerifyCallNode);
+};
+
+export const findJwtDecodeWithoutVerifyCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isJwtDecodeWithoutVerifyCallNode);
+};
+
+export const hasJwtVerifyIgnoreExpirationCall = (node: unknown): boolean => {
+  return hasNode(node, isJwtVerifyIgnoreExpirationCallNode);
+};
+
+export const findJwtVerifyIgnoreExpirationCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isJwtVerifyIgnoreExpirationCallNode);
+};
+
 export const hasJwtSignWithoutExpirationCall = (node: unknown): boolean => {
-  const hasExpClaim = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'ObjectProperty') {
-        return false;
-      }
-      const keyNode = value.key;
-      return (
-        (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'exp') ||
-        (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'exp')
-      );
-    });
-  };
+  return hasNode(node, isJwtSignWithoutExpirationCallNode);
+};
 
-  const hasExpiresInOption = (candidate: unknown): boolean => {
-    return hasNode(candidate, (value) => {
-      if (value.type !== 'ObjectProperty') {
-        return false;
-      }
-      const keyNode = value.key;
-      return (
-        (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'expiresIn') ||
-        (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'expiresIn')
-      );
-    });
-  };
-
-  return hasNode(node, (value) => {
-    if (value.type !== 'CallExpression') {
-      return false;
-    }
-
-    const callee = value.callee;
-    if (!isObject(callee) || callee.type !== 'MemberExpression' || callee.computed === true) {
-      return false;
-    }
-
-    const objectNode = callee.object;
-    const propertyNode = callee.property;
-    if (
-      !isObject(objectNode) ||
-      objectNode.type !== 'Identifier' ||
-      (objectNode.name !== 'jwt' && objectNode.name !== 'jsonwebtoken') ||
-      !isObject(propertyNode) ||
-      propertyNode.type !== 'Identifier' ||
-      propertyNode.name !== 'sign'
-    ) {
-      return false;
-    }
-
-    const args = value.arguments;
-    if (!Array.isArray(args) || args.length < 2) {
-      return false;
-    }
-
-    const payloadArg = args[0];
-    const optionsArg = args[2];
-    return !hasExpClaim(payloadArg) && !hasExpiresInOption(optionsArg);
-  });
+export const findJwtSignWithoutExpirationCallLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isJwtSignWithoutExpirationCallNode);
 };

--- a/core/facts/detectors/security/securityTls.test.ts
+++ b/core/facts/detectors/security/securityTls.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  findTlsEnvRejectUnauthorizedZeroOverrideLines,
+  findTlsRejectUnauthorizedFalseOptionLines,
   hasTlsEnvRejectUnauthorizedZeroOverride,
   hasTlsRejectUnauthorizedFalseOption,
 } from './securityTls';
@@ -118,4 +120,37 @@ test('hasTlsEnvRejectUnauthorizedZeroOverride detecta process.env.NODE_TLS_REJEC
   assert.equal(hasTlsEnvRejectUnauthorizedZeroOverride(templateLiteralZeroAst), true);
   assert.equal(hasTlsEnvRejectUnauthorizedZeroOverride(safeValueAst), false);
   assert.equal(hasTlsEnvRejectUnauthorizedZeroOverride(otherEnvAst), false);
+});
+
+test('find*Lines de securityTls retornan lineas de coincidencia', () => {
+  const ast = {
+    type: 'Program',
+    body: [
+      {
+        type: 'ObjectProperty',
+        loc: { start: { line: 5 } },
+        key: { type: 'Identifier', name: 'rejectUnauthorized' },
+        value: { type: 'BooleanLiteral', value: false },
+      },
+      {
+        type: 'AssignmentExpression',
+        loc: { start: { line: 11 } },
+        left: {
+          type: 'MemberExpression',
+          computed: false,
+          object: {
+            type: 'MemberExpression',
+            computed: false,
+            object: { type: 'Identifier', name: 'process' },
+            property: { type: 'Identifier', name: 'env' },
+          },
+          property: { type: 'Identifier', name: 'NODE_TLS_REJECT_UNAUTHORIZED' },
+        },
+        right: { type: 'StringLiteral', value: '0' },
+      },
+    ],
+  };
+
+  assert.deepEqual(findTlsRejectUnauthorizedFalseOptionLines(ast), [5]);
+  assert.deepEqual(findTlsEnvRejectUnauthorizedZeroOverrideLines(ast), [11]);
 });

--- a/core/facts/detectors/security/securityTls.ts
+++ b/core/facts/detectors/security/securityTls.ts
@@ -1,88 +1,100 @@
-import { hasNode, isObject } from '../utils/astHelpers';
+import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
+
+const isZeroLikeLiteral = (candidate: unknown): boolean => {
+  if (!isObject(candidate)) {
+    return false;
+  }
+  if (candidate.type === 'StringLiteral') {
+    return candidate.value === '0';
+  }
+  if (candidate.type === 'NumericLiteral') {
+    return candidate.value === 0;
+  }
+  if (
+    candidate.type === 'TemplateLiteral' &&
+    Array.isArray(candidate.expressions) &&
+    candidate.expressions.length === 0 &&
+    Array.isArray(candidate.quasis) &&
+    candidate.quasis.length === 1
+  ) {
+    return candidate.quasis[0]?.value?.cooked === '0';
+  }
+  return false;
+};
+
+const isNodeTlsEnvMember = (candidate: unknown): boolean => {
+  if (!isObject(candidate) || candidate.type !== 'MemberExpression') {
+    return false;
+  }
+
+  const envMember = candidate.object;
+  const keyNode = candidate.property;
+  if (!isObject(envMember) || envMember.type !== 'MemberExpression') {
+    return false;
+  }
+
+  const processNode = envMember.object;
+  const envKeyNode = envMember.property;
+  const isProcessEnv =
+    isObject(processNode) &&
+    processNode.type === 'Identifier' &&
+    processNode.name === 'process' &&
+    ((envMember.computed === true &&
+      isObject(envKeyNode) &&
+      envKeyNode.type === 'StringLiteral' &&
+      envKeyNode.value === 'env') ||
+      (envMember.computed !== true &&
+        isObject(envKeyNode) &&
+        envKeyNode.type === 'Identifier' &&
+        envKeyNode.name === 'env'));
+  if (!isProcessEnv) {
+    return false;
+  }
+
+  return (
+    (candidate.computed === true &&
+      isObject(keyNode) &&
+      keyNode.type === 'StringLiteral' &&
+      keyNode.value === 'NODE_TLS_REJECT_UNAUTHORIZED') ||
+    (candidate.computed !== true &&
+      isObject(keyNode) &&
+      keyNode.type === 'Identifier' &&
+      keyNode.name === 'NODE_TLS_REJECT_UNAUTHORIZED')
+  );
+};
+
+const isTlsRejectUnauthorizedFalseOptionNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'ObjectProperty') {
+    return false;
+  }
+
+  const keyNode = value.key;
+  const valueNode = value.value;
+  const keyMatches =
+    (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'rejectUnauthorized') ||
+    (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'rejectUnauthorized');
+  return keyMatches && isObject(valueNode) && valueNode.type === 'BooleanLiteral' && valueNode.value === false;
+};
+
+const isTlsEnvRejectUnauthorizedZeroOverrideNode = (value: Record<string, unknown>): boolean => {
+  if (value.type !== 'AssignmentExpression') {
+    return false;
+  }
+  return isNodeTlsEnvMember(value.left) && isZeroLikeLiteral(value.right);
+};
 
 export const hasTlsRejectUnauthorizedFalseOption = (node: unknown): boolean => {
-  return hasNode(node, (value) => {
-    if (value.type !== 'ObjectProperty') {
-      return false;
-    }
+  return hasNode(node, isTlsRejectUnauthorizedFalseOptionNode);
+};
 
-    const keyNode = value.key;
-    const valueNode = value.value;
-    const keyMatches =
-      (isObject(keyNode) && keyNode.type === 'Identifier' && keyNode.name === 'rejectUnauthorized') ||
-      (isObject(keyNode) && keyNode.type === 'StringLiteral' && keyNode.value === 'rejectUnauthorized');
-    return keyMatches && isObject(valueNode) && valueNode.type === 'BooleanLiteral' && valueNode.value === false;
-  });
+export const findTlsRejectUnauthorizedFalseOptionLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isTlsRejectUnauthorizedFalseOptionNode);
 };
 
 export const hasTlsEnvRejectUnauthorizedZeroOverride = (node: unknown): boolean => {
-  const isZeroLikeLiteral = (candidate: unknown): boolean => {
-    if (!isObject(candidate)) {
-      return false;
-    }
-    if (candidate.type === 'StringLiteral') {
-      return candidate.value === '0';
-    }
-    if (candidate.type === 'NumericLiteral') {
-      return candidate.value === 0;
-    }
-    if (
-      candidate.type === 'TemplateLiteral' &&
-      Array.isArray(candidate.expressions) &&
-      candidate.expressions.length === 0 &&
-      Array.isArray(candidate.quasis) &&
-      candidate.quasis.length === 1
-    ) {
-      return candidate.quasis[0]?.value?.cooked === '0';
-    }
-    return false;
-  };
+  return hasNode(node, isTlsEnvRejectUnauthorizedZeroOverrideNode);
+};
 
-  const isNodeTlsEnvMember = (candidate: unknown): boolean => {
-    if (!isObject(candidate) || candidate.type !== 'MemberExpression') {
-      return false;
-    }
-
-    const envMember = candidate.object;
-    const keyNode = candidate.property;
-    if (!isObject(envMember) || envMember.type !== 'MemberExpression') {
-      return false;
-    }
-
-    const processNode = envMember.object;
-    const envKeyNode = envMember.property;
-    const isProcessEnv =
-      isObject(processNode) &&
-      processNode.type === 'Identifier' &&
-      processNode.name === 'process' &&
-      ((envMember.computed === true &&
-        isObject(envKeyNode) &&
-        envKeyNode.type === 'StringLiteral' &&
-        envKeyNode.value === 'env') ||
-        (envMember.computed !== true &&
-          isObject(envKeyNode) &&
-          envKeyNode.type === 'Identifier' &&
-          envKeyNode.name === 'env'));
-    if (!isProcessEnv) {
-      return false;
-    }
-
-    return (
-      (candidate.computed === true &&
-        isObject(keyNode) &&
-        keyNode.type === 'StringLiteral' &&
-        keyNode.value === 'NODE_TLS_REJECT_UNAUTHORIZED') ||
-      (candidate.computed !== true &&
-        isObject(keyNode) &&
-        keyNode.type === 'Identifier' &&
-        keyNode.name === 'NODE_TLS_REJECT_UNAUTHORIZED')
-    );
-  };
-
-  return hasNode(node, (value) => {
-    if (value.type !== 'AssignmentExpression') {
-      return false;
-    }
-    return isNodeTlsEnvMember(value.left) && isZeroLikeLiteral(value.right);
-  });
+export const findTlsEnvRejectUnauthorizedZeroOverrideLines = (node: unknown): readonly number[] => {
+  return collectNodeLineMatches(node, isTlsEnvRejectUnauthorizedZeroOverrideNode);
 };

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -20,7 +20,44 @@ Estado operativo activo del repositorio.
   - referencias rotas críticas: `0`
   - compilación TypeScript: `OK` (`npm run typecheck`)
   - inventario de `.md` normalizado y sin reportes/ciclos forenses en `docs/` root
-- 🚧 `P-ADHOC-LINES-002` Extender extracción de líneas AST al resto de familias heurísticas (`process/security/browser/fs`) para minimizar anchors por fallback.
+- ✅ `P-ADHOC-LINES-002` Extender extracción de líneas AST al resto de familias heurísticas (`process/security/browser/fs`) para minimizar anchors por fallback.
+  - detectores `process/security/browser` con `find*Lines` y pruebas dedicadas
+  - autolocalización de líneas AST por convención `has*/find*Lines`
+  - inferencia para familia `fs` (`sync/promises/callbacks`) sin hardcode por regla
+  - validación: tests heurísticos focales `OK` + `npm run typecheck` `OK`
+- ✅ `P-ADHOC-LINES-003` Verificar trazabilidad clicable end-to-end en menú/reportes usando `lines` de todas las familias AST.
+  - salida de bloqueo en gate (`runPlatformGateOutput`) enriquecida con `severity + ruleId + message + file:line`
+  - `exportLegacyAuditMarkdown` ahora incluye secciones markdown con rutas clicables `./path#Lline`
+  - cobertura de tests para salida clicable y export markdown
+  - validación: tests focales `OK` + `npm run typecheck` `OK`
+- ✅ `P-ADHOC-LINES-004` Ejecutar smoke e2e de trazabilidad (`pre-write`, `pre-commit`, `pre-push`, menú opción 1/8/9) y registrar evidencias finales.
+  - tests runtime menú para opción `9` (diagnóstico clicable) y opción `8` (export markdown clicable)
+  - tests de salida gate (`runPlatformGateOutput`) con `lines` array/string/sin líneas
+  - validación: suite focal `OK` (29 tests) + `npm run typecheck` `OK`
+- ✅ `P-ADHOC-LINES-005` Ejecutar auditoría funcional completa y verificar visualmente trazabilidad clicable en salida real de hooks + menú.
+  - hooks reales ejecutados con evidencia en:
+    - `.audit_tmp/prewrite-functional.out`
+    - `.audit_tmp/precommit-functional.out`
+    - `.audit_tmp/prepush-functional.out`
+  - validado `file:line` en bloqueos de hooks:
+    - `pre-write`: `openspec/changes:1`, `.ai_evidence.json:1`, `.git/HEAD:1`
+    - `pre-commit` / `pre-push`: `openspec/changes:1`
+  - flujo menú consumer validado en TTY real (`1 -> 8 -> 9 -> 10`) con evidencia en:
+    - `.audit_tmp/menu-functional-tty.out`
+    - export markdown: `.audit-reports/pumuki-legacy-audit.md`
+  - comprobadas secciones clicables en markdown:
+    - `## Clickable Top Files`
+    - `## Clickable Findings` con enlaces `./path#Lline`
+- ✅ `P-ADHOC-LINES-006` Consolidar reporte final de recuperación de detección enterprise (resumen funcional + evidencias clave) para cierre operativo del ciclo.
+  - reporte oficial creado en `docs/validation/enterprise-detection-recovery-closure.md`
+  - incluye estado consolidado del gate, severidades, cobertura y evidencias de hooks/menú/export markdown
+  - `docs/validation/README.md` actualizado para registrar el documento como referencia versionada
+- ✅ `P-ADHOC-LINES-007` Preparar cierre Git Flow end-to-end (commit atómico, PR, merge y sincronización) sin pérdida de cambios.
+  - rama de trabajo dedicada `feature/p-adhoc-lines-007-gitflow-closure`
+  - validación previa de calidad ejecutada (`tsx --test` focal + `npm run typecheck`)
+  - lote consolidado para commit atómico del ciclo de recuperación
+  - cierre previsto por PR con merge a `develop` y sincronización de ramas protegidas
+- 🚧 `P-ADHOC-LINES-008` Ejecutar auditoría full-repo post-cierre y emitir informe final de violaciones por severidad con rutas clicables.
 
 ## Siguiente paso operativo
-- ⏳ Mantener `P-ADHOC-LINES-002` como único trabajo en construcción hasta cierre técnico.
+- 🚧 Ejecutar `P-ADHOC-LINES-008` para validar el estado post-cierre con auditoría full-repo.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -20,6 +20,7 @@ Keep these as source-of-truth operational references:
 - `enterprise-consumer-isolation-policy.md`
 - `mock-consumer-integration-runbook.md`
 - `detection-audit-baseline.md`
+- `enterprise-detection-recovery-closure.md`
 
 ## Generated Outputs (Do Not Keep as Baseline Docs)
 

--- a/docs/validation/enterprise-detection-recovery-closure.md
+++ b/docs/validation/enterprise-detection-recovery-closure.md
@@ -1,0 +1,61 @@
+# Enterprise Detection Recovery Closure
+
+Estado de cierre operativo del ciclo de recuperación de detección enterprise.
+
+## Objetivo
+
+Consolidar en un único documento el resultado funcional real del motor de detección, trazabilidad clicable y comportamiento de hooks/menú.
+
+## Evidencias funcionales validadas
+
+- Hooks ejecutados en local:
+  - `node bin/pumuki-pre-write.js` → `.audit_tmp/prewrite-functional.out`
+  - `node bin/pumuki-pre-commit.js` → `.audit_tmp/precommit-functional.out`
+  - `node bin/pumuki-pre-push.js` → `.audit_tmp/prepush-functional.out`
+- Menú consumer ejecutado en TTY real con flujo completo:
+  - `1 -> 8 -> 9 -> 10` → `.audit_tmp/menu-functional-tty.out`
+- Export Markdown generado desde menú:
+  - `.audit-reports/pumuki-legacy-audit.md`
+
+## Resultado consolidado del gate
+
+- Stage: `PRE_COMMIT`
+- Audit mode: `engine`
+- Outcome: `BLOCK`
+- Total violations: `83`
+- Severidad enterprise:
+  - `CRITICAL: 42`
+  - `HIGH: 37`
+  - `MEDIUM: 4`
+  - `LOW: 0`
+
+## Cobertura de reglas
+
+- `active: 417`
+- `evaluated: 417`
+- `matched: 13`
+- `unevaluated: 0`
+- `coverage_ratio: 1`
+
+## Verificaciones de trazabilidad clicable
+
+- `pre-write` imprime anchors `file:line` en bloqueos SDD y AI gate:
+  - `openspec/changes:1`
+  - `.ai_evidence.json:1`
+  - `.git/HEAD:1`
+- `pre-commit` y `pre-push` imprimen anchor `file:line`:
+  - `openspec/changes:1`
+- Menú opción `9` muestra bloque:
+  - `VIOLATIONS — CLICKABLE LOCATIONS`
+- Export Markdown (menú opción `8`) incluye:
+  - `## Clickable Top Files`
+  - `## Clickable Findings`
+  - enlaces tipo `./path#Lline`
+
+## Criterio de cierre del ciclo
+
+- Recuperación funcional completada para:
+  - salida clicable en hooks
+  - salida clicable en menú
+  - salida clicable en export markdown
+- El bloqueo actual del gate responde a violaciones reales detectadas, no a fallo del circuito de trazabilidad.

--- a/integrations/git/__tests__/runPlatformGateOutput.test.ts
+++ b/integrations/git/__tests__/runPlatformGateOutput.test.ts
@@ -20,7 +20,7 @@ test('printGateFindings no emite logs cuando no hay findings', () => {
   assert.deepEqual(captured, []);
 });
 
-test('printGateFindings imprime ruleId y message por cada finding', () => {
+test('printGateFindings imprime severidad, ruleId, message y ubicación clicable', () => {
   const findings: ReadonlyArray<Finding> = [
     {
       ruleId: 'R1',
@@ -28,6 +28,7 @@ test('printGateFindings imprime ruleId y message por cada finding', () => {
       code: 'sample-1',
       message: 'Primera alerta',
       filePath: 'src/a.ts',
+      lines: [42, 60],
     },
     {
       ruleId: 'R2',
@@ -35,6 +36,13 @@ test('printGateFindings imprime ruleId y message por cada finding', () => {
       code: 'sample-2',
       message: 'Segunda alerta',
       filePath: 'src/b.ts',
+      lines: '17',
+    },
+    {
+      ruleId: 'R3',
+      severity: 'CRITICAL',
+      code: 'sample-3',
+      message: 'Tercera alerta',
     },
   ];
   const captured: string[] = [];
@@ -50,5 +58,9 @@ test('printGateFindings imprime ruleId y message por cada finding', () => {
     process.stdout.write = originalWrite;
   }
 
-  assert.deepEqual(captured, ['R1: Primera alerta', 'R2: Segunda alerta']);
+  assert.deepEqual(captured, [
+    '[ERROR] R1: Primera alerta -> src/a.ts:42',
+    '[WARN] R2: Segunda alerta -> src/b.ts:17',
+    '[CRITICAL] R3: Tercera alerta',
+  ]);
 });

--- a/integrations/git/runPlatformGateOutput.ts
+++ b/integrations/git/runPlatformGateOutput.ts
@@ -1,7 +1,45 @@
 import type { Finding } from '../../core/gate/Finding';
 
+const normalizeAnchorLine = (lines: Finding['lines']): number => {
+  if (Array.isArray(lines)) {
+    const candidates = lines
+      .map((line) => Number(line))
+      .filter((line) => Number.isFinite(line))
+      .map((line) => Math.trunc(line))
+      .filter((line) => line > 0);
+    return candidates.length > 0 ? Math.min(...candidates) : 1;
+  }
+  if (typeof lines === 'number' && Number.isFinite(lines)) {
+    const normalized = Math.trunc(lines);
+    return normalized > 0 ? normalized : 1;
+  }
+  if (typeof lines === 'string') {
+    const candidates = lines
+      .match(/\d+/g)
+      ?.map((token) => Number.parseInt(token, 10))
+      .filter((line) => Number.isFinite(line) && line > 0);
+    if (candidates && candidates.length > 0) {
+      return Math.min(...candidates);
+    }
+  }
+  return 1;
+};
+
+const formatLocation = (finding: Finding): string | null => {
+  if (!finding.filePath || finding.filePath.trim().length === 0) {
+    return null;
+  }
+  const anchorLine = normalizeAnchorLine(finding.lines);
+  return `${finding.filePath.replace(/\\/g, '/')}:${anchorLine}`;
+};
+
 const formatFinding = (finding: Finding): string => {
-  return `${finding.ruleId}: ${finding.message}`;
+  const location = formatLocation(finding);
+  const severity = finding.severity.toUpperCase();
+  if (!location) {
+    return `[${severity}] ${finding.ruleId}: ${finding.message}`;
+  }
+  return `[${severity}] ${finding.ruleId}: ${finding.message} -> ${location}`;
 };
 
 export const printGateFindings = (findings: ReadonlyArray<Finding>): void => {

--- a/scripts/__tests__/framework-menu-legacy-audit.test.ts
+++ b/scripts/__tests__/framework-menu-legacy-audit.test.ts
@@ -336,6 +336,12 @@ test('exportLegacyAuditMarkdown genera reporte markdown en .audit-reports', asyn
     assert.equal(existsSync(filePath), true);
     const markdown = readFileSync(filePath, 'utf8');
     assert.match(markdown, /# PUMUKI Audit Report/);
+    assert.match(markdown, /## Clickable Top Files/);
+    assert.match(markdown, /## Clickable Findings/);
+    assert.match(
+      markdown,
+      /\[apps\/ios\/App\/Feature\.swift:18\]\(\.\/apps\/ios\/App\/Feature\.swift#L18\)/
+    );
     assert.match(markdown, /FINAL SUMMARY — VIOLATIONS BY SEVERITY/);
   });
 });


### PR DESCRIPTION
## Summary
- restore AST line propagation across process/security/browser/fs heuristic families
- render clickable file:line locations in gate output, menu diagnostics and markdown export
- add functional closure document and update refactor progress tracker

## Validation
- npx --yes tsx@4.21.0 --test core/facts/__tests__/extractHeuristicFacts.test.ts core/facts/detectors/browser/index.test.ts core/facts/detectors/process/core.test.ts core/facts/detectors/process/shell.test.ts core/facts/detectors/process/spawn.test.ts core/facts/detectors/security/securityCredentials.test.ts core/facts/detectors/security/securityCrypto.test.ts core/facts/detectors/security/securityJwt.test.ts core/facts/detectors/security/securityTls.test.ts integrations/git/__tests__/runPlatformGateOutput.test.ts integrations/lifecycle/__tests__/lifecycle.test.ts scripts/__tests__/framework-menu-consumer-runtime.test.ts scripts/__tests__/framework-menu-legacy-audit.test.ts
- npm run typecheck