### PR TITLE
docs: update tracking after #493 fix (P12.F1.T6 -> T7)

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T6` (ejecutar fix E2E de regresión `#493` en Pumuki).
+- Task activa (`🚧`): `P12.F1.T7` (sincronizar canónico RuralGO tras fix `#493` con refs reales).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -786,9 +786,27 @@ Criterio de salida F5:
     - `gh issue create --title \"Regression: pre-push upstream bootstrap deadlock still reproducible in 6.3.28\" ...`
     - `git push --set-upstream origin feature/rgo-1590-01-ios-physical-signoff` (bloqueo reproducido)
     - `git branch --set-upstream-to=origin/develop ... && git push origin HEAD` (workaround operativo)
-- 🚧 `P12.F1.T6` Ejecutar fix E2E de regresión `#493` en Pumuki (issue -> rama -> tests -> PR -> merge).
+- ✅ `P12.F1.T6` Ejecutar fix E2E de regresión `#493` en Pumuki (issue -> rama -> tests -> PR -> merge).
+  - cierre ejecutado:
+    - rama: `bugfix/493-prepush-upstream-bootstrap-deadlock`.
+    - fix aplicado:
+      - hook `pre-push` captura `stdin` y lo propaga por `PUMUKI_PRE_PUSH_STDIN`.
+      - stage runner prioriza `PUMUKI_PRE_PUSH_STDIN` para detectar bootstrap sin upstream.
+    - tests de regresión añadidos:
+      - `integrations/lifecycle/__tests__/hookBlock.test.ts`
+      - `integrations/git/__tests__/stageRunners.test.ts`
+    - PR: `#495` (mergeada en `develop`).
+    - commit de merge: `d1311d738604b0a01a9a5d99010cc19722b7051e`.
+    - issue: `#493` cerrada manualmente tras merge.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/hookBlock.test.ts`
+    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/stageRunners.test.ts`
+    - `npm run -s typecheck`
+    - `gh pr view 495 --json number,state,mergedAt,mergeCommit,url`
+    - `gh issue close 493 --comment \"Closed via merged PR #495...\"`
+- 🚧 `P12.F1.T7` Sincronizar canónico RuralGO tras fix `#493` (`REPORTED -> FIXED` con refs reales issue/PR/commit/evidencia).
   - objetivo inmediato:
-    - reproducir en tests el escenario `pre-push` + `--set-upstream` y preparar patch sin romper casos con upstream ya configurado.
+    - actualizar `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` con `FIXED (#493, #495)` en IDs afectados y causa raíz consolidada.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- mark P12.F1.T6 as completed with references to issue #493 and PR #495
- set P12.F1.T7 as the single in-progress task
- update master tracking file to point to P12.F1.T7

## Validation
- npm run -s validation:tracking-single-active