### PR TITLE
fix(sdd): align PRE_PUSH completeness with OpenSpec validate --all (#483)

### DIFF
--- a/integrations/sdd/__tests__/openSpecCli.test.ts
+++ b/integrations/sdd/__tests__/openSpecCli.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 import {
   evaluateOpenSpecCompatibility,
   OPENSPEC_COMPATIBILITY_MATRIX,
+  validateOpenSpecChanges,
 } from '../openSpecCli';
 
 test('evaluateOpenSpecCompatibility marca incompatible cuando OpenSpec no está instalado', () => {
@@ -85,4 +89,40 @@ test('evaluateOpenSpecCompatibility marca incompatible en versión menor de mino
 
   assert.equal(result.compatible, false);
   assert.equal(result.parsedVersion, '1.0.99');
+});
+
+test('validateOpenSpecChanges ejecuta openspec validate --all para alinear contrato de completitud', () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'pumuki-sdd-openspec-validate-all-'));
+  try {
+    const binDir = join(repoRoot, 'node_modules', '.bin');
+    const argsCapturePath = join(repoRoot, 'openspec-args.json');
+    mkdirSync(binDir, { recursive: true });
+
+    const jsPath = join(binDir, 'openspec');
+    const script = `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.writeFileSync(${JSON.stringify(argsCapturePath)}, JSON.stringify(args), 'utf8');
+if (args[0] === 'validate') {
+  process.stdout.write(JSON.stringify({
+    summary: {
+      totals: { items: 1, failed: 0, passed: 1 },
+      byLevel: { ERROR: 0, WARNING: 0, INFO: 0 }
+    }
+  }));
+  process.exit(0);
+}
+process.exit(0);
+`;
+    writeFileSync(jsPath, script, 'utf8');
+    chmodSync(jsPath, 0o755);
+    mkdirSync(join(repoRoot, 'openspec', 'changes', 'dummy-change'), { recursive: true });
+
+    const validation = validateOpenSpecChanges(repoRoot);
+    assert.equal(validation.ok, true);
+    const args = JSON.parse(readFileSync(argsCapturePath, 'utf8')) as Array<string>;
+    assert.deepEqual(args, ['validate', '--all', '--json', '--no-interactive']);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
 });

--- a/integrations/sdd/__tests__/policy.test.ts
+++ b/integrations/sdd/__tests__/policy.test.ts
@@ -214,6 +214,10 @@ test('evaluateSddPolicy bloquea con SDD_VALIDATION_FAILED cuando OpenSpec devuel
     const result = evaluateSddPolicy({ stage: 'PRE_COMMIT', repoRoot });
     assert.equal(result.decision.allowed, false);
     assert.equal(result.decision.code, 'SDD_VALIDATION_FAILED');
+    assert.equal(
+      result.decision.details?.command,
+      'openspec validate --all --json --no-interactive'
+    );
     assert.equal(result.decision.details?.exitCode, 2);
     assert.equal(result.decision.details?.failedItems, 1);
     assert.equal(result.decision.details?.errors, 1);
@@ -250,6 +254,10 @@ test('evaluateSddPolicy permite CI cuando validación OpenSpec es satisfactoria'
     const result = evaluateSddPolicy({ stage: 'CI', repoRoot });
     assert.equal(result.decision.allowed, true);
     assert.equal(result.decision.code, 'ALLOWED');
+    assert.equal(
+      result.decision.details?.command,
+      'openspec validate --all --json --no-interactive'
+    );
     assert.equal(result.decision.details?.passedItems, 4);
     assert.equal(result.decision.details?.warnings, 2);
     assert.equal(result.validation?.ok, true);

--- a/integrations/sdd/openSpecCli.ts
+++ b/integrations/sdd/openSpecCli.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path';
 import type { OpenSpecValidationSummary } from './types';
 
 export const OPENSPEC_NPM_PACKAGE_NAME = '@fission-ai/openspec';
+export const OPENSPEC_VALIDATE_ALL_COMMAND = 'openspec validate --all --json --no-interactive';
 export const OPENSPEC_COMPATIBILITY_MATRIX = {
   packageName: OPENSPEC_NPM_PACKAGE_NAME,
   minimumVersion: '1.1.1',
@@ -163,10 +164,7 @@ export const isOpenSpecProjectInitialized = (repoRoot: string): boolean =>
 export const validateOpenSpecChanges = (
   repoRoot: string
 ): OpenSpecValidationSummary => {
-  const result = runOpenSpecCommand(
-    ['validate', '--changes', '--json', '--no-interactive'],
-    repoRoot
-  );
+  const result = runOpenSpecCommand(['validate', '--all', '--json', '--no-interactive'], repoRoot);
   const parsed = parseValidationJson(result.stdout);
   const hasErrors = parsed.totals.failed > 0 || parsed.issues.errors > 0;
   return {

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -4,6 +4,7 @@ import {
   detectOpenSpecInstallation,
   evaluateOpenSpecCompatibility,
   isOpenSpecProjectInitialized,
+  OPENSPEC_VALIDATE_ALL_COMMAND,
   validateOpenSpecChanges,
 } from './openSpecCli';
 import { readSddSession } from './sessionStore';
@@ -167,6 +168,7 @@ export const evaluateSddPolicy = (params: {
         validation.exitCode !== 0 ? 'SDD_VALIDATION_FAILED' : 'SDD_VALIDATION_ERROR',
         'OpenSpec validation failed for active changes. Resolve SDD issues before continuing.',
         {
+          command: OPENSPEC_VALIDATE_ALL_COMMAND,
           exitCode: validation.exitCode,
           failedItems: validation.totals.failed,
           errors: validation.issues.errors,
@@ -180,6 +182,7 @@ export const evaluateSddPolicy = (params: {
     status,
     validation,
     decision: allowed('SDD validation passed for active changes.', {
+      command: OPENSPEC_VALIDATE_ALL_COMMAND,
       passedItems: validation.totals.passed,
       warnings: validation.issues.warnings,
     }),


### PR DESCRIPTION
## Summary
- switch SDD/OpenSpec validation command from `validate --changes` to `validate --all`
- expose deterministic command trace in SDD decision details
- add regression tests to lock command contract and diagnostics

## Validation
- npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/openSpecCli.test.ts
- npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/policy.test.ts
- npm run -s typecheck

Fixes #483