### PR TITLE
fix: allow pre-push bootstrap on first upstream push (#480)

### DIFF
--- a/integrations/git/__tests__/resolveGitRefs.test.ts
+++ b/integrations/git/__tests__/resolveGitRefs.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { resolveCiBaseRef, resolveUpstreamRef } from '../resolveGitRefs';
+import {
+  resolveCiBaseRef,
+  resolvePrePushBootstrapBaseRef,
+  resolveUpstreamRef,
+} from '../resolveGitRefs';
 import { runGit, withGithubBaseRef, withTempRepo } from './helpers/gitTestUtils';
 
 const withResolveRepo = async (
@@ -93,6 +97,34 @@ test(
           const resolved = resolveCiBaseRef();
           assert.equal(resolved, 'HEAD');
         });
+      },
+      'trunk'
+    );
+  }
+);
+
+test(
+  'resolvePrePushBootstrapBaseRef prefers develop when available',
+  { concurrency: false },
+  async () => {
+    await withResolveRepo(async (repoRoot) => {
+      runGit(repoRoot, ['checkout', '--quiet', '-b', 'develop']);
+      runGit(repoRoot, ['checkout', '--quiet', '-b', 'feature/bootstrap-base']);
+
+      const resolved = resolvePrePushBootstrapBaseRef();
+      assert.equal(resolved, 'develop');
+    });
+  }
+);
+
+test(
+  'resolvePrePushBootstrapBaseRef falls back to HEAD when no base refs are resolvable',
+  { concurrency: false },
+  async () => {
+    await withResolveRepo(
+      async () => {
+        const resolved = resolvePrePushBootstrapBaseRef();
+        assert.equal(resolved, 'HEAD');
       },
       'trunk'
     );

--- a/integrations/git/__tests__/stageRunners.test.ts
+++ b/integrations/git/__tests__/stageRunners.test.ts
@@ -317,6 +317,25 @@ test('runPrePushStage fails safe with guidance when branch has no upstream', asy
   });
 });
 
+test('runPrePushStage allows bootstrap push without upstream when stdin indicates new remote branch', async () => {
+  await withStageRunnerRepo(async (repoRoot) => {
+    setupBackendCommitRangeWithoutUpstream(repoRoot);
+    const headOid = runGit(repoRoot, ['rev-parse', 'HEAD']).trim();
+    const remoteZero = '0'.repeat(40);
+
+    const exitCode = await runPrePushStage({
+      readPrePushStdin: () =>
+        `refs/heads/feature/no-upstream ${headOid} refs/heads/feature/no-upstream ${remoteZero}\n`,
+      resolvePrePushBootstrapBaseRef: () => 'main',
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(existsSync(join(repoRoot, '.ai_evidence.json')), true);
+    const evidence = readEvidence(repoRoot);
+    assert.equal(evidence.snapshot.stage, 'PRE_PUSH');
+  });
+});
+
 test('runCiStage uses skills policy override and writes CI policy trace', async () => {
   await withStageRunnerRepo(async (repoRoot) => {
     writeSkillsPolicy(repoRoot, {

--- a/integrations/git/resolveGitRefs.ts
+++ b/integrations/git/resolveGitRefs.ts
@@ -49,3 +49,14 @@ export const resolveCiBaseRef = (): string => {
 
   return resolveDefaultCiBaseRef();
 };
+
+export const resolvePrePushBootstrapBaseRef = (): string => {
+  const candidates = ['origin/develop', 'develop', resolveCiBaseRef()];
+  for (const candidate of candidates) {
+    if (isResolvableRef(candidate)) {
+      return candidate;
+    }
+  }
+
+  return 'HEAD';
+};

--- a/integrations/git/stageRunners.ts
+++ b/integrations/git/stageRunners.ts
@@ -1,8 +1,13 @@
 import { resolvePolicyForStage } from '../gate/stagePolicies';
-import { resolveCiBaseRef, resolveUpstreamRef } from './resolveGitRefs';
+import {
+  resolveCiBaseRef,
+  resolvePrePushBootstrapBaseRef,
+  resolveUpstreamRef,
+} from './resolveGitRefs';
 import { runPlatformGate } from './runPlatformGate';
 import { GitService } from './GitService';
 import { emitAuditSummaryNotificationFromEvidence } from '../notifications/emitAuditSummaryNotification';
+import { readFileSync } from 'node:fs';
 
 const PRE_PUSH_UPSTREAM_REQUIRED_MESSAGE =
   'pumuki pre-push blocked: branch has no upstream tracking reference. Configure upstream first (for example: git push --set-upstream origin <branch>) and retry.';
@@ -10,9 +15,11 @@ const PRE_PUSH_UPSTREAM_REQUIRED_MESSAGE =
 type StageRunnerDependencies = {
   resolvePolicyForStage: typeof resolvePolicyForStage;
   resolveUpstreamRef: typeof resolveUpstreamRef;
+  resolvePrePushBootstrapBaseRef: typeof resolvePrePushBootstrapBaseRef;
   resolveCiBaseRef: typeof resolveCiBaseRef;
   runPlatformGate: typeof runPlatformGate;
   resolveRepoRoot: () => string;
+  readPrePushStdin: () => string;
   notifyAuditSummaryFromEvidence: (params: {
     repoRoot: string;
     stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
@@ -22,9 +29,20 @@ type StageRunnerDependencies = {
 const defaultDependencies: StageRunnerDependencies = {
   resolvePolicyForStage,
   resolveUpstreamRef,
+  resolvePrePushBootstrapBaseRef,
   resolveCiBaseRef,
   runPlatformGate,
   resolveRepoRoot: () => new GitService().resolveRepoRoot(),
+  readPrePushStdin: () => {
+    if (process.stdin.isTTY) {
+      return '';
+    }
+    try {
+      return readFileSync(0, 'utf8');
+    } catch {
+      return '';
+    }
+  },
   notifyAuditSummaryFromEvidence: ({ repoRoot, stage }) => {
     emitAuditSummaryNotificationFromEvidence({
       repoRoot,
@@ -50,6 +68,32 @@ const notifyAuditSummaryForStage = (
   });
 };
 
+const ZERO_HASH = /^0+$/;
+
+const shouldAllowBootstrapPrePush = (rawInput: string): boolean => {
+  const lines = rawInput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    const [localRef, localOid, remoteRef, remoteOid] = line.split(/\s+/);
+    if (!localRef || !localOid || !remoteRef || !remoteOid) {
+      continue;
+    }
+    const localIsBranch = localRef.startsWith('refs/heads/');
+    const remoteIsBranch = remoteRef.startsWith('refs/heads/');
+    const localIsDeletion = ZERO_HASH.test(localOid);
+    const remoteIsNewBranch = ZERO_HASH.test(remoteOid);
+
+    if (localIsBranch && remoteIsBranch && !localIsDeletion && remoteIsNewBranch) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 export async function runPreCommitStage(
   dependencies: Partial<StageRunnerDependencies> = {}
 ): Promise<number> {
@@ -72,6 +116,21 @@ export async function runPrePushStage(
   const activeDependencies = getDependencies(dependencies);
   const upstreamRef = activeDependencies.resolveUpstreamRef();
   if (!upstreamRef) {
+    const prePushInput = activeDependencies.readPrePushStdin();
+    if (shouldAllowBootstrapPrePush(prePushInput)) {
+      const resolved = activeDependencies.resolvePolicyForStage('PRE_PUSH');
+      const exitCode = await activeDependencies.runPlatformGate({
+        policy: resolved.policy,
+        policyTrace: resolved.trace,
+        scope: {
+          kind: 'range',
+          fromRef: activeDependencies.resolvePrePushBootstrapBaseRef(),
+          toRef: 'HEAD',
+        },
+      });
+      notifyAuditSummaryForStage(activeDependencies, 'PRE_PUSH');
+      return exitCode;
+    }
     process.stderr.write(`${PRE_PUSH_UPSTREAM_REQUIRED_MESSAGE}\n`);
     notifyAuditSummaryForStage(activeDependencies, 'PRE_PUSH');
     return 1;


### PR DESCRIPTION
## What this fixes
Resolves issue #480 by removing the bootstrap deadlock when running first push with `git push --set-upstream ...` on a branch without upstream.

## Behavior change
- If upstream exists: unchanged (`upstream..HEAD` scope).
- If upstream is missing:
  - with real pre-push stdin showing new remote branch creation (`remote_oid=000...`): run gate using bootstrap base ref and continue.
  - without bootstrap context: keep fail-safe block with guidance.

## RED -> GREEN evidence
- Added regression tests:
  - `runPrePushStage allows bootstrap push without upstream when stdin indicates new remote branch`.
  - `resolvePrePushBootstrapBaseRef` coverage.
- Commands executed:
  - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/resolveGitRefs.test.ts integrations/git/__tests__/stageRunners.test.ts`
  - `npm run -s typecheck`
- Result: `23 passed, 0 failed`.

## Real hook evidence
- First push succeeded on new branch with no upstream:
  - `git push --set-upstream origin bugfix/480-prepush-upstream-bootstrap`

## Risk notes
- No changes to normal pre-push flow for branches with upstream.
- Guard remains strict when no bootstrap push context is present.
