### PR TITLE
docs: baseline y plan de saneamiento CI (cycle 014)

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -94,10 +94,10 @@ Estado operativo activo del repositorio.
     - menú `1` refleja severidad y top violaciones con rutas clicables actualizadas
 
 ## Siguiente paso operativo
-- 🚧 Ejecutar `P-ADHOC-LINES-012` para cierre final del ciclo enterprise.
+- 🚧 Ejecutar `P-ADHOC-LINES-014` para saneamiento CI post-merge en `main`.
 
 ## Backlog global restante
-- 🚧 `P-ADHOC-LINES-012` Cierre final del ciclo enterprise:
+- ✅ `P-ADHOC-LINES-012` Cierre final del ciclo enterprise:
   - ✅ revalidación integral ejecutada:
     - tests focales `48/48` en `.audit_tmp/p-adhoc-lines-012-tests.out`
     - `typecheck` `OK` en `.audit_tmp/p-adhoc-lines-012-typecheck.out`
@@ -117,5 +117,25 @@ Estado operativo activo del repositorio.
   - ✅ paridad legacy por severidad cerrada:
     - `CRITICAL 42 >= 9`, `HIGH 43 >= 41`, `MEDIUM 59 >= 21`, `LOW 0 = 0`
     - reporte: `.audit-reports/p-adhoc-lines-012-legacy-parity-v2.md`
-  - ⏳ cierre operativo pendiente:
-    - cierre Git Flow end-to-end del ciclo de remediación
+  - ✅ cierre Git Flow end-to-end completado:
+    - PR `#360` (feature -> `develop`) merged
+    - PR `#361` (`develop` -> `main`) merged (admin)
+    - ramas locales y remotas sincronizadas con solo `develop` y `main`
+- ✅ `P-ADHOC-LINES-013` Verificación post-merge de estabilidad:
+  - estado post-merge de `PR #361` verificado (`MERGED`, commit `cedaf08f93d70ad7d820556f2574becf8ed03f6b`)
+  - baseline de checks no verdes consolidado en:
+    - `.audit_tmp/p-adhoc-lines-013-main-pr-checks.tsv`
+    - `.audit_tmp/p-adhoc-lines-013-main-pr-checks-unique.tsv`
+  - nota oficial de riesgo residual y plan de saneamiento publicada:
+    - `docs/validation/post-merge-main-stability-note.md`
+  - índice documental actualizado en `docs/validation/README.md`
+- 🚧 `P-ADHOC-LINES-014` Saneamiento CI post-merge en `main`:
+  - ✅ baseline de fallos post-merge recopilado:
+    - `.audit_tmp/p-adhoc-lines-013-main-pr-checks.tsv`
+    - `.audit_tmp/p-adhoc-lines-013-main-pr-checks-unique.tsv`
+    - `.audit_tmp/p-adhoc-lines-014-ci-failure-map.md`
+  - ✅ plan incremental por dominios documentado:
+    - `docs/validation/ci-sanitization-plan-cycle-014.md`
+  - ⏳ reproducir fallos clave de checks en local (por lote) y confirmar causas raíz
+  - ⏳ ejecutar correcciones por lotes con PR incremental sin bypass admin
+  - ⏳ objetivo de salida: checks críticos en verde en `main`

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -22,6 +22,8 @@ Keep these as source-of-truth operational references:
 - `detection-audit-baseline.md`
 - `enterprise-detection-recovery-closure.md`
 - `enterprise-detection-revalidation-cycle-012.md`
+- `post-merge-main-stability-note.md`
+- `ci-sanitization-plan-cycle-014.md`
 - `post-merge-detection-audit-report.md`
 - `legacy-parity-gap-analysis.md`
 

--- a/docs/validation/ci-sanitization-plan-cycle-014.md
+++ b/docs/validation/ci-sanitization-plan-cycle-014.md
@@ -1,0 +1,59 @@
+# CI Sanitization Plan — Cycle 014
+
+Plan operativo para sanear CI en `main` tras cierre del ciclo de detección.
+
+## Baseline actual (post-merge)
+
+Fuente de baseline:
+
+- `.audit_tmp/p-adhoc-lines-013-main-pr-checks-unique.tsv`
+- `.audit_tmp/p-adhoc-lines-014-ci-failure-map.md`
+
+Workflows con fallo detectados:
+
+1. `CI` (9 jobs fallando)
+2. `Pumuki Package Smoke` (2 jobs)
+3. `Pumuki Frontend Gate` (1 job)
+4. `Pumuki Deterministic Tests` (1 job)
+5. `Pumuki Phase5 Mock Closure` (1 job)
+6. `Pumuki Heuristics Tests` (1 job)
+7. `Pumuki iOS Gate` (1 job)
+8. `Pumuki Backend Gate` (1 job)
+9. `Pumuki Android Gate` (1 job)
+10. `security/snyk` (error externo)
+
+## Agrupación por dominio
+
+- `Core CI`: Lint, Type Check, Build Verification, matrix Node 18/20 macOS+Ubuntu, Stage Gate Tests, Skills Lock Freshness.
+- `Rule gates`: iOS, Android, Backend, Frontend gates.
+- `Quality suites`: heuristics tests, deterministic tests.
+- `Packaging`: smoke minimal/block.
+- `External security`: Snyk status.
+
+## Estrategia incremental (sin bypass admin)
+
+### Fase A — Estabilización base
+
+- Objetivo: verde en `Lint`, `Type Check`, `Build Verification` y `Stage Gate Tests`.
+- Salida: PR pequeño orientado a CI core.
+
+### Fase B — Suites de calidad
+
+- Objetivo: verde en `heuristics-tests` y `deterministic-tests`.
+- Salida: PR independiente para evitar mezcla de causas.
+
+### Fase C — Gates por plataforma
+
+- Objetivo: verde en `ios-gate`, `android-gate`, `backend-gate`, `frontend-gate`.
+- Salida: PR por lote (o por plataforma si hay acoplamiento alto).
+
+### Fase D — Packaging y seguridad
+
+- Objetivo: verde en `package-smoke (minimal/block)` y triage de `security/snyk`.
+- Salida: PR técnico + nota operativa para dependencia externa (Snyk) si aplica.
+
+## Criterio de cierre
+
+- `main` sin merge administrativo para cambios funcionales de este ciclo.
+- Todos los checks críticos en verde en PR `develop -> main`.
+- Evidencia consolidada en `docs/validation/post-merge-main-stability-note.md`.

--- a/docs/validation/post-merge-main-stability-note.md
+++ b/docs/validation/post-merge-main-stability-note.md
@@ -1,0 +1,71 @@
+# Post-Merge Main Stability Note (Cycle 013)
+
+Estado de estabilidad tras merge administrativo de `develop` a `main` (`PR #361`).
+
+## Estado de ramas
+
+- Local: solo `develop`, `main`.
+- Remotas: solo `origin/develop`, `origin/main`.
+- PRs del cierre:
+  - `#360` merged a `develop`.
+  - `#361` merged a `main` (admin merge, política de base bloqueaba merge normal).
+
+## Estado del PR #361
+
+- URL: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/361`
+- Estado: `MERGED`
+- Merge commit: `cedaf08f93d70ad7d820556f2574becf8ed03f6b`
+- `mergeStateStatus` previo al merge: `BLOCKED`
+- `reviewDecision` previo al merge: `REVIEW_REQUIRED`
+
+## Checks no verdes detectados (baseline post-merge)
+
+Fuente: `.audit_tmp/p-adhoc-lines-013-main-pr-checks-unique.tsv`
+
+1. CI / Build Verification — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457851
+2. CI / Lint — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457789
+3. CI / Skills Lock Freshness — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457802
+4. CI / Stage Gate Tests — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457843
+5. CI / Test - Node 18.x on macos-latest — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457840
+6. CI / Test - Node 18.x on ubuntu-latest — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457831
+7. CI / Test - Node 20.x on macos-latest — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457857
+8. CI / Test - Node 20.x on ubuntu-latest — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457839
+9. CI / Type Check — FAILURE  
+   https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094220/job/64532457804
+10. Pumuki Android Gate / android-gate — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094304/job/64532457906
+11. Pumuki Backend Gate / backend-gate — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094239/job/64532457919
+12. Pumuki Deterministic Tests — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094211/job/64532457936
+13. Pumuki Frontend Gate / frontend-gate — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094207/job/64532457799
+14. Pumuki Heuristics Tests — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094228/job/64532457800
+15. Pumuki Package Smoke (block) — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094202/job/64532458056
+16. Pumuki Package Smoke (minimal) — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094202/job/64532458182
+17. Pumuki Phase5 Mock Closure — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094221/job/64532457782
+18. Pumuki iOS Gate / ios-gate — FAILURE  
+    https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22308094231/job/64532457934
+19. security/snyk (swiftenprofundidad) — ERROR  
+    https://app.snyk.io/org/swiftenprofundidad/pr-checks/4fcc9f2f-f4ea-44e9-8191-f4a5ab187c4a
+
+## Riesgo residual
+
+- El repositorio queda sincronizado en ramas protegidas, pero la salud CI global en `main` no está verde.
+- Se mantiene riesgo operativo de regresiones no detectadas por pipeline hasta normalizar checks.
+
+## Siguiente paso recomendado
+
+- Ejecutar un ciclo dedicado de saneamiento CI por lotes (`lint/typecheck/tests/gates/package smoke/snyk`) con PR incremental y reglas de salida: checks críticos en verde antes del siguiente merge administrativo.


### PR DESCRIPTION
## Resumen
- consolida baseline post-merge de fallos CI en `main`
- publica nota oficial de estabilidad post-merge (`P-ADHOC-LINES-013`)
- publica plan incremental de saneamiento CI (`P-ADHOC-LINES-014`)
- actualiza tracker y catálogo de docs de validación

## Documentación añadida
- `docs/validation/post-merge-main-stability-note.md`
- `docs/validation/ci-sanitization-plan-cycle-014.md`

## Tracker
- `P-ADHOC-LINES-013` marcado en ✅
- `P-ADHOC-LINES-014` queda en 🚧 con backlog técnico
