### PR TITLE
feat(prewrite): auto-remediate OpenSpec blockers with next action

### DIFF
--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
@@ -13,6 +13,7 @@ import {
 } from '../saasIngestionContract';
 import { resolveHotspotsSaasIngestionMetricsPath } from '../saasIngestionMetrics';
 import { parseLifecycleCliArgs, runLifecycleCli } from '../cli';
+import { openSddSession } from '../../sdd/sessionStore';
 import { resolveMcpAiGateReceiptPath, writeMcpAiGateReceipt } from '../../mcp/aiGateReceipt';
 
 const runGit = (cwd: string, args: ReadonlyArray<string>): string =>
@@ -37,6 +38,118 @@ const createGitRepo = (trackedNodeModules = false): string => {
   }
 
   return repo;
+};
+
+const writePreWriteEvidence = (repoRoot: string, branch: string): void => {
+  writeFileSync(
+    join(repoRoot, '.ai_evidence.json'),
+    JSON.stringify(
+      {
+        version: '2.1',
+        timestamp: new Date().toISOString(),
+        snapshot: {
+          stage: 'PRE_COMMIT',
+          outcome: 'PASS',
+          rules_coverage: {
+            stage: 'PRE_COMMIT',
+            active_rule_ids: ['skills.backend.no-empty-catch'],
+            evaluated_rule_ids: ['skills.backend.no-empty-catch'],
+            matched_rule_ids: [],
+            unevaluated_rule_ids: [],
+            counts: {
+              active: 1,
+              evaluated: 1,
+              matched: 0,
+              unevaluated: 0,
+            },
+            coverage_ratio: 1,
+          },
+          findings: [],
+        },
+        ledger: [],
+        platforms: {},
+        rulesets: [],
+        human_intent: null,
+        ai_gate: {
+          status: 'ALLOWED',
+          violations: [],
+          human_intent: null,
+        },
+        severity_metrics: {
+          gate_status: 'ALLOWED',
+          total_violations: 0,
+          by_severity: {
+            CRITICAL: 0,
+            ERROR: 0,
+            WARN: 0,
+            INFO: 0,
+          },
+        },
+        repo_state: {
+          repo_root: repoRoot,
+          git: {
+            available: true,
+            branch,
+            upstream: null,
+            ahead: 0,
+            behind: 0,
+            dirty: false,
+            staged: 0,
+            unstaged: 0,
+          },
+          lifecycle: {
+            installed: true,
+            package_version: '6.3.26',
+            lifecycle_version: '6.3.26',
+            hooks: {
+              pre_commit: 'managed',
+              pre_push: 'managed',
+            },
+          },
+        },
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+};
+
+const withFakeNpmOpenSpecInstaller = async <T>(
+  repoRoot: string,
+  callback: () => Promise<T>
+): Promise<T> => {
+  const previousPath = process.env.PATH ?? '';
+  const fakeBinDir = join(repoRoot, '.fake-bin');
+  mkdirSync(fakeBinDir, { recursive: true });
+  const npmPath = join(fakeBinDir, 'npm');
+  const script = `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+if (args[0] === 'install' && args.includes('@fission-ai/openspec@latest')) {
+  const cwd = process.cwd();
+  const binDir = path.join(cwd, 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const openspecPath = path.join(binDir, 'openspec');
+  fs.writeFileSync(
+    openspecPath,
+    '#!/usr/bin/env node\\nconst args = process.argv.slice(2);\\nif (args.includes(\"--version\")) { process.stdout.write(\"OpenSpec CLI v1.2.0\\\\n\"); process.exit(0); }\\nif (args[0] === \"validate\") { process.stdout.write(JSON.stringify({ summary: { totals: { items: 1, failed: 0, passed: 1 }, byLevel: { ERROR: 0, WARNING: 0, INFO: 0 } } })); process.exit(0); }\\nprocess.exit(0);\\n',
+    'utf8'
+  );
+  fs.chmodSync(openspecPath, 0o755);
+  process.exit(0);
+}
+process.exit(0);
+`;
+  writeFileSync(npmPath, script, 'utf8');
+  chmodSync(npmPath, 0o755);
+  process.env.PATH = `${fakeBinDir}:${previousPath}`;
+  try {
+    return await callback();
+  } finally {
+    process.env.PATH = previousPath;
+  }
 };
 
 const withSilentConsole = async <T>(callback: () => Promise<T>): Promise<T> => {
@@ -610,6 +723,133 @@ test('runLifecycleCli sdd validate PRE_WRITE sin --json renderiza panel legacy d
     assert.match(output, /PRE-FLIGHT CHECK/);
     assert.match(output, /MCP receipt: required=yes kind=valid/);
   } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli sdd validate PRE_WRITE auto-bootstrap de OpenSpec y habilita flujo determinista', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const changeId = 'bootstrap-openspec-missing';
+
+  try {
+    runGit(repo, ['checkout', '-b', 'feature/prewrite-openspec-bootstrap']);
+    writeFileSync(
+      join(repo, 'package.json'),
+      JSON.stringify({ name: 'fixture', version: '1.0.0' }, null, 2),
+      'utf8'
+    );
+    mkdirSync(join(repo, 'openspec', 'changes', changeId), { recursive: true });
+    writeFileSync(join(repo, 'openspec', 'changes', changeId, 'proposal.md'), '# proposal\n', 'utf8');
+    openSddSession({ cwd: repo, changeId, ttlMinutes: 60 });
+    writePreWriteEvidence(repo, 'feature/prewrite-openspec-bootstrap');
+    writeMcpAiGateReceipt({
+      repoRoot: repo,
+      stage: 'PRE_WRITE',
+      status: 'ALLOWED',
+      allowed: true,
+    });
+
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await withFakeNpmOpenSpecInstaller(repo, async () =>
+      runLifecycleCli(['sdd', 'validate', '--stage=PRE_WRITE', '--json'], {
+        runPlatformGate: async () => 0,
+      })
+    );
+    assert.equal(code, 0);
+    assert.equal(existsSync(join(repo, 'node_modules', '.bin', 'openspec')), true);
+
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      sdd?: {
+        decision?: { code?: string; allowed?: boolean };
+        status?: { openspec?: { installed?: boolean; compatible?: boolean } };
+      };
+      bootstrap?: { enabled?: boolean; attempted?: boolean; status?: string; actions?: string[] };
+    };
+    assert.equal(payload.sdd?.decision?.allowed, true);
+    assert.equal(payload.sdd?.decision?.code, 'ALLOWED');
+    assert.equal(payload.sdd?.status?.openspec?.installed, true);
+    assert.equal(payload.sdd?.status?.openspec?.compatible, true);
+    assert.equal(payload.bootstrap?.enabled, true);
+    assert.equal(payload.bootstrap?.attempted, true);
+    assert.equal(payload.bootstrap?.status, 'OK');
+    assert.equal((payload.bootstrap?.actions ?? []).includes('npm-install:@fission-ai/openspec@latest'), true);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli sdd validate PRE_WRITE con auto-bootstrap deshabilitado expone next_action ejecutable', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const previousAutoBootstrap = process.env.PUMUKI_PREWRITE_AUTO_BOOTSTRAP;
+  const changeId = 'bootstrap-disabled-openspec-missing';
+
+  try {
+    runGit(repo, ['checkout', '-b', 'feature/prewrite-openspec-bootstrap-disabled']);
+    writeFileSync(
+      join(repo, 'package.json'),
+      JSON.stringify({ name: 'fixture', version: '1.0.0' }, null, 2),
+      'utf8'
+    );
+    mkdirSync(join(repo, 'openspec', 'changes', changeId), { recursive: true });
+    writeFileSync(join(repo, 'openspec', 'changes', changeId, 'proposal.md'), '# proposal\n', 'utf8');
+    openSddSession({ cwd: repo, changeId, ttlMinutes: 60 });
+    writePreWriteEvidence(repo, 'feature/prewrite-openspec-bootstrap-disabled');
+    writeMcpAiGateReceipt({
+      repoRoot: repo,
+      stage: 'PRE_WRITE',
+      status: 'ALLOWED',
+      allowed: true,
+    });
+    process.env.PUMUKI_PREWRITE_AUTO_BOOTSTRAP = '0';
+
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await withFakeNpmOpenSpecInstaller(repo, async () =>
+      runLifecycleCli(['sdd', 'validate', '--stage=PRE_WRITE', '--json'], {
+        runPlatformGate: async () => 0,
+      })
+    );
+    assert.equal(code, 1);
+    assert.equal(existsSync(join(repo, 'node_modules', '.bin', 'openspec')), false);
+
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      sdd?: { decision?: { code?: string; allowed?: boolean } };
+      bootstrap?: { enabled?: boolean; attempted?: boolean; status?: string; details?: string };
+      next_action?: { reason?: string; command?: string };
+    };
+    assert.equal(payload.sdd?.decision?.allowed, false);
+    assert.equal(payload.sdd?.decision?.code, 'OPENSPEC_MISSING');
+    assert.equal(payload.bootstrap?.enabled, false);
+    assert.equal(payload.bootstrap?.attempted, false);
+    assert.equal(payload.bootstrap?.status, 'SKIPPED');
+    assert.match(payload.bootstrap?.details ?? '', /PUMUKI_PREWRITE_AUTO_BOOTSTRAP=0/);
+    assert.equal(payload.next_action?.reason, 'OPENSPEC_MISSING');
+    assert.equal(payload.next_action?.command, 'npx --yes --package pumuki@latest pumuki install');
+  } finally {
+    if (typeof previousAutoBootstrap === 'undefined') {
+      delete process.env.PUMUKI_PREWRITE_AUTO_BOOTSTRAP;
+    } else {
+      process.env.PUMUKI_PREWRITE_AUTO_BOOTSTRAP = previousAutoBootstrap;
+    }
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);
     rmSync(repo, { recursive: true, force: true });

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -8,6 +8,7 @@ import { runLifecycleRemove } from './remove';
 import { readLifecycleStatus } from './status';
 import { runLifecycleUninstall } from './uninstall';
 import { runLifecycleUpdate } from './update';
+import { runOpenSpecBootstrap } from './openSpecBootstrap';
 import { runLifecycleAdapterInstall, type AdapterAgent } from './adapter';
 import { createLoopSessionContract, isLoopSessionTransitionAllowed } from './loopSessionContract';
 import {
@@ -796,16 +797,37 @@ const printDoctorReport = (report: LifecycleDoctorReport): void => {
 };
 
 const PRE_WRITE_TELEMETRY_CHAIN = 'pumuki->mcp->ai_gate->ai_evidence';
+const PRE_WRITE_INSTALL_REMEDIATION_COMMAND =
+  'npx --yes --package pumuki@latest pumuki install';
 
 type PreWriteValidationEnvelope = {
   sdd: ReturnType<typeof evaluateSddPolicy>;
   ai_gate: ReturnType<typeof evaluateAiGate>;
   automation: PreWriteAutomationTrace;
+  bootstrap: {
+    enabled: boolean;
+    attempted: boolean;
+    status: 'SKIPPED' | 'OK' | 'FAILED';
+    actions: ReadonlyArray<string>;
+    details?: string;
+  };
+  next_action?: {
+    reason: string;
+    command: string;
+  };
   telemetry: {
     chain: typeof PRE_WRITE_TELEMETRY_CHAIN;
     stage: SddStage;
     mcp_tool: 'ai_gate_check';
   };
+};
+
+type PreWriteOpenSpecBootstrapTrace = {
+  enabled: boolean;
+  attempted: boolean;
+  status: 'SKIPPED' | 'OK' | 'FAILED';
+  actions: string[];
+  details?: string;
 };
 
 type LifecycleCliDependencies = {
@@ -832,6 +854,37 @@ const PRE_WRITE_HINTS_BY_CODE: Readonly<Record<string, string>> = {
   MCP_ENTERPRISE_RECEIPT_STALE: 'Vuelve a ejecutar ai_gate_check para emitir recibo fresco.',
   MCP_ENTERPRISE_RECEIPT_STAGE_MISMATCH: 'Reejecuta ai_gate_check con stage PRE_WRITE.',
   MCP_ENTERPRISE_RECEIPT_REPO_ROOT_MISMATCH: 'Genera el recibo MCP en este mismo repositorio.',
+};
+
+const PRE_WRITE_OPENSPEC_AUTOREMEDIABLE_CODES = new Set<string>([
+  'OPENSPEC_MISSING',
+  'OPENSPEC_VERSION_UNSUPPORTED',
+  'OPENSPEC_PROJECT_MISSING',
+]);
+
+const resolvePreWriteNextAction = (params: {
+  sdd: ReturnType<typeof evaluateSddPolicy>;
+  aiGate: ReturnType<typeof evaluateAiGate> | null;
+}): PreWriteValidationEnvelope['next_action'] | undefined => {
+  if (!params.sdd.decision.allowed && PRE_WRITE_OPENSPEC_AUTOREMEDIABLE_CODES.has(params.sdd.decision.code)) {
+    return {
+      reason: params.sdd.decision.code,
+      command: PRE_WRITE_INSTALL_REMEDIATION_COMMAND,
+    };
+  }
+  if (!params.aiGate || params.aiGate.allowed) {
+    return undefined;
+  }
+  const hasMcpViolation = params.aiGate.violations.some((violation) =>
+    violation.code.startsWith('MCP_ENTERPRISE_RECEIPT_')
+  );
+  if (!hasMcpViolation) {
+    return undefined;
+  }
+  return {
+    reason: 'MCP_ENTERPRISE_RECEIPT',
+    command: 'npx --yes --package pumuki@latest pumuki-pre-write',
+  };
 };
 
 const wrapPreWritePanelLine = (value: string, width: number): string[] => {
@@ -958,7 +1011,9 @@ const resolveAiGateViolationLocation = (code: string) => {
 const buildPreWriteValidationEnvelope = (
   result: ReturnType<typeof evaluateSddPolicy>,
   aiGate: ReturnType<typeof evaluateAiGate>,
-  automation: PreWriteAutomationTrace
+  automation: PreWriteAutomationTrace,
+  bootstrap: PreWriteOpenSpecBootstrapTrace,
+  nextAction: PreWriteValidationEnvelope['next_action']
 ): PreWriteValidationEnvelope => ({
   sdd: result,
   ai_gate: aiGate,
@@ -966,6 +1021,14 @@ const buildPreWriteValidationEnvelope = (
     attempted: automation.attempted,
     actions: [...automation.actions],
   },
+  bootstrap: {
+    enabled: bootstrap.enabled,
+    attempted: bootstrap.attempted,
+    status: bootstrap.status,
+    actions: [...bootstrap.actions],
+    details: bootstrap.details,
+  },
+  next_action: nextAction,
   telemetry: {
     chain: PRE_WRITE_TELEMETRY_CHAIN,
     stage: result.stage,
@@ -1331,9 +1394,46 @@ export const runLifecycleCli = async (
           return 0;
         }
         if (parsed.sddCommand === 'validate') {
-          const result = evaluateSddPolicy({
+          let result = evaluateSddPolicy({
             stage: parsed.sddStage ?? 'PRE_COMMIT',
           });
+          const preWriteAutoBootstrapEnabled = process.env.PUMUKI_PREWRITE_AUTO_BOOTSTRAP !== '0';
+          const preWriteBootstrapTrace: PreWriteOpenSpecBootstrapTrace = {
+            enabled: preWriteAutoBootstrapEnabled,
+            attempted: false,
+            status: 'SKIPPED',
+            actions: [],
+          };
+          if (
+            result.stage === 'PRE_WRITE'
+            && !result.decision.allowed
+            && PRE_WRITE_OPENSPEC_AUTOREMEDIABLE_CODES.has(result.decision.code)
+          ) {
+            if (preWriteAutoBootstrapEnabled) {
+              preWriteBootstrapTrace.attempted = true;
+              try {
+                const bootstrap = runOpenSpecBootstrap({
+                  repoRoot: process.cwd(),
+                });
+                preWriteBootstrapTrace.status = 'OK';
+                preWriteBootstrapTrace.actions = [...bootstrap.actions];
+                if (bootstrap.skippedReason) {
+                  preWriteBootstrapTrace.details = `skipped=${bootstrap.skippedReason}`;
+                }
+              } catch (error) {
+                preWriteBootstrapTrace.status = 'FAILED';
+                preWriteBootstrapTrace.details = error instanceof Error
+                  ? error.message
+                  : 'Unknown OpenSpec bootstrap error';
+              }
+              result = evaluateSddPolicy({
+                stage: parsed.sddStage ?? 'PRE_COMMIT',
+              });
+            } else {
+              preWriteBootstrapTrace.details =
+                'auto bootstrap disabled via PUMUKI_PREWRITE_AUTO_BOOTSTRAP=0';
+            }
+          }
           const shouldEvaluateAiGate = result.stage === 'PRE_WRITE';
           let aiGate = shouldEvaluateAiGate
             ? runEnterpriseAiGateCheck({
@@ -1357,11 +1457,21 @@ export const runLifecycleCli = async (
             automationTrace.attempted = auto.trace.attempted;
             automationTrace.actions = auto.trace.actions;
           }
+          const nextAction = resolvePreWriteNextAction({
+            sdd: result,
+            aiGate,
+          });
           if (parsed.json) {
             writeInfo(
               JSON.stringify(
                 aiGate
-                  ? buildPreWriteValidationEnvelope(result, aiGate, automationTrace)
+                  ? buildPreWriteValidationEnvelope(
+                    result,
+                    aiGate,
+                    automationTrace,
+                    preWriteBootstrapTrace,
+                    nextAction
+                  )
                   : result,
                 null,
                 2
@@ -1382,6 +1492,16 @@ export const runLifecycleCli = async (
                 `[pumuki][sdd] validation: ok=${result.validation.ok ? 'yes' : 'no'} failed=${result.validation.totals.failed} errors=${result.validation.issues.errors}`
               );
             }
+            if (result.stage === 'PRE_WRITE') {
+              writeInfo(
+                `[pumuki][sdd] openspec auto-bootstrap: enabled=${preWriteBootstrapTrace.enabled ? 'yes' : 'no'} attempted=${preWriteBootstrapTrace.attempted ? 'yes' : 'no'} status=${preWriteBootstrapTrace.status} actions=${preWriteBootstrapTrace.actions.join(',') || 'none'}`
+              );
+              if (preWriteBootstrapTrace.details) {
+                writeInfo(
+                  `[pumuki][sdd] openspec auto-bootstrap details: ${preWriteBootstrapTrace.details}`
+                );
+              }
+            }
             if (aiGate) {
               writeInfo(buildPreWriteValidationPanel({
                 sdd: result,
@@ -1399,6 +1519,9 @@ export const runLifecycleCli = async (
                   )
                 );
               }
+            }
+            if (nextAction) {
+              writeInfo(`[pumuki][sdd] next action (${nextAction.reason}): ${nextAction.command}`);
             }
           }
           if (result.stage === 'PRE_WRITE' && aiGate) {


### PR DESCRIPTION
## Summary
- add deterministic PRE_WRITE OpenSpec auto-bootstrap path before AI gate evaluation
- add env switch PUMUKI_PREWRITE_AUTO_BOOTSTRAP=0 to disable auto-bootstrap deterministically
- expose next_action command in PRE_WRITE JSON output when blockers remain
- print deterministic bootstrap diagnostics in non-JSON output
- add integration tests for enabled/disabled auto-bootstrap scenarios

## Validation
- npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts
- npm run -s typecheck

Closes #485