### PR TITLE
feat: loop runner local deterministic workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ npx --yes pumuki sdd session --open --change=<change-id>
 npx --yes pumuki sdd validate --stage=PRE_COMMIT
 ```
 
+Optional loop runner session (local, deterministic):
+
+```bash
+npx --yes pumuki loop run --objective="stabilize gate before commit" --max-attempts=3 --json
+npx --yes pumuki loop list --json
+```
+
 Run local gates:
 
 ```bash
@@ -178,6 +185,17 @@ npx --yes pumuki sdd session --open --change=<change-id>
 npx --yes pumuki sdd session --refresh
 npx --yes pumuki sdd session --close
 npx --yes pumuki sdd validate --stage=PRE_COMMIT
+```
+
+### Loop Runner (Consumer)
+
+```bash
+npx --yes pumuki loop run --objective="stabilize gate before commit" --max-attempts=3 --json
+npx --yes pumuki loop status --session=<session-id> --json
+npx --yes pumuki loop stop --session=<session-id> --json
+npx --yes pumuki loop resume --session=<session-id> --json
+npx --yes pumuki loop list --json
+npx --yes pumuki loop export --session=<session-id> --output-json=.audit-reports/loop-session.json
 ```
 
 ### Stage Gates (Consumer)

--- a/docs/REFRACTOR_PROGRESS.md
+++ b/docs/REFRACTOR_PROGRESS.md
@@ -132,7 +132,32 @@ Fuente unica de seguimiento operativo. No se abren nuevos MDs temporales de trac
   - versión publicada: `pumuki@6.3.23`
   - evidencia npm: `npm publish --access public` en verde; `npm view pumuki version dist-tags --json` => `latest: 6.3.23`
 - ✅ `P3.T19` Standby post-release `6.3.23` cerrado por validación explícita del usuario.
-- 🚧 `P3.T20` Cierre administrativo final del bloque `P3` en modo espera operativa (sin cambios funcionales pendientes).
+- ✅ `P3.T20` Cierre administrativo final del bloque `P3` en modo espera operativa (sin cambios funcionales pendientes).
+
+### Fase P4 — Integración `loop runner` local (inspiración Ralph Loop, tool-agnostic)
+- ✅ `P4.T1` Definir contrato local de sesión de loop (estado, intentos, límites y transiciones) y sus fixtures de test.
+  - implementación: `integrations/lifecycle/loopSessionContract.ts` (`create/parse/transition`).
+  - tests RED->GREEN: `integrations/lifecycle/__tests__/loopSessionContract.test.ts`.
+- ✅ `P4.T2` Implementar store determinista local de sesiones loop (`.pumuki/loop-sessions`) con operaciones `create/read/update/list`.
+  - implementación: `integrations/lifecycle/loopSessionStore.ts`.
+  - validación: `integrations/lifecycle/__tests__/loopSessionStore.test.ts` en verde.
+- ✅ `P4.T3` Integrar comando CLI `pumuki loop` (`run|status|stop|resume|list|export`) con parseo estricto.
+  - implementación: `integrations/lifecycle/cli.ts` (`parseLifecycleCliArgs` + `runLifecycleCli` loop commands).
+  - validación: `integrations/lifecycle/__tests__/cli.test.ts` (subcomandos loop parse/runtime).
+- ✅ `P4.T4` Acoplar ejecución de `loop run` al gate (`runPlatformGate`) con política fail-fast y evidencia por intento.
+  - implementación: `integrations/lifecycle/cli.ts` (`LOOP_RUN_POLICY`, intento gate por `workingTree`, evidencia `.attempt-<n>.json`).
+  - validación: test de bloqueo fail-fast en `integrations/lifecycle/__tests__/cli.test.ts`.
+- ✅ `P4.T5` Completar suite TDD end-to-end (`parse + store + runtime`) y validación de typecheck.
+  - tests en verde: `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/loopSessionContract.test.ts integrations/lifecycle/__tests__/loopSessionStore.test.ts integrations/lifecycle/__tests__/cli.test.ts`.
+  - typecheck en verde: `npm run typecheck`.
+- ✅ `P4.T6` Consolidar documentación estable (`README/docs`) y cierre técnico del bloque P4.
+  - documentación actualizada: `README.md`, `docs/USAGE.md` (sección `loop` + semántica fail-fast + evidencia).
+- ✅ `P4.T7` Revalidación global post-P4 ejecutada y fix de no-determinismo temporal en waiver TDD/BDD aplicado.
+  - fix aplicado: `integrations/git/__tests__/tddBddEnforcement.test.ts` (`expires_at` en futuro estable).
+  - validación en verde:
+    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/tddBddEnforcement.test.ts`
+    - `npm test`
+- 🚧 `P4.T8` Cierre GitFlow post-P4 (feature -> develop -> main) y sincronización final.
 
 ## Plan Por Fases (Ciclo 014)
 Plan base visible para seguimiento previo y durante la implementacion.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -223,7 +223,7 @@ npx --yes pumuki-ci
 npx --yes pumuki-pre-write
 ```
 
-### 2.1) Lifecycle + SDD CLI (install / uninstall / remove / update / doctor / status / sdd)
+### 2.1) Lifecycle + SDD + Loop CLI (install / uninstall / remove / update / doctor / status / sdd / loop)
 
 Canonical npm package commands:
 
@@ -260,6 +260,14 @@ npx --yes pumuki sdd session --close
 npx --yes pumuki analytics hotspots report --top=10 --since-days=90 --json
 npx --yes pumuki analytics hotspots diagnose --json
 
+# local deterministic loop sessions (fail-fast gate per attempt)
+npx --yes pumuki loop run --objective="stabilize gate before commit" --max-attempts=3 --json
+npx --yes pumuki loop status --session=<session-id> --json
+npx --yes pumuki loop stop --session=<session-id> --json
+npx --yes pumuki loop resume --session=<session-id> --json
+npx --yes pumuki loop list --json
+npx --yes pumuki loop export --session=<session-id> --output-json=.audit-reports/loop-session.json
+
 # update dependency to latest and re-apply hooks
 npx --yes pumuki update --latest
 
@@ -284,6 +292,12 @@ npm run skills:import:custom -- --source /abs/path/to/SKILL.md --source ./skills
 `pumuki remove` is the enterprise-safe removal path because it performs lifecycle cleanup before package uninstall.
 When no modules remain, it also prunes orphan `node_modules/.package-lock.json` residue.
 Plain `npm uninstall pumuki` removes only the dependency; it does not remove managed hooks or lifecycle state.
+
+Loop runtime behavior:
+- `pumuki loop run` creates a session in `.pumuki/loop-sessions/`.
+- Each run executes one gate attempt on `workingTree`.
+- Gate policy is strict fail-fast: a blocked attempt returns exit code `1` and status `blocked`.
+- Per-attempt evidence is persisted as `.pumuki/loop-sessions/<session-id>.attempt-<n>.json`.
 
 OpenSpec integration behavior:
 - `pumuki install` auto-bootstraps OpenSpec (`@fission-ai/openspec`) when missing/incompatible and scaffolds `openspec/` project baseline when absent.

--- a/integrations/git/__tests__/tddBddEnforcement.test.ts
+++ b/integrations/git/__tests__/tddBddEnforcement.test.ts
@@ -177,7 +177,7 @@ test('enforceTddBddPolicy aplica waiver auditable con un aprobador y no bloquea'
               reason: 'incident hotfix',
               approved_by: 'tech-lead',
               approved_at: '2026-02-26T10:00:00.000Z',
-              expires_at: '2026-02-27T10:00:00.000Z',
+              expires_at: '2099-12-31T23:59:59.000Z',
             },
           ],
         },

--- a/integrations/lifecycle/__tests__/loopSessionContract.test.ts
+++ b/integrations/lifecycle/__tests__/loopSessionContract.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createLoopSessionContract,
+  isLoopSessionTransitionAllowed,
+  parseLoopSessionContract,
+} from '../loopSessionContract';
+
+test('createLoopSessionContract crea sesión canónica con estado inicial running y sin intentos', () => {
+  const session = createLoopSessionContract({
+    sessionId: 'loop-001',
+    objective: 'stabilize gate before commit',
+    generatedAt: '2026-02-27T10:00:00+00:00',
+    maxAttempts: 3,
+  });
+
+  assert.equal(session.version, '1');
+  assert.equal(session.status, 'running');
+  assert.equal(session.current_attempt, 0);
+  assert.equal(session.max_attempts, 3);
+  assert.equal(session.attempts.length, 0);
+});
+
+test('isLoopSessionTransitionAllowed valida transiciones permitidas y bloquea inválidas', () => {
+  assert.equal(isLoopSessionTransitionAllowed('running', 'blocked'), true);
+  assert.equal(isLoopSessionTransitionAllowed('running', 'completed'), true);
+  assert.equal(isLoopSessionTransitionAllowed('running', 'stopped'), true);
+  assert.equal(isLoopSessionTransitionAllowed('blocked', 'running'), true);
+  assert.equal(isLoopSessionTransitionAllowed('blocked', 'stopped'), true);
+  assert.equal(isLoopSessionTransitionAllowed('stopped', 'running'), true);
+
+  assert.equal(isLoopSessionTransitionAllowed('completed', 'running'), false);
+  assert.equal(isLoopSessionTransitionAllowed('completed', 'stopped'), false);
+  assert.equal(isLoopSessionTransitionAllowed('running', 'running'), false);
+});
+
+test('parseLoopSessionContract rechaza contratos con intentos fuera de límite', () => {
+  const session = createLoopSessionContract({
+    sessionId: 'loop-002',
+    objective: 'enforce strict gate',
+    generatedAt: '2026-02-27T10:00:00+00:00',
+    maxAttempts: 2,
+  });
+  const invalid = {
+    ...session,
+    current_attempt: 3,
+    attempts: [
+      {
+        attempt: 1,
+        started_at: '2026-02-27T10:01:00+00:00',
+        finished_at: '2026-02-27T10:02:00+00:00',
+        outcome: 'pass',
+        gate_allowed: true,
+        gate_code: 'ALLOW',
+      },
+      {
+        attempt: 2,
+        started_at: '2026-02-27T10:03:00+00:00',
+        finished_at: '2026-02-27T10:04:00+00:00',
+        outcome: 'pass',
+        gate_allowed: true,
+        gate_code: 'ALLOW',
+      },
+      {
+        attempt: 3,
+        started_at: '2026-02-27T10:05:00+00:00',
+        finished_at: '2026-02-27T10:06:00+00:00',
+        outcome: 'pass',
+        gate_allowed: true,
+        gate_code: 'ALLOW',
+      },
+    ],
+  };
+  const parsed = parseLoopSessionContract(invalid);
+  assert.equal(parsed.kind, 'invalid');
+  if (parsed.kind === 'invalid') {
+    assert.match(parsed.reason, /max_attempts/i);
+  }
+});

--- a/integrations/lifecycle/__tests__/loopSessionStore.test.ts
+++ b/integrations/lifecycle/__tests__/loopSessionStore.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { withTempDir } from '../../__tests__/helpers/tempDir';
+import { createLoopSessionContract } from '../loopSessionContract';
+import {
+  createLoopSession,
+  listLoopSessions,
+  readLoopSession,
+  resolveLoopSessionPath,
+  updateLoopSession,
+} from '../loopSessionStore';
+
+test('createLoopSession persiste contrato y readLoopSession lo recupera', async () => {
+  await withTempDir('pumuki-loop-store-test-', (repoRoot) => {
+    const session = createLoopSessionContract({
+      sessionId: 'loop-store-001',
+      objective: 'gate stabilization',
+      generatedAt: '2026-02-27T12:00:00+00:00',
+      maxAttempts: 3,
+    });
+
+    const created = createLoopSession({
+      repoRoot,
+      session,
+    });
+
+    assert.equal(created.path, resolveLoopSessionPath(repoRoot, session.session_id));
+    const persistedRaw = readFileSync(created.path, 'utf8');
+    assert.match(persistedRaw, /"session_id": "loop-store-001"/);
+
+    const readResult = readLoopSession({
+      repoRoot,
+      sessionId: session.session_id,
+    });
+    assert.equal(readResult.kind, 'valid');
+    if (readResult.kind === 'valid') {
+      assert.equal(readResult.session.objective, session.objective);
+      assert.equal(readResult.session.max_attempts, 3);
+    }
+  });
+});
+
+test('updateLoopSession sobrescribe sesión existente y listLoopSessions ordena por updated_at desc', async () => {
+  await withTempDir('pumuki-loop-store-test-', (repoRoot) => {
+    const older = createLoopSessionContract({
+      sessionId: 'loop-store-older',
+      objective: 'older objective',
+      generatedAt: '2026-02-27T12:00:00+00:00',
+      maxAttempts: 2,
+    });
+    const newer = createLoopSessionContract({
+      sessionId: 'loop-store-newer',
+      objective: 'newer objective',
+      generatedAt: '2026-02-27T12:10:00+00:00',
+      maxAttempts: 2,
+    });
+    createLoopSession({ repoRoot, session: older });
+    createLoopSession({ repoRoot, session: newer });
+
+    const updatedOlder = {
+      ...older,
+      status: 'blocked' as const,
+      updated_at: '2026-02-27T12:20:00+00:00',
+      current_attempt: 1,
+      attempts: [
+        {
+          attempt: 1,
+          started_at: '2026-02-27T12:15:00+00:00',
+          finished_at: '2026-02-27T12:16:00+00:00',
+          outcome: 'block' as const,
+          gate_allowed: false,
+          gate_code: 'BLOCKED_BY_GATE',
+        },
+      ],
+    };
+    updateLoopSession({ repoRoot, session: updatedOlder });
+
+    const listed = listLoopSessions(repoRoot);
+    assert.equal(listed.length, 2);
+    assert.equal(listed[0]?.session_id, 'loop-store-older');
+    assert.equal(listed[0]?.status, 'blocked');
+    assert.equal(listed[1]?.session_id, 'loop-store-newer');
+  });
+});
+
+test('readLoopSession devuelve missing cuando no existe sesión', async () => {
+  await withTempDir('pumuki-loop-store-test-', (repoRoot) => {
+    const result = readLoopSession({
+      repoRoot,
+      sessionId: 'unknown-loop',
+    });
+    assert.equal(result.kind, 'missing');
+    if (result.kind === 'missing') {
+      assert.equal(result.path, join(repoRoot, '.pumuki', 'loop-sessions', 'unknown-loop.json'));
+    }
+  });
+});

--- a/integrations/lifecycle/index.ts
+++ b/integrations/lifecycle/index.ts
@@ -74,6 +74,20 @@ export {
   appendOperationalMemorySnapshotFromLocalSignals,
   resolveOperationalMemorySnapshotsPath,
 } from './operationalMemorySnapshot';
+export {
+  createLoopSessionContract,
+  createLoopSessionId,
+  isLoopSessionTransitionAllowed,
+  parseLoopSessionContract,
+} from './loopSessionContract';
+export {
+  createLoopSession,
+  listLoopSessions,
+  readLoopSession,
+  resolveLoopSessionPath,
+  resolveLoopSessionsDirectory,
+  updateLoopSession,
+} from './loopSessionStore';
 export type {
   CreateHotspotsSaasIngestionPayloadParams,
   HotspotsSaasIngestionPayloadBodyCompat,
@@ -107,6 +121,20 @@ export type {
   AppendOperationalMemorySnapshotFromLocalSignalsResult,
   OperationalMemorySnapshotV1,
 } from './operationalMemorySnapshot';
+export type {
+  CreateLoopSessionContractParams,
+  LoopSessionAttemptOutcome,
+  LoopSessionAttemptV1,
+  LoopSessionContractV1,
+  LoopSessionStatus,
+  ParseLoopSessionContractResult,
+} from './loopSessionContract';
+export type {
+  ReadLoopSessionParams,
+  ReadLoopSessionResult,
+  UpsertLoopSessionParams,
+  WriteLoopSessionResult,
+} from './loopSessionStore';
 export type { BuildHotspotsSaasIngestionPayloadFromLocalParams } from './saasIngestionBuilder';
 export type {
   HotspotsSaasIngestionAuthPolicy,

--- a/integrations/lifecycle/loopSessionContract.ts
+++ b/integrations/lifecycle/loopSessionContract.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+const loopSessionAttemptSchema = z
+  .object({
+    attempt: z.number().int().positive(),
+    started_at: z.string().datetime({ offset: true }),
+    finished_at: z.string().datetime({ offset: true }),
+    outcome: z.enum(['pass', 'block', 'error', 'stopped']),
+    gate_allowed: z.boolean(),
+    gate_code: z.string().min(1),
+    evidence_path: z.string().min(1).optional(),
+    notes: z.string().min(1).optional(),
+  })
+  .strict();
+
+const loopSessionContractSchema = z
+  .object({
+    version: z.literal('1'),
+    session_id: z.string().min(1),
+    objective: z.string().min(1),
+    status: z.enum(['running', 'blocked', 'stopped', 'completed']),
+    created_at: z.string().datetime({ offset: true }),
+    updated_at: z.string().datetime({ offset: true }),
+    max_attempts: z.number().int().positive(),
+    current_attempt: z.number().int().min(0),
+    attempts: z.array(loopSessionAttemptSchema),
+  })
+  .strict();
+
+const loopSessionTransitions: Readonly<Record<LoopSessionStatus, ReadonlyArray<LoopSessionStatus>>> = {
+  running: ['blocked', 'stopped', 'completed'],
+  blocked: ['running', 'stopped', 'completed'],
+  stopped: ['running'],
+  completed: [],
+};
+
+const parseValidationError = (error: z.ZodError): string =>
+  error.issues[0]
+    ? `${error.issues[0].path.join('.') || 'contract'}: ${error.issues[0].message}`
+    : 'invalid_loop_session_contract';
+
+export type LoopSessionStatus = z.infer<typeof loopSessionContractSchema>['status'];
+export type LoopSessionAttemptOutcome = z.infer<typeof loopSessionAttemptSchema>['outcome'];
+export type LoopSessionAttemptV1 = z.infer<typeof loopSessionAttemptSchema>;
+export type LoopSessionContractV1 = z.infer<typeof loopSessionContractSchema>;
+
+export type CreateLoopSessionContractParams = {
+  sessionId?: string;
+  objective: string;
+  generatedAt?: string;
+  maxAttempts: number;
+};
+
+export type ParseLoopSessionContractResult =
+  | {
+      kind: 'valid';
+      contract: LoopSessionContractV1;
+    }
+  | {
+      kind: 'invalid';
+      reason: string;
+    };
+
+export const createLoopSessionId = (): string => `loop-${randomUUID()}`;
+
+export const isLoopSessionTransitionAllowed = (
+  current: LoopSessionStatus,
+  next: LoopSessionStatus
+): boolean => {
+  if (current === next) {
+    return false;
+  }
+  return loopSessionTransitions[current].includes(next);
+};
+
+export const createLoopSessionContract = (
+  params: CreateLoopSessionContractParams
+): LoopSessionContractV1 => {
+  const generatedAt = params.generatedAt ?? new Date().toISOString();
+  return loopSessionContractSchema.parse({
+    version: '1',
+    session_id: params.sessionId?.trim() || createLoopSessionId(),
+    objective: params.objective.trim(),
+    status: 'running',
+    created_at: generatedAt,
+    updated_at: generatedAt,
+    max_attempts: params.maxAttempts,
+    current_attempt: 0,
+    attempts: [],
+  });
+};
+
+const hasValidAttemptOrder = (attempts: ReadonlyArray<LoopSessionAttemptV1>): boolean => {
+  let expected = 1;
+  for (const attempt of attempts) {
+    if (attempt.attempt !== expected) {
+      return false;
+    }
+    expected += 1;
+  }
+  return true;
+};
+
+export const parseLoopSessionContract = (candidate: unknown): ParseLoopSessionContractResult => {
+  const parsed = loopSessionContractSchema.safeParse(candidate);
+  if (!parsed.success) {
+    return {
+      kind: 'invalid',
+      reason: parseValidationError(parsed.error),
+    };
+  }
+  const contract = parsed.data;
+  if (contract.current_attempt > contract.max_attempts) {
+    return {
+      kind: 'invalid',
+      reason: `current_attempt exceeds max_attempts (${contract.current_attempt} > ${contract.max_attempts})`,
+    };
+  }
+  if (contract.attempts.length > contract.max_attempts) {
+    return {
+      kind: 'invalid',
+      reason: `attempts length exceeds max_attempts (${contract.attempts.length} > ${contract.max_attempts})`,
+    };
+  }
+  if (contract.current_attempt !== contract.attempts.length) {
+    return {
+      kind: 'invalid',
+      reason: `current_attempt must match attempts length (${contract.current_attempt} != ${contract.attempts.length})`,
+    };
+  }
+  if (!hasValidAttemptOrder(contract.attempts)) {
+    return {
+      kind: 'invalid',
+      reason: 'attempt sequence must be contiguous starting at 1',
+    };
+  }
+  return {
+    kind: 'valid',
+    contract,
+  };
+};

--- a/integrations/lifecycle/loopSessionStore.ts
+++ b/integrations/lifecycle/loopSessionStore.ts
@@ -1,0 +1,167 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { isAbsolute, resolve, join } from 'node:path';
+import {
+  parseLoopSessionContract,
+  type LoopSessionContractV1,
+} from './loopSessionContract';
+
+const DEFAULT_LOOP_SESSIONS_DIRECTORY = '.pumuki/loop-sessions';
+
+const normalizeSessionId = (sessionId: string): string => {
+  const normalized = sessionId.trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(normalized)) {
+    throw new Error(`Invalid loop session id "${sessionId}".`);
+  }
+  return normalized;
+};
+
+const toAbsolutePath = (repoRoot: string, maybeRelative: string): string => {
+  if (isAbsolute(maybeRelative)) {
+    return resolve(maybeRelative);
+  }
+  return resolve(repoRoot, maybeRelative);
+};
+
+export type ReadLoopSessionParams = {
+  repoRoot: string;
+  sessionId: string;
+};
+
+export type UpsertLoopSessionParams = {
+  repoRoot: string;
+  session: LoopSessionContractV1;
+};
+
+export type ReadLoopSessionResult =
+  | {
+      kind: 'missing';
+      path: string;
+    }
+  | {
+      kind: 'invalid';
+      path: string;
+      reason: string;
+    }
+  | {
+      kind: 'valid';
+      path: string;
+      session: LoopSessionContractV1;
+    };
+
+export type WriteLoopSessionResult = {
+  path: string;
+  bytes: number;
+};
+
+export const resolveLoopSessionsDirectory = (repoRoot: string): string => {
+  const configured = process.env.PUMUKI_LOOP_SESSIONS_DIR?.trim();
+  const candidate =
+    configured && configured.length > 0
+      ? configured
+      : DEFAULT_LOOP_SESSIONS_DIRECTORY;
+  return toAbsolutePath(repoRoot, candidate);
+};
+
+export const resolveLoopSessionPath = (repoRoot: string, sessionId: string): string =>
+  join(resolveLoopSessionsDirectory(repoRoot), `${normalizeSessionId(sessionId)}.json`);
+
+const parseStoredSession = (path: string): ReadLoopSessionResult => {
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    const contractParsed = parseLoopSessionContract(parsed);
+    if (contractParsed.kind === 'invalid') {
+      return {
+        kind: 'invalid',
+        path,
+        reason: contractParsed.reason,
+      };
+    }
+    return {
+      kind: 'valid',
+      path,
+      session: contractParsed.contract,
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'invalid_loop_session_json';
+    return {
+      kind: 'invalid',
+      path,
+      reason,
+    };
+  }
+};
+
+export const readLoopSession = (params: ReadLoopSessionParams): ReadLoopSessionResult => {
+  const path = resolveLoopSessionPath(params.repoRoot, params.sessionId);
+  if (!existsSync(path)) {
+    return {
+      kind: 'missing',
+      path,
+    };
+  }
+  return parseStoredSession(path);
+};
+
+const validateSessionBeforeWrite = (session: LoopSessionContractV1): LoopSessionContractV1 => {
+  const parsed = parseLoopSessionContract(session);
+  if (parsed.kind === 'invalid') {
+    throw new Error(`Invalid loop session contract: ${parsed.reason}`);
+  }
+  return parsed.contract;
+};
+
+export const createLoopSession = (params: UpsertLoopSessionParams): WriteLoopSessionResult => {
+  const contract = validateSessionBeforeWrite(params.session);
+  const path = resolveLoopSessionPath(params.repoRoot, contract.session_id);
+  if (existsSync(path)) {
+    throw new Error(`Loop session already exists at "${path}".`);
+  }
+  mkdirSync(resolveLoopSessionsDirectory(params.repoRoot), { recursive: true });
+  const serialized = `${JSON.stringify(contract, null, 2)}\n`;
+  writeFileSync(path, serialized, 'utf8');
+  return {
+    path,
+    bytes: Buffer.byteLength(serialized, 'utf8'),
+  };
+};
+
+export const updateLoopSession = (params: UpsertLoopSessionParams): WriteLoopSessionResult => {
+  const contract = validateSessionBeforeWrite(params.session);
+  const path = resolveLoopSessionPath(params.repoRoot, contract.session_id);
+  if (!existsSync(path)) {
+    throw new Error(`Loop session does not exist at "${path}".`);
+  }
+  mkdirSync(resolveLoopSessionsDirectory(params.repoRoot), { recursive: true });
+  const serialized = `${JSON.stringify(contract, null, 2)}\n`;
+  writeFileSync(path, serialized, 'utf8');
+  return {
+    path,
+    bytes: Buffer.byteLength(serialized, 'utf8'),
+  };
+};
+
+export const listLoopSessions = (repoRoot: string): ReadonlyArray<LoopSessionContractV1> => {
+  const directory = resolveLoopSessionsDirectory(repoRoot);
+  if (!existsSync(directory)) {
+    return [];
+  }
+  const sessions: Array<LoopSessionContractV1> = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) {
+      continue;
+    }
+    const result = parseStoredSession(join(directory, entry.name));
+    if (result.kind === 'valid') {
+      sessions.push(result.session);
+    }
+  }
+  return sessions.sort((a, b) => {
+    const updatedA = new Date(a.updated_at).getTime();
+    const updatedB = new Date(b.updated_at).getTime();
+    if (updatedA !== updatedB) {
+      return updatedB - updatedA;
+    }
+    return a.session_id.localeCompare(b.session_id);
+  });
+};


### PR DESCRIPTION
## Summary
- add local loop session contract/store for deterministic run state
- add lifecycle CLI loop commands: run/status/stop/resume/list/export
- integrate loop run with strict fail-fast gate attempt + per-attempt evidence file
- harden waiver test to avoid time-based flake and update stable docs/tracker

## Validation
- npm run typecheck
- npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/loopSessionContract.test.ts integrations/lifecycle/__tests__/loopSessionStore.test.ts integrations/lifecycle/__tests__/cli.test.ts
- npx --yes tsx@4.21.0 --test integrations/git/__tests__/tddBddEnforcement.test.ts
- npm test
