### PR TITLE
docs(validation): external follow-up probe #1 (cycle 014)

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -272,6 +272,11 @@ Plan base visible para seguimiento previo y durante la implementacion.
   - ✅ playbook operativo de seguimiento externo publicado:
     - `docs/validation/ci-sanitization-cycle-014-external-follow-up.md`
     - índice actualizado: `docs/validation/README.md`
+  - ✅ sondeo externo #1 registrado:
+    - PR muestra: `#382` (`37/37` checks no verdes)
+    - `security/snyk (swiftenprofundidad)` en `ERROR`
+    - muestreo de jobs confirma patrón externo (`runner_id=0`, `steps=[]`) en CI/gate/package
+    - evidencia en `.audit_tmp/p-adhoc-lines-015-pr-382-*.json` y `.audit_tmp/p-adhoc-lines-015-pr382-*.json`
   - vigilar restablecimiento de billing en GitHub Actions y estado de `security/snyk`;
   - al restablecerse, abrir PR de control `develop -> main` sin admin y capturar nueva evidencia remota;
   - cerrar con actualización de documentación si la ejecución remota estricta queda en verde.

--- a/docs/validation/ci-sanitization-cycle-014-external-follow-up.md
+++ b/docs/validation/ci-sanitization-cycle-014-external-follow-up.md
@@ -41,3 +41,28 @@ Seguimiento operativo posterior al cierre administrativo del ciclo `014`, orient
 - seguimiento activo por bloqueo externo (billing de Actions + dependencia Snyk).
 - cierre administrativo ya publicado en:
   - `docs/validation/ci-sanitization-cycle-014-administrative-closure.md`
+
+## Sondeo #1 de seguimiento externo (2026-02-23)
+
+PR usada para muestra reciente:
+
+- `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/382`
+
+Resultado agregado:
+
+- `37/37` checks no verdes.
+- `security/snyk (swiftenprofundidad)` continúa en `ERROR`.
+
+Muestreo API de jobs (dominios distintos):
+
+- CI (`job 64557071687`) -> `runner_id=0`, `steps=[]`
+- Android gate (`job 64557071688`) -> `runner_id=0`, `steps=[]`
+- package-smoke minimal (`job 64557059070`) -> `runner_id=0`, `steps=[]`
+
+Evidencia:
+
+- `.audit_tmp/p-adhoc-lines-015-pr-382-status.json`
+- `.audit_tmp/p-adhoc-lines-015-pr-382-checks.json`
+- `.audit_tmp/p-adhoc-lines-015-pr382-ci-job.json`
+- `.audit_tmp/p-adhoc-lines-015-pr382-android-job.json`
+- `.audit_tmp/p-adhoc-lines-015-pr382-package-minimal-job.json`


### PR DESCRIPTION
Registra el sondeo #1 post-cierre administrativo: checks no verdes, patrón runner_id=0 y Snyk ERROR.