### PR TITLE
feat(sdd): add deterministic sync-docs workflow

### DIFF
--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -144,6 +144,21 @@ test('parseLifecycleCliArgs soporta subcomandos SDD', () => {
       sddTtlMinutes: 60,
     }
   );
+  assert.deepEqual(
+    parseLifecycleCliArgs([
+      'sdd',
+      'sync-docs',
+      '--dry-run',
+      '--json',
+    ]),
+    {
+      command: 'sdd',
+      purgeArtifacts: false,
+      json: true,
+      sddCommand: 'sync-docs',
+      sddSyncDocsDryRun: true,
+    }
+  );
 });
 
 test('parseLifecycleCliArgs soporta analytics hotspots report', () => {
@@ -594,6 +609,65 @@ test('runLifecycleCli sdd validate PRE_WRITE sin --json renderiza panel legacy d
     const output = printed.join('\n');
     assert.match(output, /PRE-FLIGHT CHECK/);
     assert.match(output, /MCP receipt: required=yes kind=valid/);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli sdd sync-docs dry-run devuelve diff sin modificar el archivo canónico', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const canonicalDoc = join(
+    repo,
+    'docs',
+    'technical',
+    '08-validation',
+    'refactor',
+    'pumuki-integration-feedback.md'
+  );
+
+  try {
+    mkdirSync(dirname(canonicalDoc), { recursive: true });
+    writeFileSync(
+      canonicalDoc,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    const before = readFileSync(canonicalDoc, 'utf8');
+
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli(['sdd', 'sync-docs', '--dry-run', '--json']);
+    assert.equal(code, 0);
+    const after = readFileSync(canonicalDoc, 'utf8');
+    assert.equal(before, after);
+
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      command?: string;
+      dryRun?: boolean;
+      updated?: boolean;
+      files?: Array<{ updated?: boolean; diffMarkdown?: string }>;
+    };
+    assert.equal(payload.command, 'pumuki sdd sync-docs');
+    assert.equal(payload.dryRun, true);
+    assert.equal(payload.updated, true);
+    assert.equal(payload.files?.[0]?.updated, true);
+    assert.match(payload.files?.[0]?.diffMarkdown ?? '', /sdd-status/i);
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -22,6 +22,7 @@ import {
   openSddSession,
   readSddStatus,
   refreshSddSession,
+  runSddSyncDocs,
   type SddStage,
 } from '../sdd';
 import { evaluateAiGate } from '../gate/evaluateAiGate';
@@ -52,7 +53,7 @@ type LifecycleCommand =
   | 'adapter'
   | 'analytics';
 
-type SddCommand = 'status' | 'validate' | 'session';
+type SddCommand = 'status' | 'validate' | 'session' | 'sync-docs';
 type LoopCommand = 'run' | 'status' | 'stop' | 'resume' | 'list' | 'export';
 type AnalyticsCommand = 'hotspots';
 type AnalyticsHotspotsCommand = 'report' | 'diagnose';
@@ -74,6 +75,7 @@ type ParsedArgs = {
   sddSessionAction?: SddSessionAction;
   sddChangeId?: string;
   sddTtlMinutes?: number;
+  sddSyncDocsDryRun?: boolean;
   adapterCommand?: 'install';
   adapterAgent?: AdapterAgent;
   adapterDryRun?: boolean;
@@ -107,6 +109,7 @@ Pumuki lifecycle commands:
   pumuki sdd session --open --change=<change-id> [--ttl-minutes=<n>] [--json]
   pumuki sdd session --refresh [--ttl-minutes=<n>] [--json]
   pumuki sdd session --close [--json]
+  pumuki sdd sync-docs [--dry-run] [--json]
 `.trim();
 
 const LOOP_RUN_POLICY: GatePolicy = {
@@ -403,6 +406,7 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   let sddSessionAction: ParsedArgs['sddSessionAction'];
   let sddChangeId: ParsedArgs['sddChangeId'];
   let sddTtlMinutes: ParsedArgs['sddTtlMinutes'];
+  let sddSyncDocsDryRun = false;
   let adapterCommand: ParsedArgs['adapterCommand'];
   let adapterAgent: ParsedArgs['adapterAgent'];
   let adapterDryRun = false;
@@ -580,7 +584,8 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
     if (
       subcommandRaw !== 'status' &&
       subcommandRaw !== 'validate' &&
-      subcommandRaw !== 'session'
+      subcommandRaw !== 'session' &&
+      subcommandRaw !== 'sync-docs'
     ) {
       throw new Error(`Unsupported SDD subcommand "${subcommandRaw}".\n\n${HELP_TEXT}`);
     }
@@ -591,27 +596,52 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         json = true;
         continue;
       }
+      if (arg === '--dry-run') {
+        if (sddCommand !== 'sync-docs') {
+          throw new Error(`--dry-run is only supported with "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+        }
+        sddSyncDocsDryRun = true;
+        continue;
+      }
       if (arg.startsWith('--stage=')) {
+        if (sddCommand !== 'validate') {
+          throw new Error(`--stage is only supported with "pumuki sdd validate".\n\n${HELP_TEXT}`);
+        }
         sddStage = parseSddStage(arg.slice('--stage='.length));
         continue;
       }
       if (arg === '--open') {
+        if (sddCommand !== 'session') {
+          throw new Error(`--open is only supported with "pumuki sdd session".\n\n${HELP_TEXT}`);
+        }
         sddSessionAction = 'open';
         continue;
       }
       if (arg === '--refresh') {
+        if (sddCommand !== 'session') {
+          throw new Error(`--refresh is only supported with "pumuki sdd session".\n\n${HELP_TEXT}`);
+        }
         sddSessionAction = 'refresh';
         continue;
       }
       if (arg === '--close') {
+        if (sddCommand !== 'session') {
+          throw new Error(`--close is only supported with "pumuki sdd session".\n\n${HELP_TEXT}`);
+        }
         sddSessionAction = 'close';
         continue;
       }
       if (arg.startsWith('--change=')) {
+        if (sddCommand !== 'session') {
+          throw new Error(`--change is only supported with "pumuki sdd session".\n\n${HELP_TEXT}`);
+        }
         sddChangeId = arg.slice('--change='.length).trim();
         continue;
       }
       if (arg.startsWith('--ttl-minutes=')) {
+        if (sddCommand !== 'session') {
+          throw new Error(`--ttl-minutes is only supported with "pumuki sdd session".\n\n${HELP_TEXT}`);
+        }
         const minutes = Number.parseInt(arg.slice('--ttl-minutes='.length), 10);
         if (!Number.isFinite(minutes) || minutes <= 0) {
           throw new Error(`Invalid --ttl-minutes value "${arg}".`);
@@ -637,6 +667,20 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         json,
         sddCommand,
         sddStage: sddStage ?? 'PRE_COMMIT',
+      };
+    }
+    if (sddCommand === 'sync-docs') {
+      if (sddSessionAction || sddChangeId || typeof sddTtlMinutes === 'number') {
+        throw new Error(
+          `"pumuki sdd sync-docs" only supports [--dry-run] [--json].\n\n${HELP_TEXT}`
+        );
+      }
+      return {
+        command: commandRaw,
+        purgeArtifacts: false,
+        json,
+        sddCommand,
+        sddSyncDocsDryRun,
       };
     }
 
@@ -1405,6 +1449,28 @@ export const runLifecycleCli = async (
             writeInfo(JSON.stringify(session, null, 2));
           } else {
             writeInfo('[pumuki][sdd] session closed');
+          }
+          return 0;
+        }
+        if (parsed.sddCommand === 'sync-docs') {
+          const syncResult = runSddSyncDocs({
+            repoRoot: process.cwd(),
+            dryRun: parsed.sddSyncDocsDryRun === true,
+          });
+          if (parsed.json) {
+            writeInfo(JSON.stringify(syncResult, null, 2));
+          } else {
+            writeInfo(
+              `[pumuki][sdd] sync-docs dry_run=${syncResult.dryRun ? 'yes' : 'no'} updated=${syncResult.updated ? 'yes' : 'no'} files=${syncResult.files.length}`
+            );
+            for (const file of syncResult.files) {
+              writeInfo(
+                `[pumuki][sdd] file=${file.path} updated=${file.updated ? 'yes' : 'no'} before=${file.beforeDigest} after=${file.afterDigest}`
+              );
+              if (file.updated) {
+                writeInfo(file.diffMarkdown);
+              }
+            }
           }
           return 0;
         }

--- a/integrations/sdd/__tests__/syncDocs.test.ts
+++ b/integrations/sdd/__tests__/syncDocs.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { runSddSyncDocs } from '../syncDocs';
+
+const runGit = (cwd: string, args: ReadonlyArray<string>): string =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+const withFixtureRepo = async (
+  prefix: string,
+  callback: (repoRoot: string) => Promise<void> | void
+): Promise<void> => {
+  const repoRoot = mkdtempSync(join(tmpdir(), prefix));
+  runGit(repoRoot, ['init', '-b', 'main']);
+  runGit(repoRoot, ['config', 'user.email', 'pumuki-test@example.com']);
+  runGit(repoRoot, ['config', 'user.name', 'Pumuki Test']);
+  writeFileSync(join(repoRoot, 'README.md'), '# fixture\n', 'utf8');
+  try {
+    await callback(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+};
+
+const writeCanonicalDoc = (repoRoot: string, body: string): string => {
+  const path = join(
+    repoRoot,
+    'docs',
+    'technical',
+    '08-validation',
+    'refactor',
+    'pumuki-integration-feedback.md'
+  );
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body, 'utf8');
+  return path;
+};
+
+test('runSddSyncDocs dry-run previsualiza diff y no modifica archivo', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-dry-run-', (repoRoot) => {
+    const canonicalPath = writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+    const before = readFileSync(canonicalPath, 'utf8');
+
+    const result = runSddSyncDocs({
+      repoRoot,
+      dryRun: true,
+    });
+    const after = readFileSync(canonicalPath, 'utf8');
+
+    assert.equal(result.dryRun, true);
+    assert.equal(result.updated, true);
+    assert.equal(result.files.length, 1);
+    assert.equal(result.files[0]?.updated, true);
+    assert.match(result.files[0]?.diffMarkdown ?? '', /sdd-status/i);
+    assert.equal(before, after);
+  });
+});
+
+test('runSddSyncDocs aplica cambios deterministas y segunda ejecución no cambia nada', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-apply-', (repoRoot) => {
+    const canonicalPath = writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+
+    const first = runSddSyncDocs({
+      repoRoot,
+      dryRun: false,
+    });
+    const synced = readFileSync(canonicalPath, 'utf8');
+    const second = runSddSyncDocs({
+      repoRoot,
+      dryRun: false,
+    });
+
+    assert.equal(first.updated, true);
+    assert.match(synced, /openspec_installed:/);
+    assert.equal(second.updated, false);
+    assert.equal(second.files[0]?.updated, false);
+  });
+});
+
+test('runSddSyncDocs falla con conflicto de marcadores y no toca el archivo', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-conflict-', (repoRoot) => {
+    const canonicalPath = writeCanonicalDoc(repoRoot, '# Canonical\n\nwithout managed markers\n');
+    const before = readFileSync(canonicalPath, 'utf8');
+
+    assert.throws(
+      () =>
+        runSddSyncDocs({
+          repoRoot,
+          dryRun: false,
+        }),
+      /sync-docs conflict/i
+    );
+    const after = readFileSync(canonicalPath, 'utf8');
+    assert.equal(before, after);
+  });
+});

--- a/integrations/sdd/index.ts
+++ b/integrations/sdd/index.ts
@@ -9,3 +9,4 @@ export type {
 } from './types';
 export { evaluateSddPolicy, readSddStatus } from './policy';
 export { closeSddSession, openSddSession, readSddSession, refreshSddSession } from './sessionStore';
+export { runSddSyncDocs } from './syncDocs';

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -1,0 +1,198 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { readSddStatus } from './policy';
+
+export const SDD_SYNC_DOCS_CANONICAL_FILES = [
+  'docs/technical/08-validation/refactor/pumuki-integration-feedback.md',
+] as const;
+
+const SDD_STATUS_SECTION = {
+  id: 'sdd-status',
+  begin: '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+  end: '<!-- PUMUKI:END SDD_STATUS -->',
+} as const;
+
+type ManagedSectionSyncResult = {
+  sectionId: string;
+  updated: boolean;
+  before: string;
+  after: string;
+  diffMarkdown: string;
+};
+
+export type SddSyncDocsFileResult = {
+  path: string;
+  updated: boolean;
+  beforeDigest: string;
+  afterDigest: string;
+  sections: ReadonlyArray<ManagedSectionSyncResult>;
+  diffMarkdown: string;
+};
+
+export type SddSyncDocsResult = {
+  command: 'pumuki sdd sync-docs';
+  dryRun: boolean;
+  repoRoot: string;
+  updated: boolean;
+  files: ReadonlyArray<SddSyncDocsFileResult>;
+};
+
+const normalizeSectionBody = (value: string): string => value.trim().replace(/\r\n/g, '\n');
+
+const computeDigest = (value: string): string =>
+  createHash('sha256').update(value, 'utf8').digest('hex');
+
+const prefixLines = (value: string, marker: '-' | '+'): string =>
+  value
+    .split('\n')
+    .map((line) => `${marker} ${line}`)
+    .join('\n');
+
+const buildSectionDiffMarkdown = (params: { sectionId: string; before: string; after: string }): string => {
+  if (params.before === params.after) {
+    return `### ${params.sectionId}\nNo changes.\n`;
+  }
+  return [
+    `### ${params.sectionId}`,
+    '```diff',
+    prefixLines(params.before, '-'),
+    prefixLines(params.after, '+'),
+    '```',
+    '',
+  ].join('\n');
+};
+
+const buildFileDiffMarkdown = (params: {
+  path: string;
+  sections: ReadonlyArray<ManagedSectionSyncResult>;
+}): string =>
+  [
+    `## ${params.path}`,
+    ...params.sections.map((section) => section.diffMarkdown),
+  ].join('\n');
+
+const formatSddStatusManagedBody = (repoRoot: string): string => {
+  const status = readSddStatus(repoRoot);
+  return [
+    `- repo_root: ${status.repoRoot}`,
+    `- openspec_installed: ${status.openspec.installed ? 'yes' : 'no'}`,
+    `- openspec_version: ${status.openspec.version ?? 'unknown'}`,
+    `- openspec_project_initialized: ${status.openspec.projectInitialized ? 'yes' : 'no'}`,
+    `- openspec_compatible: ${status.openspec.compatible ? 'yes' : 'no'}`,
+    `- sdd_session_active: ${status.session.active ? 'yes' : 'no'}`,
+    `- sdd_session_valid: ${status.session.valid ? 'yes' : 'no'}`,
+    `- sdd_session_change: ${status.session.changeId ?? 'none'}`,
+  ].join('\n');
+};
+
+const applyManagedSection = (params: {
+  filePath: string;
+  source: string;
+  beginMarker: string;
+  endMarker: string;
+  renderedBody: string;
+  sectionId: string;
+}): {
+  nextSource: string;
+  result: ManagedSectionSyncResult;
+} => {
+  const beginIndex = params.source.indexOf(params.beginMarker);
+  const endIndex = params.source.indexOf(params.endMarker);
+
+  if (beginIndex === -1 || endIndex === -1 || endIndex < beginIndex) {
+    throw new Error(
+      `[pumuki][sdd] sync-docs conflict in ${params.filePath}: expected managed markers ${params.beginMarker} ... ${params.endMarker}`
+    );
+  }
+
+  const bodyStart = beginIndex + params.beginMarker.length;
+  const bodyEnd = endIndex;
+  const beforeBody = normalizeSectionBody(params.source.slice(bodyStart, bodyEnd));
+  const afterBody = normalizeSectionBody(params.renderedBody);
+  const updated = beforeBody !== afterBody;
+  const replacement = `${params.beginMarker}\n${params.renderedBody}\n${params.endMarker}`;
+  const nextSource = updated
+    ? `${params.source.slice(0, beginIndex)}${replacement}${params.source.slice(
+      endIndex + params.endMarker.length
+    )}`
+    : params.source;
+
+  const result: ManagedSectionSyncResult = {
+    sectionId: params.sectionId,
+    updated,
+    before: beforeBody,
+    after: afterBody,
+    diffMarkdown: buildSectionDiffMarkdown({
+      sectionId: params.sectionId,
+      before: beforeBody,
+      after: afterBody,
+    }),
+  };
+  return { nextSource, result };
+};
+
+export const runSddSyncDocs = (params?: {
+  repoRoot?: string;
+  dryRun?: boolean;
+}): SddSyncDocsResult => {
+  const repoRoot = resolve(params?.repoRoot ?? process.cwd());
+  const dryRun = params?.dryRun === true;
+
+  const updates = SDD_SYNC_DOCS_CANONICAL_FILES.map((relativePath) => {
+    const absolutePath = resolve(repoRoot, relativePath);
+    if (!existsSync(absolutePath)) {
+      throw new Error(
+        `[pumuki][sdd] sync-docs missing canonical file: ${relativePath}`
+      );
+    }
+
+    const currentSource = readFileSync(absolutePath, 'utf8');
+    const renderedStatusBody = formatSddStatusManagedBody(repoRoot);
+    const sectionUpdate = applyManagedSection({
+      filePath: relativePath,
+      source: currentSource,
+      beginMarker: SDD_STATUS_SECTION.begin,
+      endMarker: SDD_STATUS_SECTION.end,
+      renderedBody: renderedStatusBody,
+      sectionId: SDD_STATUS_SECTION.id,
+    });
+
+    return {
+      relativePath,
+      absolutePath,
+      currentSource,
+      nextSource: sectionUpdate.nextSource,
+      sections: [sectionUpdate.result] as const,
+    };
+  });
+
+  if (!dryRun) {
+    for (const update of updates) {
+      if (update.currentSource === update.nextSource) {
+        continue;
+      }
+      writeFileSync(update.absolutePath, update.nextSource, 'utf8');
+    }
+  }
+
+  const files: ReadonlyArray<SddSyncDocsFileResult> = updates.map((update) => ({
+    path: update.relativePath,
+    updated: update.currentSource !== update.nextSource,
+    beforeDigest: computeDigest(update.currentSource),
+    afterDigest: computeDigest(update.nextSource),
+    sections: update.sections,
+    diffMarkdown: buildFileDiffMarkdown({
+      path: update.relativePath,
+      sections: update.sections,
+    }),
+  }));
+
+  return {
+    command: 'pumuki sdd sync-docs',
+    dryRun,
+    repoRoot,
+    updated: files.some((file) => file.updated),
+    files,
+  };
+};


### PR DESCRIPTION
## Summary
- add native `pumuki sdd sync-docs` command scaffold with `--dry-run`
- add managed-section updater for canonical SDD/OpenSpec doc blocks
- enforce conflict-safe behavior (missing/invalid markers fail without partial writes)
- emit deterministic JSON payload and markdown diff preview

## Files
- `integrations/sdd/syncDocs.ts`
- `integrations/lifecycle/cli.ts`
- `integrations/sdd/index.ts`
- tests in `integrations/sdd/__tests__/syncDocs.test.ts` and `integrations/lifecycle/__tests__/cli.test.ts`

## Validation
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

Closes #484