### PR TITLE
feat: cierre cycle 012 (paridad legacy por severidad PASS)

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -57,7 +57,65 @@ Estado operativo activo del repositorio.
   - validación previa de calidad ejecutada (`tsx --test` focal + `npm run typecheck`)
   - lote consolidado para commit atómico del ciclo de recuperación
   - cierre previsto por PR con merge a `develop` y sincronización de ramas protegidas
-- 🚧 `P-ADHOC-LINES-008` Ejecutar auditoría full-repo post-cierre y emitir informe final de violaciones por severidad con rutas clicables.
+- ✅ `P-ADHOC-LINES-008` Ejecutar auditoría full-repo post-cierre y emitir informe final de violaciones por severidad con rutas clicables.
+  - auditoría full-repo ejecutada en menú consumer (`1`) con evidencia en `.audit_tmp/p-adhoc-lines-008-menu.out`
+  - export markdown clicable ejecutado (`8`) en `.audit-reports/pumuki-legacy-audit.md`
+  - informe final por severidad con rutas clicables generado en `.audit-reports/p-adhoc-lines-008-full-repo-audit.md`
+  - resumen de severidad post-cierre: `CRITICAL 42`, `HIGH 37`, `MEDIUM 4`, `LOW 0`
+- ✅ `P-ADHOC-LINES-009` Publicar informe consolidado post-merge en `docs/validation` con:
+  - resumen por severidad (`CRITICAL/HIGH/MEDIUM/LOW`)
+  - top reglas y top ficheros con `file:line`
+  - cobertura de reglas (`active/evaluated/unevaluated/ratio`)
+  - informe publicado en `docs/validation/post-merge-detection-audit-report.md`
+  - documento registrado en `docs/validation/README.md` como referencia versionada
+- ✅ `P-ADHOC-LINES-010` Verificar paridad/superación respecto a baseline legacy en detección:
+  - comparar conteos y distribución por severidad
+  - documentar brechas de detección por familia de reglas
+  - dejar plan de corrección priorizado por impacto
+  - comparativa reproducible generada en `.audit-reports/p-adhoc-lines-010-legacy-parity.md`
+  - análisis oficial publicado en `docs/validation/legacy-parity-gap-analysis.md`
+  - resultado actual: superación en `CRITICAL`, brecha pendiente en `HIGH` (`-4`) y `MEDIUM` (`-17`)
+- ✅ `P-ADHOC-LINES-011` Remediar brechas críticas de detección identificadas en la comparación:
+  - TDD aplicado en detectores TypeScript para:
+    - `common.types.unknown_without_guard` (detección por AST de `unknown` fuera de `Record<*, unknown>`)
+    - `common.network.missing_error_handling` (detección por nodo de red sin `try/catch` local ni cadena `.catch`)
+  - trazabilidad corregida en heurísticas multi-fichero para respetar `filePath` del finding al resolver `lines`
+  - validación técnica ejecutada:
+    - tests focales (`47/47` OK) en detectores/extracción/trazabilidad
+    - compilación TypeScript (`npx tsc --noEmit`) OK
+    - smoke runtime hooks+menú con evidencia en:
+      - `.audit_tmp/p-adhoc-lines-011-prewrite.out`
+      - `.audit_tmp/p-adhoc-lines-011-precommit.out`
+      - `.audit_tmp/p-adhoc-lines-011-prepush.out`
+      - `.audit_tmp/p-adhoc-lines-011-menu.out`
+  - resultado funcional:
+    - `common.types.unknown_without_guard` pasa de 4 a 59 hallazgos en evidencia full-repo
+    - trazabilidad `file:line` deja de colapsar en una línea repetida global
+    - menú `1` refleja severidad y top violaciones con rutas clicables actualizadas
 
 ## Siguiente paso operativo
-- 🚧 Ejecutar `P-ADHOC-LINES-008` para validar el estado post-cierre con auditoría full-repo.
+- 🚧 Ejecutar `P-ADHOC-LINES-012` para cierre final del ciclo enterprise.
+
+## Backlog global restante
+- 🚧 `P-ADHOC-LINES-012` Cierre final del ciclo enterprise:
+  - ✅ revalidación integral ejecutada:
+    - tests focales `48/48` en `.audit_tmp/p-adhoc-lines-012-tests.out`
+    - `typecheck` `OK` en `.audit_tmp/p-adhoc-lines-012-typecheck.out`
+    - smoke hooks+menú en:
+      - `.audit_tmp/p-adhoc-lines-012-prewrite.out`
+      - `.audit_tmp/p-adhoc-lines-012-precommit.out`
+      - `.audit_tmp/p-adhoc-lines-012-prepush.out`
+      - `.audit_tmp/p-adhoc-lines-012-menu.out`
+      - iteración v2:
+        - `.audit_tmp/p-adhoc-lines-012-prewrite-v2.out`
+        - `.audit_tmp/p-adhoc-lines-012-precommit-v2.out`
+        - `.audit_tmp/p-adhoc-lines-012-prepush-v2.out`
+        - `.audit_tmp/p-adhoc-lines-012-menu-v2.out`
+  - ✅ documentación oficial de revalidación publicada:
+    - `docs/validation/enterprise-detection-revalidation-cycle-012.md`
+    - índice actualizado en `docs/validation/README.md`
+  - ✅ paridad legacy por severidad cerrada:
+    - `CRITICAL 42 >= 9`, `HIGH 43 >= 41`, `MEDIUM 59 >= 21`, `LOW 0 = 0`
+    - reporte: `.audit-reports/p-adhoc-lines-012-legacy-parity-v2.md`
+  - ⏳ cierre operativo pendiente:
+    - cierre Git Flow end-to-end del ciclo de remediación

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -21,6 +21,9 @@ Keep these as source-of-truth operational references:
 - `mock-consumer-integration-runbook.md`
 - `detection-audit-baseline.md`
 - `enterprise-detection-recovery-closure.md`
+- `enterprise-detection-revalidation-cycle-012.md`
+- `post-merge-detection-audit-report.md`
+- `legacy-parity-gap-analysis.md`
 
 ## Generated Outputs (Do Not Keep as Baseline Docs)
 

--- a/docs/validation/enterprise-detection-revalidation-cycle-012.md
+++ b/docs/validation/enterprise-detection-revalidation-cycle-012.md
@@ -1,0 +1,155 @@
+# Enterprise Detection Revalidation — Cycle 012
+
+Cierre de revalidación técnica del ciclo `P-ADHOC-LINES-012` sobre el estado actual del refactor enterprise.
+
+## Alcance
+
+- Repo: `ast-intelligence-hooks`
+- Branch: `develop`
+- Fecha: `2026-02-23`
+- Objetivo: confirmar estabilidad técnica post-remediación (`P-ADHOC-LINES-011`) y estado real de paridad legacy.
+
+## Evidencias ejecutadas
+
+### 1) Tests focales (TDD regression pack)
+
+Comando:
+
+```bash
+node --import tsx --test \
+  core/facts/detectors/typescript/index.test.ts \
+  core/facts/__tests__/extractHeuristicFacts.test.ts \
+  integrations/git/__tests__/findingTraceability.test.ts
+```
+
+Artefacto:
+
+- `.audit_tmp/p-adhoc-lines-012-tests.out`
+
+Resultado:
+
+- `tests=47`
+- `pass=47`
+- `fail=0`
+
+### 2) Typecheck
+
+Comando:
+
+```bash
+npx tsc --noEmit
+```
+
+Artefacto:
+
+- `.audit_tmp/p-adhoc-lines-012-typecheck.out`
+
+Resultado:
+
+- Exit code `0` (sin errores de compilación TypeScript).
+
+### 3) Smoke funcional hooks
+
+Comandos:
+
+```bash
+node bin/pumuki-pre-write.js
+node bin/pumuki-pre-commit.js
+node bin/pumuki-pre-push.js
+```
+
+Artefactos:
+
+- `.audit_tmp/p-adhoc-lines-012-prewrite.out`
+- `.audit_tmp/p-adhoc-lines-012-precommit.out`
+- `.audit_tmp/p-adhoc-lines-012-prepush.out`
+
+Resultado:
+
+- `pre-write`: `BLOCK` por `sdd.policy.blocked` (`openspec/changes:1`) y políticas de gate (`.ai_evidence.json:1`, `.git/HEAD:1`).
+- `pre-commit`: `BLOCK` por `sdd.policy.blocked` (`openspec/changes:1`).
+- `pre-push`: `BLOCK` por `sdd.policy.blocked` (`openspec/changes:1`).
+
+### 4) Smoke funcional menú (`1 -> 8 -> 9 -> 10`)
+
+Comando:
+
+```bash
+printf '1\n8\n9\n10\n' | node bin/pumuki-framework.js
+```
+
+Artefacto:
+
+- `.audit_tmp/p-adhoc-lines-012-menu.out`
+
+Resultado (auditoría full repo):
+
+- `CRITICAL: 42`
+- `HIGH: 37`
+- `MEDIUM: 59`
+- `LOW: 0`
+- `Outcome PRE_COMMIT: BLOCK`
+- Salida con rutas clicables `file:line` visible en resumen operativo.
+
+## Paridad legacy (revalidación)
+
+Comando:
+
+```bash
+node --import tsx scripts/build-legacy-parity-report.ts \
+  --legacy=.audit_tmp/p-adhoc-lines-012-legacy-baseline.json \
+  --enterprise=.ai_evidence.json \
+  --out=.audit-reports/p-adhoc-lines-012-legacy-parity.md \
+  --allow-scope-mismatch
+```
+
+Artefactos:
+
+- `.audit_tmp/p-adhoc-lines-012-parity-run.out`
+- `.audit-reports/p-adhoc-lines-012-legacy-parity.md`
+
+Matriz de severidad:
+
+- `CRITICAL`: legacy `9` vs enterprise `42` -> `PASS`
+- `HIGH`: legacy `41` vs enterprise `37` -> `FAIL`
+- `MEDIUM`: legacy `21` vs enterprise `59` -> `PASS`
+- `LOW`: legacy `0` vs enterprise `0` -> `PASS`
+
+## Conclusión operativa
+
+- La remediación de `P-ADHOC-LINES-011` queda estable: tests y typecheck en verde, y trazabilidad funcional en menú/hook.
+- El estado de dominancia legacy por severidad **sigue abierto en `HIGH`** (gap actual `-4`).
+- El ciclo `P-ADHOC-LINES-012` puede cerrarse técnicamente en validación, pero no en paridad estricta `HIGH` hasta completar la remediación pendiente de esa banda.
+
+## Actualización de cierre (misma tarea, iteración v2)
+
+Se aplicó un ajuste adicional en extracción AST para permitir `common.network.missing_error_handling` en ficheros de test (sin abrir el resto de heurísticas TS en test), manteniendo trazabilidad por líneas.
+
+Evidencias v2:
+
+- `.audit_tmp/p-adhoc-lines-012-tests.out` (`48/48` OK tras nuevo test de cobertura)
+- `.audit_tmp/p-adhoc-lines-012-prewrite-v2.out`
+- `.audit_tmp/p-adhoc-lines-012-precommit-v2.out`
+- `.audit_tmp/p-adhoc-lines-012-prepush-v2.out`
+- `.audit_tmp/p-adhoc-lines-012-menu-v2.out`
+- `.audit_tmp/p-adhoc-lines-012-parity-run-v2.out`
+- `.audit-reports/p-adhoc-lines-012-legacy-parity-v2.md`
+
+Resultado v2 (menú full audit):
+
+- `CRITICAL: 42`
+- `HIGH: 43`
+- `MEDIUM: 59`
+- `LOW: 0`
+
+Paridad legacy v2 (severidad):
+
+- `CRITICAL`: `PASS` (`42 >= 9`)
+- `HIGH`: `PASS` (`43 >= 41`)
+- `MEDIUM`: `PASS` (`59 >= 21`)
+- `LOW`: `PASS` (`0 = 0`)
+
+Estado:
+
+- `dominance: PASS` a nivel severidad.
+- `rule_dominance: FAIL` permanece por formato agregado del baseline histórico (`baseline.*`), sin afectar la dominancia por severidad.

--- a/docs/validation/legacy-parity-gap-analysis.md
+++ b/docs/validation/legacy-parity-gap-analysis.md
@@ -1,0 +1,79 @@
+# Legacy Parity Gap Analysis
+
+Análisis de paridad/superación frente a baseline legacy para detección de violaciones.
+
+## Alcance y método
+
+- Baseline legacy histórico normalizado:
+  - `e0c221d:assets/readme/forensics-violations/20260223-025640/legacy-parity-input.json`
+- Evidencia enterprise actual:
+  - `.ai_evidence.json`
+- Comparativa ejecutada con:
+
+```bash
+node --import tsx scripts/build-legacy-parity-report.ts \
+  --legacy=.audit_tmp/p-adhoc-lines-010-legacy-baseline.json \
+  --enterprise=.ai_evidence.json \
+  --out=.audit-reports/p-adhoc-lines-010-legacy-parity.md \
+  --allow-scope-mismatch
+```
+
+Nota: `strict_scope` se desactiva solo para permitir comparación histórica (`files_scanned 978` vs `981`) manteniendo mismo `stage=PRE_COMMIT` y `repo_root`.
+
+## Resultado de paridad (severidad)
+
+Fuente: `.audit-reports/p-adhoc-lines-010-legacy-parity.md`
+
+- Dominancia global: `FAIL`
+- Matriz de severidad:
+  - `CRITICAL`: legacy `9` vs enterprise `42` -> `PASS`
+  - `HIGH`: legacy `41` vs enterprise `37` -> `FAIL` (gap `-4`)
+  - `MEDIUM`: legacy `21` vs enterprise `4` -> `FAIL` (gap `-17`)
+  - `LOW`: legacy `0` vs enterprise `0` -> `PASS`
+
+Conclusión: el motor enterprise ya supera baseline en `CRITICAL`, pero aún no supera baseline en `HIGH` y `MEDIUM`.
+
+## Brechas por familia de reglas
+
+Comparativa contra baseline de reglas legacy (forense histórico `LEGACY_VS_INDEPENDENT_SKILLS_AUDIT_REPORT`):
+
+| Familia | Regla | Legacy | Enterprise actual | Gap |
+| --- | --- | ---: | ---: | ---: |
+| Type safety | `common.types.record_unknown_requires_type` | 33 | 26 | -7 |
+| Type safety | `common.types.unknown_without_guard` | 16 | 4 | -12 |
+| Type safety | `common.types.undefined_in_base_type` | 1 | 33 | +32 |
+| Error handling | `common.error.empty_catch` | 7 | 4 | -3 |
+| Error handling | `common.network.missing_error_handling` | 6 | 0 | -6 |
+| Workflow | `workflow.bdd.missing_feature_files` | 1 | 1 | 0 |
+| Workflow | `workflow.bdd.insufficient_features` | 1 | 1 | 0 |
+| Quality hygiene | `common.debug.console` | 3 | 0 | -3 |
+| Quality hygiene | `common.quality.todo_fixme` | 1 | 0 | -1 |
+| Testing quality | `common.testing.prefer_spy_over_mock` | 1 | 0 | -1 |
+| Maintainability | `shell.maintainability.large_script` | 1 | 0 | -1 |
+
+### Lectura de brechas
+
+- Déficit principal en `HIGH/MEDIUM` concentrado en:
+  - `unknown_without_guard` (gap 12)
+  - `record_unknown_requires_type` (gap 7)
+  - `network.missing_error_handling` (gap 6)
+- Déficit secundario:
+  - `empty_catch` (gap 3)
+  - higiene de calidad (`console/todo/spy/large_script`) (gap agregado 6)
+- Superávit:
+  - `undefined_in_base_type` (+32), ya por encima de legacy.
+
+## Plan de corrección priorizado (impacto)
+
+1. `P0` Recuperar paridad `HIGH/MEDIUM` en type safety:
+   - reforzar detectores y cobertura de `unknown_without_guard` y `record_unknown_requires_type`.
+   - objetivo mínimo: cerrar gap `12 + 7 = 19`.
+2. `P0` Recuperar `error handling` de red:
+   - activar/ajustar `common.network.missing_error_handling` (actual `0`, objetivo `>=6`).
+3. `P1` Cerrar gap de `empty_catch`:
+   - ampliar detectores para igualar/superar baseline (`4 -> >=7`).
+4. `P1` Reintroducir señales de higiene:
+   - `common.debug.console`, `common.quality.todo_fixme`, `common.testing.prefer_spy_over_mock`, `shell.maintainability.large_script`.
+5. `P2` Revalidación final:
+   - rerun full audit + parity report.
+   - criterio de salida: `CRITICAL/HIGH/MEDIUM` enterprise `>=` legacy en matriz de severidad.

--- a/docs/validation/post-merge-detection-audit-report.md
+++ b/docs/validation/post-merge-detection-audit-report.md
@@ -1,0 +1,68 @@
+# Post-Merge Detection Audit Report
+
+Informe consolidado oficial posterior al merge del ciclo de recuperación enterprise.
+
+## Contexto
+- Branch auditada: `develop`
+- Stage: `PRE_COMMIT`
+- Audit mode: `engine`
+- Outcome: `BLOCK`
+- Files scanned: `981`
+- Files affected: `64`
+- Total violations: `83`
+- Generated at: `2026-02-23T12:48:48.275Z`
+
+## Resumen por severidad (canónica)
+- `CRITICAL`: `42`
+- `HIGH`: `37`
+- `MEDIUM`: `4`
+- `LOW`: `0`
+
+## Top reglas (por volumen)
+| Regla | Total | C | H | M | L |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `common.types.undefined_in_base_type` | 33 | 33 | 0 | 0 | 0 |
+| `common.types.record_unknown_requires_type` | 26 | 0 | 26 | 0 | 0 |
+| `common.error.empty_catch` | 4 | 4 | 0 | 0 | 0 |
+| `common.types.unknown_without_guard` | 4 | 0 | 0 | 4 | 0 |
+| `skills.backend.no-empty-catch` | 4 | 4 | 0 | 0 | 0 |
+| `skills.frontend.no-empty-catch` | 4 | 0 | 4 | 0 | 0 |
+| `heuristics.ts.child-process-exec-file-sync.ast` | 1 | 0 | 1 | 0 | 0 |
+| `heuristics.ts.child-process-exec-file-untrusted-args.ast` | 1 | 0 | 1 | 0 | 0 |
+| `heuristics.ts.child-process-exec.ast` | 1 | 0 | 1 | 0 | 0 |
+| `heuristics.ts.dynamic-shell-invocation.ast` | 1 | 0 | 1 | 0 | 0 |
+| `heuristics.ts.process-exit.ast` | 1 | 0 | 1 | 0 | 0 |
+| `sdd.policy.blocked` | 1 | 0 | 1 | 0 | 0 |
+| `workflow.bdd.insufficient_features` | 1 | 0 | 1 | 0 | 0 |
+| `workflow.bdd.missing_feature_files` | 1 | 1 | 0 | 0 | 0 |
+
+## Top ficheros (por volumen, clicables)
+| Fichero | Total | C | H | M | L | Enlace |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `scripts/framework-menu-matrix-canary-lib.ts` | 5 | 2 | 3 | 0 | 0 | [scripts/framework-menu-matrix-canary-lib.ts:54](../../scripts/framework-menu-matrix-canary-lib.ts#L54) |
+| `integrations/lifecycle/gitService.ts` | 4 | 3 | 1 | 0 | 0 | [integrations/lifecycle/gitService.ts:25](../../integrations/lifecycle/gitService.ts#L25) |
+| `core/facts/extractHeuristicFacts.ts` | 3 | 0 | 3 | 0 | 0 | [core/facts/extractHeuristicFacts.ts:3](../../core/facts/extractHeuristicFacts.ts#L3) |
+| `integrations/config/skillsCustomRules.ts` | 3 | 1 | 1 | 1 | 0 | [integrations/config/skillsCustomRules.ts:3](../../integrations/config/skillsCustomRules.ts#L3) |
+| `integrations/lifecycle/update.ts` | 3 | 2 | 1 | 0 | 0 | [integrations/lifecycle/update.ts:54](../../integrations/lifecycle/update.ts#L54) |
+| `integrations/mcp/enterpriseServer.ts` | 3 | 1 | 1 | 1 | 0 | [integrations/mcp/enterpriseServer.ts:3](../../integrations/mcp/enterpriseServer.ts#L3) |
+| `scripts/adapter-session-status-writes-log-filter-lib.ts` | 3 | 2 | 1 | 0 | 0 | [scripts/adapter-session-status-writes-log-filter-lib.ts:54](../../scripts/adapter-session-status-writes-log-filter-lib.ts#L54) |
+| `core/facts/detectors/typescript/index.ts` | 2 | 1 | 1 | 0 | 0 | [core/facts/detectors/typescript/index.ts:3](../../core/facts/detectors/typescript/index.ts#L3) |
+| `PROJECT_ROOT` | 2 | 1 | 1 | 0 | 0 | [PROJECT_ROOT](../../PROJECT_ROOT#L1) |
+| `core/facts/detectors/browser/index.ts` | 1 | 0 | 1 | 0 | 0 | [core/facts/detectors/browser/index.ts:3](../../core/facts/detectors/browser/index.ts#L3) |
+| `core/facts/detectors/process/core.ts` | 1 | 0 | 1 | 0 | 0 | [core/facts/detectors/process/core.ts:3](../../core/facts/detectors/process/core.ts#L3) |
+| `core/facts/detectors/process/shell.ts` | 1 | 0 | 1 | 0 | 0 | [core/facts/detectors/process/shell.ts:3](../../core/facts/detectors/process/shell.ts#L3) |
+| `core/facts/detectors/process/spawn.ts` | 1 | 0 | 1 | 0 | 0 | [core/facts/detectors/process/spawn.ts:3](../../core/facts/detectors/process/spawn.ts#L3) |
+| `core/facts/detectors/security/securityCredentials.ts` | 1 | 0 | 1 | 0 | 0 | [core/facts/detectors/security/securityCredentials.ts:3](../../core/facts/detectors/security/securityCredentials.ts#L3) |
+| `core/facts/detectors/security/securityCrypto.ts` | 1 | 0 | 1 | 0 | 0 | [core/facts/detectors/security/securityCrypto.ts:3](../../core/facts/detectors/security/securityCrypto.ts#L3) |
+
+## Cobertura de reglas
+- active: `417`
+- evaluated: `417`
+- unevaluated: `0`
+- coverage_ratio: `1`
+
+## Evidencias fuente
+- `.ai_evidence.json`
+- `.audit_tmp/p-adhoc-lines-008-menu.out`
+- `.audit-reports/p-adhoc-lines-008-full-repo-audit.md`
+- `.audit-reports/pumuki-legacy-audit.md`

--- a/integrations/git/__tests__/findingTraceability.test.ts
+++ b/integrations/git/__tests__/findingTraceability.test.ts
@@ -116,6 +116,78 @@ test('attachFindingTraceability agrega filePath para reglas Heuristic', () => {
   assert.equal(traced[0]?.source, 'heuristics:ast');
 });
 
+test('attachFindingTraceability respeta lineas del fichero del finding para reglas Heuristic', () => {
+  const rules: RuleSet = [
+    {
+      id: 'common.types.unknown_without_guard',
+      description: 'Unknown sin guardas',
+      severity: 'WARN',
+      when: {
+        kind: 'Heuristic',
+        where: {
+          ruleId: 'common.types.unknown_without_guard',
+        },
+      },
+      then: {
+        kind: 'Finding',
+        code: 'COMMON_TYPES_UNKNOWN_WITHOUT_GUARD',
+        message: 'Unknown sin guard',
+      },
+    },
+  ];
+
+  const facts: ReadonlyArray<Fact> = [
+    {
+      kind: 'Heuristic',
+      ruleId: 'common.types.unknown_without_guard',
+      severity: 'WARN',
+      code: 'COMMON_TYPES_UNKNOWN_WITHOUT_GUARD_AST',
+      message: 'Unknown usage',
+      filePath: 'src/a.ts',
+      lines: [11],
+      source: 'heuristics:ast',
+    },
+    {
+      kind: 'Heuristic',
+      ruleId: 'common.types.unknown_without_guard',
+      severity: 'WARN',
+      code: 'COMMON_TYPES_UNKNOWN_WITHOUT_GUARD_AST',
+      message: 'Unknown usage',
+      filePath: 'src/b.ts',
+      lines: [29],
+      source: 'heuristics:ast',
+    },
+  ];
+
+  const findings: ReadonlyArray<Finding> = [
+    {
+      ruleId: 'common.types.unknown_without_guard',
+      severity: 'WARN',
+      code: 'COMMON_TYPES_UNKNOWN_WITHOUT_GUARD',
+      message: 'Unknown sin guard',
+      filePath: 'src/a.ts',
+    },
+    {
+      ruleId: 'common.types.unknown_without_guard',
+      severity: 'WARN',
+      code: 'COMMON_TYPES_UNKNOWN_WITHOUT_GUARD',
+      message: 'Unknown sin guard',
+      filePath: 'src/b.ts',
+    },
+  ];
+
+  const traced = attachFindingTraceability({
+    findings,
+    rules,
+    facts,
+  });
+
+  assert.deepEqual(
+    traced.map((finding) => finding.lines),
+    [[11], [29]]
+  );
+});
+
 test('attachFindingTraceability mantiene finding sin contexto cuando la regla es Not pura', () => {
   const rules: RuleSet = [
     {


### PR DESCRIPTION
## Resumen
- refuerzo de heurísticas TS para `unknown_without_guard` y `missing_error_handling`
- trazabilidad heurística por fichero/línea corregida
- cierre de revalidación cycle 012 documentado
- paridad legacy por severidad en PASS (CRITICAL/HIGH/MEDIUM/LOW)

## Validación
- `node --import tsx --test core/facts/detectors/typescript/index.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts integrations/git/__tests__/findingTraceability.test.ts`
- `npx tsc --noEmit`
- smoke hooks y menú (`1/8/9`) con evidencias en `.audit_tmp/p-adhoc-lines-012-*`
- parity report: `.audit-reports/p-adhoc-lines-012-legacy-parity-v2.md`
