### PR TITLE
promote: cierre fase D ciclo 018 (develop -> main)

### DIFF
--- a/docs/ENTERPRISE_EXECUTION_CYCLE_018.md
+++ b/docs/ENTERPRISE_EXECUTION_CYCLE_018.md
@@ -33,9 +33,9 @@ Modelo de entrega: Git Flow end-to-end + TDD (red/green/refactor)
 - ✅ `C018.C.T3` PR `develop -> main`, merge y sincronizacion de ramas protegidas.
 
 ### Fase D - Verificacion final y control operativo
-- 🚧 `C018.D.T1` Revalidacion funcional/visual del lote en local.
-- ⏳ `C018.D.T2` Actualizar documentacion oficial de validacion.
-- ⏳ `C018.D.T3` Cerrar ciclo o dejar siguiente tarea explicitamente en construccion.
+- ✅ `C018.D.T1` Revalidacion funcional/visual del lote en local.
+- ✅ `C018.D.T2` Actualizar documentacion oficial de validacion.
+- 🚧 `C018.D.T3` Cerrar ciclo o dejar siguiente tarea explicitamente en construccion.
 
 ## Siguiente tarea activa
-- `C018.D.T1` Revalidacion funcional/visual del lote en local.
+- `C018.D.T3` Cerrar ciclo o dejar siguiente tarea explicitamente en construccion.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -385,4 +385,20 @@ Plan base visible para seguimiento previo y durante la implementacion.
     - PR de promote: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/397`
     - rama origen: `develop`
     - rama destino: `main`
-  - 🚧 `C018.D.T1` En curso: revalidación funcional/visual local del lote ya promovido.
+  - ✅ `C018.D.T1` Revalidación funcional/visual local completada sobre lote promovido:
+    - reporte versionado: `docs/validation/c018-d1-local-revalidation.md`
+    - validación funcional:
+      - `stagePolicies-config-and-severity` (`8/8`)
+      - `stagePolicies` (`8/8`)
+      - `stagePolicies-promotions-third-platform-heuristics` (`13/13`)
+      - `lifecycle` (`16/16`)
+      - `typecheck` (`OK`)
+    - validación visual:
+      - `framework-menu-consumer-runtime` (`9/9`) con badges y trazabilidad clicable en menú/export.
+  - ✅ `C018.D.T2` Documentación oficial consolidada:
+    - nuevo cierre oficial: `docs/validation/c018-cycle-validation-closure.md`
+    - índice actualizado: `docs/validation/README.md`
+    - evidencias versionadas registradas:
+      - `docs/validation/c018-c1-local-evidence.md`
+      - `docs/validation/c018-d1-local-revalidation.md`
+  - 🚧 `C018.D.T3` En curso: cierre final del ciclo 018 y estado listo para siguientes instrucciones.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -30,6 +30,9 @@ Keep these as source-of-truth operational references:
 - `ci-sanitization-cycle-014-local-ci-closure.md`
 - `post-merge-detection-audit-report.md`
 - `legacy-parity-gap-analysis.md`
+- `c018-c1-local-evidence.md`
+- `c018-d1-local-revalidation.md`
+- `c018-cycle-validation-closure.md`
 
 ## Generated Outputs (Do Not Keep as Baseline Docs)
 

--- a/docs/validation/c018-cycle-validation-closure.md
+++ b/docs/validation/c018-cycle-validation-closure.md
@@ -1,0 +1,54 @@
+# Cycle 018 — Validation Closure
+
+## Scope
+
+Official validation closure for cycle `018`, covering:
+
+- stage policy hardening to unify heuristic severity behavior
+- TDD `RED -> GREEN -> REFACTOR` traceability
+- Git Flow promotes across protected branches
+- local functional and visual revalidation bundle
+
+## Delivery Trace
+
+- Feature lot merge to `develop`:
+  - PR `#396`: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/396`
+  - merge commit: `2747ab80cffa796c7b12aad35d94042a19ba3b3b`
+- Promote `develop -> main`:
+  - PR `#397`: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/397`
+  - merge commit: `d25bbf9ce3a22f29bc770ea7528562b4d3c55bf9`
+- Phase D validation updates:
+  - PR `#398`: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/398`
+
+## Technical Outcomes
+
+- `heuristics.ts.empty-catch.ast` unified to blocking severity (`ERROR`) in:
+  - `PRE_COMMIT`
+  - `PRE_PUSH`
+  - `CI`
+- Stage policy internals refactored without behavioral regression.
+- Rule and menu traceability preserved (clickable diagnostics/export).
+
+## Validation Artifacts
+
+- Cycle C evidence bundle:
+  - `docs/validation/c018-c1-local-evidence.md`
+- Cycle D functional/visual revalidation:
+  - `docs/validation/c018-d1-local-revalidation.md`
+- Raw command outputs:
+  - `.audit_tmp/c018-c1/*`
+  - `.audit_tmp/c018-d1/*`
+
+## Gate Status
+
+- Local gate policy tests: `PASS`
+- Lifecycle integration tests: `PASS`
+- Menu runtime visual tests: `PASS`
+- TypeScript typecheck: `PASS`
+
+## Branch Synchronization
+
+At closure publication time:
+
+- `origin/main...origin/develop = 0 0`
+- protected branches are synchronized.

--- a/docs/validation/c018-d1-local-revalidation.md
+++ b/docs/validation/c018-d1-local-revalidation.md
@@ -1,0 +1,47 @@
+# Cycle 018 — D.T1 Local Functional/Visual Revalidation
+
+Timestamp (UTC): `2026-02-23T21:39:46Z`
+
+## Scope
+
+Functional and visual local revalidation of the promoted lot after `C018.C.T3` (`develop -> main`), preserving enterprise behavior and traceability.
+
+## Functional Validation
+
+1. `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies-config-and-severity.test.ts`
+2. `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts`
+3. `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies-promotions-third-platform-heuristics.test.ts`
+4. `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/lifecycle.test.ts`
+5. `npm run -s typecheck`
+
+Results:
+
+- stage policies config/severity: `8/8` pass
+- stage policies core: `8/8` pass
+- stage policies promotions: `13/13` pass
+- lifecycle CLI/runtime integration: `16/16` pass
+- typecheck: pass (`0` output lines)
+
+## Visual Validation (Menu Runtime)
+
+Command:
+
+- `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-consumer-runtime.test.ts`
+
+Verified behavior:
+
+- status badge render (`PASS/WARN/BLOCK`)
+- classic vs modern menu fallback
+- clickable diagnostics in option `9` (`file:line`)
+- markdown export with clickable links in option `8`
+
+Result: `9/9` pass.
+
+## Raw Artifacts
+
+- `.audit_tmp/c018-d1/stagePolicies-config-and-severity.out`
+- `.audit_tmp/c018-d1/stagePolicies.out`
+- `.audit_tmp/c018-d1/stagePolicies-promotions-third-platform-heuristics.out`
+- `.audit_tmp/c018-d1/lifecycle.out`
+- `.audit_tmp/c018-d1/framework-menu-consumer-runtime.out`
+- `.audit_tmp/c018-d1/typecheck.out`


### PR DESCRIPTION
## Resumen
- promote final de `develop` a `main` para cierre operativo del ciclo 018
- incluye revalidación funcional/visual (`D.T1`) y cierre documental oficial (`D.T2`)

## Referencias
- PR fase D (feature -> develop): #398
- cierre validación: `docs/validation/c018-cycle-validation-closure.md`
- reporte D1: `docs/validation/c018-d1-local-revalidation.md`
