### PR TITLE
fix: preserve pre-push stdin across npx bootstrap flow (#493)

### DIFF
--- a/integrations/git/__tests__/stageRunners.test.ts
+++ b/integrations/git/__tests__/stageRunners.test.ts
@@ -336,6 +336,33 @@ test('runPrePushStage allows bootstrap push without upstream when stdin indicate
   });
 });
 
+test('runPrePushStage allows bootstrap push without upstream when hook injects stdin via env', async () => {
+  await withStageRunnerRepo(async (repoRoot) => {
+    setupBackendCommitRangeWithoutUpstream(repoRoot);
+    const headOid = runGit(repoRoot, ['rev-parse', 'HEAD']).trim();
+    const remoteZero = '0'.repeat(40);
+    const previousEnv = process.env.PUMUKI_PRE_PUSH_STDIN;
+    process.env.PUMUKI_PRE_PUSH_STDIN =
+      `refs/heads/feature/no-upstream ${headOid} refs/heads/feature/no-upstream ${remoteZero}\n`;
+
+    try {
+      const exitCode = await runPrePushStage({
+        resolvePrePushBootstrapBaseRef: () => 'main',
+      });
+      assert.equal(exitCode, 0);
+      assert.equal(existsSync(join(repoRoot, '.ai_evidence.json')), true);
+      const evidence = readEvidence(repoRoot);
+      assert.equal(evidence.snapshot.stage, 'PRE_PUSH');
+    } finally {
+      if (typeof previousEnv === 'undefined') {
+        delete process.env.PUMUKI_PRE_PUSH_STDIN;
+      } else {
+        process.env.PUMUKI_PRE_PUSH_STDIN = previousEnv;
+      }
+    }
+  });
+});
+
 test('runCiStage uses skills policy override and writes CI policy trace', async () => {
   await withStageRunnerRepo(async (repoRoot) => {
     writeSkillsPolicy(repoRoot, {

--- a/integrations/git/stageRunners.ts
+++ b/integrations/git/stageRunners.ts
@@ -34,6 +34,10 @@ const defaultDependencies: StageRunnerDependencies = {
   runPlatformGate,
   resolveRepoRoot: () => new GitService().resolveRepoRoot(),
   readPrePushStdin: () => {
+    const envInput = process.env.PUMUKI_PRE_PUSH_STDIN;
+    if (typeof envInput === 'string' && envInput.trim().length > 0) {
+      return envInput;
+    }
     if (process.stdin.isTTY) {
       return '';
     }

--- a/integrations/lifecycle/__tests__/hookBlock.test.ts
+++ b/integrations/lifecycle/__tests__/hookBlock.test.ts
@@ -12,7 +12,8 @@ test('buildPumukiManagedHookBlock genera comando correcto por hook', () => {
   const prePush = buildPumukiManagedHookBlock('pre-push');
 
   assert.match(preCommit, /npx --yes pumuki-pre-commit/);
-  assert.match(prePush, /npx --yes pumuki-pre-push/);
+  assert.match(prePush, /PUMUKI_PRE_PUSH_STDIN="\$\(cat\)"/);
+  assert.match(prePush, /PUMUKI_PRE_PUSH_STDIN="\$PUMUKI_PRE_PUSH_STDIN" npx --yes pumuki-pre-push "\$@"/);
   assert.match(preCommit, /PUMUKI MANAGED START/);
   assert.match(preCommit, /PUMUKI MANAGED END/);
 });

--- a/integrations/lifecycle/hookBlock.ts
+++ b/integrations/lifecycle/hookBlock.ts
@@ -26,11 +26,16 @@ const managedBlockPattern = new RegExp(
 
 export const buildPumukiManagedHookBlock = (hook: PumukiManagedHook): string => {
   const cli = HOOK_COMMANDS[hook];
+  const prePushCommand =
+    '  PUMUKI_PRE_PUSH_STDIN="$(cat)"\n' +
+    `  PUMUKI_PRE_PUSH_STDIN="$PUMUKI_PRE_PUSH_STDIN" npx --yes ${cli} "$@"`;
+  const hookCommand =
+    hook === 'pre-push' ? prePushCommand : `  npx --yes ${cli}`;
 
   return [
     PUMUKI_MANAGED_BLOCK_START,
     'if command -v npx >/dev/null 2>&1; then',
-    `  npx --yes ${cli}`,
+    hookCommand,
     '  status=$?',
     '  if [ "$status" -ne 0 ]; then',
     '    exit "$status"',


### PR DESCRIPTION
## Summary
- capture pre-push stdin in managed hook before invoking npx
- pass captured refs through `PUMUKI_PRE_PUSH_STDIN` to avoid stdin loss
- prefer env-provided pre-push refs in stage runner bootstrap detection
- add regression tests for hook payload and stage runner env bootstrap

## Validation
- npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/hookBlock.test.ts
- npx --yes tsx@4.21.0 --test integrations/git/__tests__/stageRunners.test.ts
- npm run -s typecheck

Fixes #493