### PR TITLE
fix: stabilize PRE_WRITE evidence sync with deterministic retry/backoff

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T2` (priorizar y ejecutar el siguiente slice de bugs/mejoras reportados en RuralGO).
+- Task activa (`🚧`): `P12.F1.T3` (publicar cierre E2E de `#481` y sincronizar trazabilidad canónica en RuralGO).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -749,9 +749,17 @@ Criterio de salida F5:
     - `git fetch origin --prune --tags`
     - análisis reachability/commit-diff de `backup/branches/*` contra `develop/main`
     - `git cherry develop <backup-head>` para validar equivalencia de fixes de lifecycle
-- 🚧 `P12.F1.T2` Priorizar y arrancar ejecución del bloque de bugs/mejoras de RuralGO reportados en Pumuki.
+- ✅ `P12.F1.T2` Priorizar y arrancar ejecución del bloque de bugs/mejoras de RuralGO reportados en Pumuki.
+  - resultado:
+    - slice priorizado y ejecutado: `#481 Stabilize PRE_WRITE evidence sync across branch/session switches`.
+    - fix aplicado con retry determinista/backoff único en PRE_WRITE (`retry_backoff`) y test dedicado de regresión.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/preWriteAutomation.test.ts`
+    - `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/cli.test.ts`
+    - `npm run -s typecheck`
+- 🚧 `P12.F1.T3` Publicar el cierre E2E de `#481` (commit + PR + merge) y sincronizar trazabilidad canónica en RuralGO.
   - objetivo inmediato:
-    - seleccionar el siguiente slice ejecutable de mayor impacto del bug registry y dejar evidencia reproducible en runbook/validadores.
+    - enlazar `issue -> branch -> commit -> PR -> merge` y actualizar estado `REPORTED/FIXED` en el MD canónico de RuralGO.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/integrations/lifecycle/__tests__/preWriteAutomation.test.ts
+++ b/integrations/lifecycle/__tests__/preWriteAutomation.test.ts
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { RepoState } from '../../evidence/schema';
+import type { AiGateCheckResult, AiGateViolation } from '../../gate/evaluateAiGate';
+import type { SddEvaluateResult } from '../../sdd/types';
+import { buildPreWriteAutomationTrace } from '../preWriteAutomation';
+
+const sampleRepoState: RepoState = {
+  repo_root: '/repo',
+  git: {
+    available: true,
+    branch: 'feature/prewrite-sync',
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    dirty: false,
+    staged: 0,
+    unstaged: 0,
+  },
+  lifecycle: {
+    installed: true,
+    package_version: '6.3.26',
+    lifecycle_version: '6.3.26',
+    hooks: {
+      pre_commit: 'managed',
+      pre_push: 'managed',
+    },
+  },
+};
+
+const buildSddAllowed = (): SddEvaluateResult => ({
+  stage: 'PRE_WRITE',
+  decision: {
+    allowed: true,
+    code: 'ALLOWED',
+    message: 'allowed',
+  },
+  status: {
+    repoRoot: '/repo',
+    openspec: {
+      installed: true,
+      version: '1.2.0',
+      projectInitialized: true,
+      minimumVersion: '1.1.1',
+      recommendedVersion: '1.1.1',
+      compatible: true,
+      parsedVersion: '1.2.0',
+    },
+    session: {
+      repoRoot: '/repo',
+      active: true,
+      changeId: 'p9-prewrite-sync',
+      valid: true,
+    },
+  },
+});
+
+const toViolation = (code: string): AiGateViolation => ({
+  code,
+  severity: 'ERROR',
+  message: code,
+});
+
+const buildAiGate = (violations: AiGateViolation[]): AiGateCheckResult => {
+  const blocked = violations.some((violation) => violation.severity === 'ERROR');
+  return {
+    stage: 'PRE_WRITE',
+    status: blocked ? 'BLOCKED' : 'ALLOWED',
+    allowed: !blocked,
+    policy: {
+      stage: 'PRE_WRITE',
+      resolved_stage: 'PRE_COMMIT',
+      block_on_or_above: 'ERROR',
+      warn_on_or_above: 'WARN',
+      trace: {
+        source: 'default',
+        bundle: 'skills.policy.default',
+        hash: 'hash',
+      },
+    },
+    evidence: {
+      kind: 'valid',
+      max_age_seconds: 300,
+      age_seconds: 5,
+    },
+    mcp_receipt: {
+      required: true,
+      kind: 'valid',
+      path: '/repo/.pumuki/artifacts/mcp-ai-gate-receipt.json',
+      max_age_seconds: 300,
+      age_seconds: 5,
+    },
+    repo_state: sampleRepoState,
+    violations,
+  };
+};
+
+test('buildPreWriteAutomationTrace aplica retry backoff único cuando persiste violación auto-curable', async () => {
+  let runPlatformGateCalls = 0;
+  let runEnterpriseCalls = 0;
+  const sleepCalls: number[] = [];
+  const aiGateSequence: AiGateCheckResult[] = [
+    buildAiGate([toViolation('EVIDENCE_STALE')]),
+    buildAiGate([]),
+  ];
+
+  const result = await buildPreWriteAutomationTrace(
+    {
+      repoRoot: '/repo',
+      sdd: buildSddAllowed(),
+      aiGate: buildAiGate([toViolation('EVIDENCE_BRANCH_MISMATCH')]),
+      runPlatformGate: async () => {
+        runPlatformGateCalls += 1;
+        return 0;
+      },
+    },
+    {
+      runEnterpriseAiGateCheck: () => {
+        const aiGate = aiGateSequence[Math.min(runEnterpriseCalls, aiGateSequence.length - 1)]!;
+        runEnterpriseCalls += 1;
+        return {
+          tool: 'ai_gate_check',
+          dryRun: true,
+          executed: true,
+          success: aiGate.allowed,
+          result: aiGate,
+        };
+      },
+      evaluateAiGate: () => buildAiGate([]),
+      writeMcpAiGateReceipt: () => ({
+        path: '/repo/.pumuki/artifacts/mcp-ai-gate-receipt.json',
+        receipt: {
+          version: '1',
+          source: 'pumuki-enterprise-mcp',
+          tool: 'ai_gate_check',
+          repo_root: '/repo',
+          stage: 'PRE_WRITE',
+          status: 'ALLOWED',
+          allowed: true,
+          issued_at: new Date('2026-03-03T00:00:00.000Z').toISOString(),
+        },
+      }),
+      retryBackoffMs: 25,
+      sleep: async (ms: number) => {
+        sleepCalls.push(ms);
+      },
+    }
+  );
+
+  assert.equal(runPlatformGateCalls, 1);
+  assert.equal(runEnterpriseCalls, 2);
+  assert.deepEqual(sleepCalls, [25]);
+  assert.equal(result.aiGate.allowed, true);
+  assert.deepEqual(
+    result.trace.actions.map((item) => item.action),
+    ['refresh_evidence', 'retry_backoff']
+  );
+  assert.equal(result.trace.actions[1]?.details.includes('EVIDENCE_STALE'), true);
+});
+
+test('buildPreWriteAutomationTrace no ejecuta retry cuando no hay violaciones auto-curables', async () => {
+  let runPlatformGateCalls = 0;
+  let runEnterpriseCalls = 0;
+  let sleepCalled = false;
+  const blockedAiGate = buildAiGate([toViolation('GITFLOW_PROTECTED_BRANCH')]);
+
+  const result = await buildPreWriteAutomationTrace(
+    {
+      repoRoot: '/repo',
+      sdd: buildSddAllowed(),
+      aiGate: blockedAiGate,
+      runPlatformGate: async () => {
+        runPlatformGateCalls += 1;
+        return 0;
+      },
+    },
+    {
+      runEnterpriseAiGateCheck: () => {
+        runEnterpriseCalls += 1;
+        return {
+          tool: 'ai_gate_check',
+          dryRun: true,
+          executed: true,
+          success: blockedAiGate.allowed,
+          result: blockedAiGate,
+        };
+      },
+      evaluateAiGate: () => blockedAiGate,
+      writeMcpAiGateReceipt: () => ({
+        path: '/repo/.pumuki/artifacts/mcp-ai-gate-receipt.json',
+        receipt: {
+          version: '1',
+          source: 'pumuki-enterprise-mcp',
+          tool: 'ai_gate_check',
+          repo_root: '/repo',
+          stage: 'PRE_WRITE',
+          status: 'BLOCKED',
+          allowed: false,
+          issued_at: new Date('2026-03-03T00:00:00.000Z').toISOString(),
+        },
+      }),
+      sleep: async () => {
+        sleepCalled = true;
+      },
+    }
+  );
+
+  assert.equal(runPlatformGateCalls, 0);
+  assert.equal(runEnterpriseCalls, 0);
+  assert.equal(sleepCalled, false);
+  assert.equal(result.aiGate.allowed, false);
+  assert.equal(result.trace.attempted, false);
+  assert.equal(result.trace.actions.length, 0);
+});

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -756,14 +756,7 @@ const PRE_WRITE_TELEMETRY_CHAIN = 'pumuki->mcp->ai_gate->ai_evidence';
 type PreWriteValidationEnvelope = {
   sdd: ReturnType<typeof evaluateSddPolicy>;
   ai_gate: ReturnType<typeof evaluateAiGate>;
-  automation: {
-    attempted: boolean;
-    actions: Array<{
-      action: 'refresh_evidence' | 'refresh_mcp_receipt';
-      status: 'OK' | 'FAILED';
-      details: string;
-    }>;
-  };
+  automation: PreWriteAutomationTrace;
   telemetry: {
     chain: typeof PRE_WRITE_TELEMETRY_CHAIN;
     stage: SddStage;

--- a/integrations/lifecycle/preWriteAutomation.ts
+++ b/integrations/lifecycle/preWriteAutomation.ts
@@ -4,6 +4,8 @@ import { runEnterpriseAiGateCheck } from '../mcp/aiGateCheck';
 import { writeMcpAiGateReceipt } from '../mcp/aiGateReceipt';
 import { evaluateSddPolicy } from '../sdd';
 
+const PRE_WRITE_AUTOMATION_RETRY_BACKOFF_MS = 200;
+
 const PRE_WRITE_AUTOFIXABLE_EVIDENCE_CODES = new Set<string>([
   'EVIDENCE_MISSING',
   'EVIDENCE_INVALID',
@@ -29,7 +31,7 @@ const PRE_WRITE_AUTOFIXABLE_MCP_RECEIPT_CODES = new Set<string>([
 ]);
 
 export type PreWriteAutomationAction = {
-  action: 'refresh_evidence' | 'refresh_mcp_receipt';
+  action: 'refresh_evidence' | 'refresh_mcp_receipt' | 'retry_backoff';
   status: 'OK' | 'FAILED';
   details: string;
 };
@@ -39,15 +41,54 @@ export type PreWriteAutomationTrace = {
   actions: PreWriteAutomationAction[];
 };
 
+type PreWriteAutomationDependencies = {
+  evaluateAiGate: typeof evaluateAiGate;
+  runEnterpriseAiGateCheck: typeof runEnterpriseAiGateCheck;
+  writeMcpAiGateReceipt: typeof writeMcpAiGateReceipt;
+  sleep: (ms: number) => Promise<void>;
+  retryBackoffMs: number;
+};
+
+const defaultDependencies: PreWriteAutomationDependencies = {
+  evaluateAiGate,
+  runEnterpriseAiGateCheck,
+  writeMcpAiGateReceipt,
+  sleep: (ms: number) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+  retryBackoffMs: PRE_WRITE_AUTOMATION_RETRY_BACKOFF_MS,
+};
+
+const hasAutoFixableEvidenceViolation = (aiGate: ReturnType<typeof evaluateAiGate>): boolean =>
+  aiGate.violations.some((violation) => PRE_WRITE_AUTOFIXABLE_EVIDENCE_CODES.has(violation.code));
+
+const hasAutoFixableMcpReceiptViolation = (aiGate: ReturnType<typeof evaluateAiGate>): boolean =>
+  aiGate.violations.some((violation) => PRE_WRITE_AUTOFIXABLE_MCP_RECEIPT_CODES.has(violation.code));
+
+const collectAutoFixableViolationCodes = (aiGate: ReturnType<typeof evaluateAiGate>): string[] =>
+  aiGate.violations
+    .filter(
+      (violation) =>
+        PRE_WRITE_AUTOFIXABLE_EVIDENCE_CODES.has(violation.code)
+        || PRE_WRITE_AUTOFIXABLE_MCP_RECEIPT_CODES.has(violation.code)
+    )
+    .map((violation) => violation.code)
+    .sort((left, right) => left.localeCompare(right));
+
 export const buildPreWriteAutomationTrace = async (params: {
   repoRoot: string;
   sdd: ReturnType<typeof evaluateSddPolicy>;
   aiGate: ReturnType<typeof evaluateAiGate>;
   runPlatformGate: typeof runPlatformGate;
-}): Promise<{
+}, dependencies: Partial<PreWriteAutomationDependencies> = {}): Promise<{
   aiGate: ReturnType<typeof evaluateAiGate>;
   trace: PreWriteAutomationTrace;
 }> => {
+  const activeDependencies: PreWriteAutomationDependencies = {
+    ...defaultDependencies,
+    ...dependencies,
+  };
   const trace: PreWriteAutomationTrace = {
     attempted: false,
     actions: [],
@@ -60,10 +101,7 @@ export const buildPreWriteAutomationTrace = async (params: {
   }
 
   let aiGate = params.aiGate;
-  const hasEvidenceAutoFixableViolation = aiGate.violations.some((violation) =>
-    PRE_WRITE_AUTOFIXABLE_EVIDENCE_CODES.has(violation.code)
-  );
-  if (hasEvidenceAutoFixableViolation) {
+  if (hasAutoFixableEvidenceViolation(aiGate)) {
     trace.attempted = true;
     try {
       const gateExitCode = await params.runPlatformGate({
@@ -85,7 +123,7 @@ export const buildPreWriteAutomationTrace = async (params: {
         status: 'OK',
         details: `runPlatformGate exit_code=${gateExitCode}`,
       });
-      aiGate = runEnterpriseAiGateCheck({
+      aiGate = activeDependencies.runEnterpriseAiGateCheck({
         repoRoot: params.repoRoot,
         stage: 'PRE_WRITE',
         requireMcpReceipt: true,
@@ -99,18 +137,15 @@ export const buildPreWriteAutomationTrace = async (params: {
     }
   }
 
-  const hasReceiptAutoFixableViolation = aiGate.violations.some((violation) =>
-    PRE_WRITE_AUTOFIXABLE_MCP_RECEIPT_CODES.has(violation.code)
-  );
-  if (hasReceiptAutoFixableViolation) {
+  if (hasAutoFixableMcpReceiptViolation(aiGate)) {
     trace.attempted = true;
     try {
-      const aiGateWithoutReceiptRequirement = evaluateAiGate({
+      const aiGateWithoutReceiptRequirement = activeDependencies.evaluateAiGate({
         repoRoot: params.repoRoot,
         stage: 'PRE_WRITE',
         requireMcpReceipt: false,
       });
-      const receiptWrite = writeMcpAiGateReceipt({
+      const receiptWrite = activeDependencies.writeMcpAiGateReceipt({
         repoRoot: params.repoRoot,
         stage: 'PRE_WRITE',
         status: aiGateWithoutReceiptRequirement.status,
@@ -121,7 +156,7 @@ export const buildPreWriteAutomationTrace = async (params: {
         status: 'OK',
         details: `receipt=${receiptWrite.path}`,
       });
-      aiGate = runEnterpriseAiGateCheck({
+      aiGate = activeDependencies.runEnterpriseAiGateCheck({
         repoRoot: params.repoRoot,
         stage: 'PRE_WRITE',
         requireMcpReceipt: true,
@@ -131,6 +166,30 @@ export const buildPreWriteAutomationTrace = async (params: {
         action: 'refresh_mcp_receipt',
         status: 'FAILED',
         details: error instanceof Error ? error.message : 'Unknown MCP receipt refresh error',
+      });
+    }
+  }
+
+  const retryCodes = collectAutoFixableViolationCodes(aiGate);
+  if (!aiGate.allowed && retryCodes.length > 0) {
+    trace.attempted = true;
+    try {
+      await activeDependencies.sleep(activeDependencies.retryBackoffMs);
+      aiGate = activeDependencies.runEnterpriseAiGateCheck({
+        repoRoot: params.repoRoot,
+        stage: 'PRE_WRITE',
+        requireMcpReceipt: true,
+      }).result;
+      trace.actions.push({
+        action: 'retry_backoff',
+        status: 'OK',
+        details: `delay_ms=${activeDependencies.retryBackoffMs} codes=${retryCodes.join(',')}`,
+      });
+    } catch (error) {
+      trace.actions.push({
+        action: 'retry_backoff',
+        status: 'FAILED',
+        details: error instanceof Error ? error.message : 'Unknown PRE_WRITE retry error',
       });
     }
   }


### PR DESCRIPTION
## Summary
- adds deterministic single retry/backoff (`retry_backoff`) to PRE_WRITE auto-healing when violations remain auto-fixable after refresh
- keeps existing evidence + MCP receipt auto-refresh behavior and centralizes dependency injection for deterministic tests
- updates PRE_WRITE JSON envelope typing to include the new automation action

## Issue
- closes #481

## RED -> GREEN Evidence
- Added regression tests for PRE_WRITE automation retry behavior:
  - `integrations/lifecycle/__tests__/preWriteAutomation.test.ts`

## Validation
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/preWriteAutomation.test.ts`
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

## Risks
- low: behavior change only impacts PRE_WRITE auto-healing path when gate is blocked with auto-fixable violations
