### PR TITLE
fix(lifecycle): support hook install in git worktrees

### DIFF
--- a/integrations/lifecycle/__tests__/install.test.ts
+++ b/integrations/lifecycle/__tests__/install.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import test from 'node:test';
 import { PUMUKI_CONFIG_KEYS } from '../constants';
 import { runLifecycleInstall } from '../install';
@@ -20,6 +20,11 @@ const withCwd = <T>(cwd: string, fn: () => T): T => {
 
 const runGit = (cwd: string, args: ReadonlyArray<string>): string =>
   execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+const resolveGitPath = (cwd: string, target: string): string => {
+  const gitPath = runGit(cwd, ['rev-parse', '--git-path', target]).trim();
+  return isAbsolute(gitPath) ? gitPath : resolve(cwd, gitPath);
+};
 
 const readLocalConfig = (cwd: string, key: string): string | undefined => {
   try {
@@ -205,6 +210,37 @@ test('runLifecycleInstall usa process.cwd cuando no recibe cwd explícito', () =
     assert.equal(realpathSync(result.repoRoot), realpathSync(repo));
     assert.deepEqual(result.changedHooks, ['pre-commit', 'pre-push']);
   } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleInstall instala hooks correctamente dentro de un git worktree', () => {
+  const repo = createGitRepo();
+  const worktree = join(
+    tmpdir(),
+    `pumuki-install-worktree-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+  const worktreeBranch = `feature/worktree-install-${Date.now().toString(36)}`;
+  try {
+    runGit(repo, ['worktree', 'add', '-b', worktreeBranch, worktree]);
+
+    const result = runLifecycleInstall({
+      cwd: worktree,
+      bootstrapOpenSpec: false,
+    });
+
+    assert.equal(realpathSync(result.repoRoot), realpathSync(worktree));
+    assert.deepEqual(result.changedHooks, ['pre-commit', 'pre-push']);
+
+    const hooksDir = resolveGitPath(worktree, 'hooks');
+    assert.equal(existsSync(join(hooksDir, 'pre-commit')), true);
+    assert.equal(existsSync(join(hooksDir, 'pre-push')), true);
+  } finally {
+    try {
+      runGit(repo, ['worktree', 'remove', '--force', worktree]);
+    } catch {
+      rmSync(worktree, { recursive: true, force: true });
+    }
     rmSync(repo, { recursive: true, force: true });
   }
 });

--- a/integrations/lifecycle/hookManager.ts
+++ b/integrations/lifecycle/hookManager.ts
@@ -1,5 +1,6 @@
+import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import { PUMUKI_MANAGED_HOOKS, type PumukiManagedHook } from './constants';
 import {
   hasPumukiManagedBlock,
@@ -17,7 +18,24 @@ export type HookUninstallResult = {
 
 const HOOK_FILE_MODE = 0o755;
 
-const resolveHooksDirectory = (repoRoot: string): string => join(repoRoot, '.git', 'hooks');
+const resolveGitPath = (repoRoot: string, gitPathTarget: string): string | null => {
+  try {
+    const resolvedPath = execFileSync('git', ['rev-parse', '--git-path', gitPathTarget], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (resolvedPath.length === 0) {
+      return null;
+    }
+    return isAbsolute(resolvedPath) ? resolvedPath : resolve(repoRoot, resolvedPath);
+  } catch {
+    return null;
+  }
+};
+
+const resolveHooksDirectory = (repoRoot: string): string =>
+  resolveGitPath(repoRoot, 'hooks') ?? join(repoRoot, '.git', 'hooks');
 
 const resolveHookPath = (repoRoot: string, hook: PumukiManagedHook): string =>
   join(resolveHooksDirectory(repoRoot), hook);


### PR DESCRIPTION
## Resumen
- corrige la resolución de ruta de hooks en worktrees usando `git rev-parse --git-path hooks`
- mantiene fallback a `.git/hooks` para repos clásicos
- añade test de regresión para instalación de lifecycle dentro de git worktree

## Validación
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/hookManager.test.ts integrations/lifecycle/__tests__/install.test.ts`
- ejecución real: `node /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks-worktree-hooks-fix/bin/pumuki.js install` en `/Users/juancarlosmerlosalbarracin/Developer/Projects/ruralgo-fork-ux-p9` (sin error `ENOTDIR` en `.git/hooks`)
