### PR TITLE
docs: sync tracker closure P3.T19/P3.T20

### DIFF
--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -131,7 +131,8 @@ Fuente unica de seguimiento operativo. No se abren nuevos MDs temporales de trac
   - hero raíz restaurado a imagen clásica full-width: `<img src="assets/logo.png" alt="Pumuki" width="100%" />`.
   - versión publicada: `pumuki@6.3.23`
   - evidencia npm: `npm publish --access public` en verde; `npm view pumuki version dist-tags --json` => `latest: 6.3.23`
-- 🚧 `P3.T19` Standby post-release `6.3.23` en espera de validación visual final del usuario.
+- ✅ `P3.T19` Standby post-release `6.3.23` cerrado por validación explícita del usuario.
+- 🚧 `P3.T20` Cierre administrativo final del bloque `P3` en modo espera operativa (sin cambios funcionales pendientes).
 
 ## Plan Por Fases (Ciclo 014)
 Plan base visible para seguimiento previo y durante la implementacion.


### PR DESCRIPTION
Tracker-only sync: close P3.T19 and keep P3.T20 as single in-construction standby task.