### PR TITLE
docs: cierre ciclo 018 y standby operativo 019A

### DIFF
--- a/docs/ENTERPRISE_EXECUTION_CYCLE_018.md
+++ b/docs/ENTERPRISE_EXECUTION_CYCLE_018.md
@@ -1,6 +1,6 @@
 # Enterprise Execution Cycle 018
 
-Estado del ciclo: 🚧 En construccion  
+Estado del ciclo: ✅ Cerrado (con standby operativo)  
 Rama base: `develop`  
 Modelo de entrega: Git Flow end-to-end + TDD (red/green/refactor)
 
@@ -35,7 +35,10 @@ Modelo de entrega: Git Flow end-to-end + TDD (red/green/refactor)
 ### Fase D - Verificacion final y control operativo
 - ✅ `C018.D.T1` Revalidacion funcional/visual del lote en local.
 - ✅ `C018.D.T2` Actualizar documentacion oficial de validacion.
-- 🚧 `C018.D.T3` Cerrar ciclo o dejar siguiente tarea explicitamente en construccion.
+- ✅ `C018.D.T3` Cerrar ciclo o dejar siguiente tarea explicitamente en construccion.
+
+### Post-Cierre (operativo)
+- 🚧 `C018.POST.T1` Standby operativo hasta apertura del siguiente ciclo.
 
 ## Siguiente tarea activa
-- `C018.D.T3` Cerrar ciclo o dejar siguiente tarea explicitamente en construccion.
+- `C018.POST.T1` Standby operativo hasta apertura del siguiente ciclo.

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -345,7 +345,7 @@ Plan base visible para seguimiento previo y durante la implementacion.
 - ✅ `P-ADHOC-LINES-018A` Cierre documental de ciclos previos consolidado.
 - ✅ `P-ADHOC-LINES-018B` Nuevo ciclo oficial creado en `docs/ENTERPRISE_EXECUTION_CYCLE_018.md` con fases, tareas y leyenda.
 - ✅ `P-ADHOC-LINES-018C` Preparar primera entrega atomica del ciclo 018 con rama `feature/*`, TDD estricto y actualizacion incremental del tracker.
-- 🚧 `P-ADHOC-LINES-018D` Ejecutar primer lote tecnico del ciclo 018 y cerrar su Git Flow end-to-end.
+- ✅ `P-ADHOC-LINES-018D` Ejecutar primer lote tecnico del ciclo 018 y cerrar su Git Flow end-to-end.
   - ✅ `C018.B.T1` RED definida para severidad unificada de `heuristics.ts.empty-catch.ast`:
     - test añadido en `integrations/gate/__tests__/stagePolicies-config-and-severity.test.ts`
     - evidencia RED: `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies-config-and-severity.test.ts`
@@ -401,4 +401,14 @@ Plan base visible para seguimiento previo y durante la implementacion.
     - evidencias versionadas registradas:
       - `docs/validation/c018-c1-local-evidence.md`
       - `docs/validation/c018-d1-local-revalidation.md`
-  - 🚧 `C018.D.T3` En curso: cierre final del ciclo 018 y estado listo para siguientes instrucciones.
+  - ✅ `C018.D.T3` Cierre final completado:
+    - PR `#398` (`feature -> develop`) merged:
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/398`
+      - merge commit: `68b4a071c8fcab199dd608e6f72700a923c7af56`
+    - PR `#399` (`develop -> main`) merged:
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/399`
+      - merge commit: `0bc37cbe9f458f995eaeab74df3396061e79422a`
+    - sincronización final de ramas protegidas:
+      - `origin/main...origin/develop = 0/0`
+
+- 🚧 `P-ADHOC-LINES-019A` Standby operativo: esperar nuevas instrucciones explícitas del usuario para abrir ciclo siguiente.

--- a/docs/validation/c018-cycle-validation-closure.md
+++ b/docs/validation/c018-cycle-validation-closure.md
@@ -19,6 +19,9 @@ Official validation closure for cycle `018`, covering:
   - merge commit: `d25bbf9ce3a22f29bc770ea7528562b4d3c55bf9`
 - Phase D validation updates:
   - PR `#398`: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/398`
+- Final phase D promote and protected branches sync:
+  - PR `#399`: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/399`
+  - merge commit: `0bc37cbe9f458f995eaeab74df3396061e79422a`
 
 ## Technical Outcomes
 


### PR DESCRIPTION
## Resumen
- marca `C018.D.T3` como completada
- cierra `P-ADHOC-LINES-018D`
- abre `P-ADHOC-LINES-019A` como única tarea en construcción (standby operativo)
- actualiza trazabilidad del cierre oficial con PR `#399`

## Validación
- `./scripts/check-refactor-progress-single-active.sh docs/REFRACTOR_PROGRESS.md`
