### PR TITLE
docs(validation): external follow-up probe #9 (cycle 014)

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -312,6 +312,11 @@ Plan base visible para seguimiento previo y durante la implementacion.
     - `security/snyk (swiftenprofundidad)` en `ERROR`
     - muestreo de jobs confirma patrón externo (`runner_id=0`, `steps=[]`) en CI/gate/package
     - evidencia en `.audit_tmp/p-adhoc-lines-015-pr-389-*.json` y `.audit_tmp/p-adhoc-lines-015-pr389-*.json`
+  - ✅ sondeo externo #9 registrado:
+    - PR muestra: `#390` (`37/37` checks no verdes)
+    - `security/snyk (swiftenprofundidad)` en `ERROR`
+    - muestreo de jobs confirma patrón externo (`runner_id=0`, `steps=[]`) en CI/gate/package
+    - evidencia en `.audit_tmp/p-adhoc-lines-015-pr-390-*.json` y `.audit_tmp/p-adhoc-lines-015-pr390-*.json`
   - vigilar restablecimiento de billing en GitHub Actions y estado de `security/snyk`;
   - al restablecerse, abrir PR de control `develop -> main` sin admin y capturar nueva evidencia remota;
   - cerrar con actualización de documentación si la ejecución remota estricta queda en verde.

--- a/docs/validation/ci-sanitization-cycle-014-external-follow-up.md
+++ b/docs/validation/ci-sanitization-cycle-014-external-follow-up.md
@@ -241,3 +241,28 @@ Evidencia:
 - `.audit_tmp/p-adhoc-lines-015-pr389-ci-job.json`
 - `.audit_tmp/p-adhoc-lines-015-pr389-android-job.json`
 - `.audit_tmp/p-adhoc-lines-015-pr389-package-minimal-job.json`
+
+## Sondeo #9 de seguimiento externo (2026-02-23)
+
+PR usada para muestra más reciente:
+
+- `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/390`
+
+Resultado agregado:
+
+- `37/37` checks no verdes.
+- `security/snyk (swiftenprofundidad)` continúa en `ERROR`.
+
+Muestreo API de jobs (dominios distintos):
+
+- CI (`job 64565936100`) -> `runner_id=0`, `steps=[]`
+- Android gate (`job 64565926785`) -> `runner_id=0`, `steps=[]`
+- package-smoke minimal (`job 64565936119`) -> `runner_id=0`, `steps=[]`
+
+Evidencia:
+
+- `.audit_tmp/p-adhoc-lines-015-pr-390-status.json`
+- `.audit_tmp/p-adhoc-lines-015-pr-390-checks.json`
+- `.audit_tmp/p-adhoc-lines-015-pr390-ci-job.json`
+- `.audit_tmp/p-adhoc-lines-015-pr390-android-job.json`
+- `.audit_tmp/p-adhoc-lines-015-pr390-package-minimal-job.json`


### PR DESCRIPTION
Registra sondeo #9 de seguimiento externo: checks no verdes, Snyk ERROR y patrón runner_id=0 en jobs de muestra.