### PR TITLE
release: publish v6.3.23 (restore classic full-width logo hero)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 No changes yet.
 
+## [6.3.23] - 2026-02-27
+
+### Changed
+
+- Restored README hero behavior to the prior full-width classic brand rendering:
+  - `<img src="assets/logo.png" alt="Pumuki" width="100%" />`
+- Keeps a deterministic, simple image path for npm and GitHub renderers.
+
 ## [6.3.22] - 2026-02-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pumuki
 
-![Pumuki](assets/logo_banner.png)
+<img src="assets/logo.png" alt="Pumuki" width="100%" />
 
 [![npm version](https://img.shields.io/npm/v/pumuki?color=1d4ed8)](https://www.npmjs.com/package/pumuki)
 [![CI](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/workflows/ci.yml/badge.svg)](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/actions/workflows/ci.yml)

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -119,8 +119,19 @@ Fuente unica de seguimiento operativo. No se abren nuevos MDs temporales de trac
     - PR `#451` (`docs/readme-enterprise-reliability-followup` -> `develop`) merged.
     - PR `#452` (`release/6.3.21` -> `develop`) merged.
     - PR `#453` (`develop` -> `main`) merged.
-- 🚧 `P3.T17` Hotfix visual definitivo de hero + bump `6.3.22` + cierre GitFlow + publicación npm.
-  - objetivo: forzar render full-width estable en GitHub y npm usando asset raster (`assets/logo_banner.png`) y referencia directa en README.
+- ✅ `P3.T17` Hotfix visual definitivo de hero + bump `6.3.22` + cierre GitFlow + publicación npm completados.
+  - render hero estabilizado para npm/GitHub con asset raster (`assets/logo_banner.png`) y referencia directa markdown en `README.md`.
+  - versión publicada: `pumuki@6.3.22`
+  - evidencia npm: `npm publish --access public` en verde; `npm view pumuki version dist-tags --json` => `latest: 6.3.22`
+  - cierre GitFlow:
+    - PR `#456` (`docs/readme-banner-fullwidth-png-6-3-22` -> `develop`) merged.
+    - PR `#457` (`develop` -> `main`) merged.
+  - sincronización final: `main`, `develop`, `origin/main`, `origin/develop` alineadas en `40a6872`.
+- ✅ `P3.T18` Restauración visual del hero al estilo previo estable del grafo y publicación `v6.3.23` completadas.
+  - hero raíz restaurado a imagen clásica full-width: `<img src="assets/logo.png" alt="Pumuki" width="100%" />`.
+  - versión publicada: `pumuki@6.3.23`
+  - evidencia npm: `npm publish --access public` en verde; `npm view pumuki version dist-tags --json` => `latest: 6.3.23`
+- 🚧 `P3.T19` Standby post-release `6.3.23` en espera de validación visual final del usuario.
 
 ## Plan Por Fases (Ciclo 014)
 Plan base visible para seguimiento previo y durante la implementacion.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -5,6 +5,12 @@ Detailed commit history remains available through Git history (`git log` / `git 
 
 ## 2026-02 (enterprise-refactor updates)
 
+### 2026-02-27 (v6.3.23)
+
+- README visual rollback to the previous stable style from git history:
+  - root hero restored to classic logo image at full width:
+    - `<img src="assets/logo.png" alt="Pumuki" width="100%" />`
+
 ### 2026-02-27 (v6.3.22)
 
 - README hero render compatibility fix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.22",
+  "version": "6.3.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.22",
+      "version": "6.3.23",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.22",
+  "version": "6.3.23",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary\n- restore README hero to previous classic full-width style\n- bump version to 6.3.23\n- update changelog, release notes and tracker