### PR TITLE
docs: cierre final ciclo 019 (standby operativo)

### DIFF
--- a/docs/ENTERPRISE_EXECUTION_CYCLE_019.md
+++ b/docs/ENTERPRISE_EXECUTION_CYCLE_019.md
@@ -1,6 +1,6 @@
 # Enterprise Execution Cycle 019
 
-Estado del ciclo: 🚧 En construccion  
+Estado del ciclo: ✅ Cerrado (standby operativo)  
 Rama base: `develop`  
 Modelo de entrega: Git Flow end-to-end + TDD (red/green/refactor)
 
@@ -46,16 +46,38 @@ Modelo de entrega: Git Flow end-to-end + TDD (red/green/refactor)
   - Evidencia local consolidada:
     - `.audit_tmp/c019-b2/*` (GREEN)
     - `.audit_tmp/c019-b3/*` (REFACTOR no-regresión)
-- 🚧 `C019.C.T2` PR `feature -> develop` y merge.
-- ⏳ `C019.C.T3` PR `develop -> main`, merge y sincronización de ramas protegidas.
+- ✅ `C019.C.T2` PR `feature -> develop` y merge.
+  - PR: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/402`
+  - Merge commit: `36f91731c60909e12ca49ba135448473ebf20af9`
+- ✅ `C019.C.T3` PR `develop -> main`, merge y sincronización de ramas protegidas.
+  - PR: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/403`
+  - Merge commit: `1ff50ccff7b3b8abb4409468d73a42d224b838a8`
+  - Sincronización local ejecutada en `develop` y `main` (`pull --ff-only`).
 
 ### Fase D - Cierre operativo
-- ⏳ `C019.D.T1` Revalidación funcional/visual post-promote.
-- ⏳ `C019.D.T2` Cierre documental oficial del ciclo.
-- ⏳ `C019.D.T3` Cierre final o paso a standby explícito.
+- ✅ `C019.D.T1` Revalidación funcional/visual post-promote.
+  - Validación funcional local:
+    - `.audit_tmp/c019-d1/stagePolicies-config-and-severity.out` (`8/8`, `exit=0`)
+    - `.audit_tmp/c019-d1/stagePolicies.out` (`8/8`, `exit=0`)
+    - `.audit_tmp/c019-d1/lifecycle.out` (`16/16`, `exit=0`)
+    - `.audit_tmp/c019-d1/menu-runtime.out` (`12/12`, `exit=0`)
+    - `.audit_tmp/c019-d1/typecheck.out` (`exit=0`)
+- ✅ `C019.D.T2` Cierre documental oficial del ciclo.
+  - Cierre consolidado en este documento de ciclo (sin apertura de MDs adicionales).
+  - Integración Git Flow registrada:
+    - `feature -> develop`: `PR #402`
+    - `develop -> main`: `PR #403`
+  - Evidencia local del ciclo consolidada:
+    - `.audit_tmp/c019-b1/*` (RED)
+    - `.audit_tmp/c019-b2/*` (GREEN)
+    - `.audit_tmp/c019-b3/*` (REFACTOR)
+    - `.audit_tmp/c019-d1/*` (post-promote revalidation)
+- ✅ `C019.D.T3` Cierre final o paso a standby explícito.
+  - Ciclo `019` cerrado formalmente tras completar fases `A/B/C/D`.
+  - Queda en standby operativo hasta nueva instrucción explícita del usuario.
 
 ## Siguiente tarea activa
-- `C019.C.T2` PR `feature -> develop` y merge.
+- `STANDBY` Esperar nueva instrucción explícita del usuario para abrir el siguiente ciclo.
 
 ## Anexo consolidado de Fase A (A.T2 + A.T3)
 

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -453,4 +453,27 @@ Plan base visible para seguimiento previo y durante la implementacion.
   - ✅ evidencia local consolidada:
     - `.audit_tmp/c019-b2/*`
     - `.audit_tmp/c019-b3/*`
-- 🚧 `P-ADHOC-LINES-019H` Ejecutar `C019.C.T2`: abrir PR `feature -> develop` y merge.
+- ✅ `P-ADHOC-LINES-019H` Ejecutar `C019.C.T2`: abrir PR `feature -> develop` y merge.
+  - ✅ PR merged: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/402`
+  - ✅ merge commit: `36f91731c60909e12ca49ba135448473ebf20af9`
+- ✅ `P-ADHOC-LINES-019I` Ejecutar `C019.C.T3`: promote `develop -> main`, merge y sincronización.
+  - ✅ PR merged: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/403`
+  - ✅ merge commit: `1ff50ccff7b3b8abb4409468d73a42d224b838a8`
+  - ✅ sincronización local ejecutada:
+    - `develop` actualizado con `origin/develop`
+    - `main` actualizado con `origin/main`
+- ✅ `P-ADHOC-LINES-019J` Ejecutar `C019.D.T1`: revalidación funcional/visual post-promote en local.
+  - ✅ revalidación local:
+    - `integrations/gate/__tests__/stagePolicies-config-and-severity.test.ts` (`exit=0`)
+    - `integrations/gate/__tests__/stagePolicies.test.ts` (`exit=0`)
+    - `integrations/lifecycle/__tests__/lifecycle.test.ts` (`exit=0`)
+    - `scripts/__tests__/framework-menu-consumer-runtime.test.ts` (`exit=0`)
+    - `npm run -s typecheck` (`exit=0`)
+    - evidencia en `.audit_tmp/c019-d1/*`
+- ✅ `P-ADHOC-LINES-019K` Ejecutar `C019.D.T2`: cierre documental oficial del ciclo `019`.
+  - ✅ cierre consolidado en `docs/ENTERPRISE_EXECUTION_CYCLE_019.md` (sin nuevos MDs de cierre).
+  - ✅ trazabilidad final de ejecución y evidencia local unificada en el propio ciclo.
+- ✅ `P-ADHOC-LINES-019L` Ejecutar `C019.D.T3`: cierre final del ciclo o standby explícito.
+  - ✅ ciclo `019` cerrado oficialmente en `docs/ENTERPRISE_EXECUTION_CYCLE_019.md`.
+  - ✅ estado final: standby operativo explícito.
+- 🚧 `P-ADHOC-LINES-019M` Standby operativo: esperar nueva instrucción explícita del usuario.


### PR DESCRIPTION
Cierra formalmente el ciclo 019 y deja standby operativo explícito en trackers.\n\n- C019.D.T3 marcado como completado\n- Estado del ciclo: cerrado\n- Tracker con una única tarea en construcción (standby)