### PR TITLE
fix(evidence): harden ai_evidence persistence against concurrent corruption (#482)

### DIFF
--- a/integrations/evidence/writeEvidence.test.ts
+++ b/integrations/evidence/writeEvidence.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
 import { withTempDir } from '../__tests__/helpers/tempDir';
@@ -384,6 +384,45 @@ test('writeEvidence preserva snapshot.memory_shadow con orden estable', async ()
         confidence: 0.987654,
         reason_codes: ['shadow.diff', 'tdd_bdd.blocked'],
       });
+    });
+  });
+});
+
+test('writeEvidence no deja temporales de evidencia tras escribir atómicamente', async () => {
+  await withTempDir('pumuki-write-evidence-atomic-cleanup-', async (tempRoot) => {
+    initGitRepo(tempRoot);
+    await withCwd(tempRoot, async () => {
+      const result = writeEvidence(sampleEvidence(tempRoot));
+      assert.equal(result.ok, true);
+      const tempArtifacts = readdirSync(tempRoot).filter((entry) =>
+        entry.startsWith('.ai_evidence.json.tmp-')
+      );
+      assert.deepEqual(tempArtifacts, []);
+    });
+  });
+});
+
+test('writeEvidence mantiene JSON válido bajo ráfaga de escrituras consecutivas', async () => {
+  await withTempDir('pumuki-write-evidence-atomic-stress-', async (tempRoot) => {
+    initGitRepo(tempRoot);
+    await withCwd(tempRoot, async () => {
+      const writes = Array.from({ length: 50 }, (_, index) =>
+        Promise.resolve().then(() => {
+          const evidence = sampleEvidence(tempRoot);
+          evidence.timestamp = `2026-02-17T00:00:${String(index).padStart(2, '0')}.000Z`;
+          const result = writeEvidence(evidence);
+          assert.equal(result.ok, true);
+        })
+      );
+
+      await Promise.all(writes);
+
+      const persisted = JSON.parse(
+        readFileSync(join(tempRoot, '.ai_evidence.json'), 'utf8')
+      ) as AiEvidenceV2_1;
+      assert.equal(persisted.version, '2.1');
+      assert.equal(typeof persisted.timestamp, 'string');
+      assert.equal(persisted.snapshot.findings.length > 0, true);
     });
   });
 });

--- a/integrations/evidence/writeEvidence.ts
+++ b/integrations/evidence/writeEvidence.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { renameSync, rmSync, writeFileSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 import type {
   AiEvidenceV2_1,
@@ -22,6 +22,7 @@ export type WriteEvidenceResult = {
 };
 
 const EVIDENCE_FILE_NAME = '.ai_evidence.json';
+const TEMP_EVIDENCE_PREFIX = '.ai_evidence.json.tmp-';
 
 const normalizeLines = (lines?: EvidenceLines): EvidenceLines | undefined => {
   if (typeof lines === 'undefined') {
@@ -341,21 +342,29 @@ const resolveRepoRoot = (): string => {
   return process.cwd();
 };
 
+const buildTempEvidencePath = (repoRoot: string): string => {
+  const uniqueSuffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+  return join(repoRoot, `${TEMP_EVIDENCE_PREFIX}${uniqueSuffix}`);
+};
+
 export function writeEvidence(
   evidence: AiEvidenceV2_1,
   options?: { repoRoot?: string }
 ): WriteEvidenceResult {
   const repoRoot = options?.repoRoot ?? resolveRepoRoot();
   const outputPath = join(repoRoot, EVIDENCE_FILE_NAME);
+  const tempPath = buildTempEvidencePath(repoRoot);
 
   try {
     const stableEvidence = toStableEvidence(evidence, repoRoot);
-    writeFileSync(outputPath, `${JSON.stringify(stableEvidence, null, 2)}\n`, 'utf8');
+    writeFileSync(tempPath, `${JSON.stringify(stableEvidence, null, 2)}\n`, 'utf8');
+    renameSync(tempPath, outputPath);
     return {
       ok: true,
       path: outputPath,
     };
   } catch (error) {
+    rmSync(tempPath, { force: true });
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[ai-evidence] ${message}`);
     return {


### PR DESCRIPTION
## Summary
- persist `.ai_evidence.json` atomically via temp file + rename
- clean temp artifact on failure for deterministic recovery
- add stress/cleanup tests to ensure evidence remains valid under rapid writes

## Validation
- npx --yes tsx@4.21.0 --test integrations/evidence/writeEvidence.test.ts
- npx --yes tsx@4.21.0 --test integrations/evidence/generateEvidence.test.ts
- npm run -s typecheck

Fixes #482