### PR TITLE
docs(readme): force full-width banner with html image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pumuki
 
-![Pumuki](assets/logo_banner.svg)
+<img src="assets/logo_banner.svg" alt="Pumuki" width="100%" />
 
 [![npm version](https://img.shields.io/npm/v/pumuki?color=1d4ed8)](https://www.npmjs.com/package/pumuki)
 [![CI](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/workflows/ci.yml/badge.svg)](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary\n- switch README hero from markdown image syntax to explicit HTML image tag\n- force width to 100% for deterministic rendering across GitHub and npm\n\n## Validation\n- markdown-only docs change