### PR TITLE
feat(sdd): auto-refresh expired sessions in hook policy

### DIFF
--- a/integrations/sdd/__tests__/policy.test.ts
+++ b/integrations/sdd/__tests__/policy.test.ts
@@ -140,16 +140,43 @@ test('evaluateSddPolicy bloquea con SDD_SESSION_MISSING cuando no existe sesión
   });
 });
 
-test('evaluateSddPolicy bloquea con SDD_SESSION_INVALID cuando la sesión está expirada', () => {
-  return withFixtureRepo('pumuki-sdd-session-invalid-', (repoRoot) => {
+test('evaluateSddPolicy auto-refresca sesión expirada en PRE_COMMIT cuando el cambio activo es válido', () => {
+  return withFixtureRepo('pumuki-sdd-session-autorefresh-', (repoRoot) => {
     writeOpenSpecBinary(repoRoot);
     const changeId = createOpenSpecChange(repoRoot);
     openSddSession({ cwd: repoRoot, changeId, ttlMinutes: 30 });
     runGit(repoRoot, ['config', '--local', 'pumuki.sdd.session.expiresAt', '2000-01-01T00:00:00.000Z']);
 
     const result = evaluateSddPolicy({ stage: 'PRE_COMMIT', repoRoot });
-    assert.equal(result.decision.allowed, false);
-    assert.equal(result.decision.code, 'SDD_SESSION_INVALID');
+    assert.equal(result.decision.allowed, true);
+    assert.equal(result.decision.code, 'ALLOWED');
+    assert.equal(result.status.session.valid, true);
+  });
+});
+
+test('evaluateSddPolicy bloquea con SDD_SESSION_INVALID cuando la sesión está expirada', () => {
+  return withFixtureRepo('pumuki-sdd-session-invalid-', (repoRoot) => {
+    const previous = process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION;
+    process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION = '0';
+    writeOpenSpecBinary(repoRoot);
+    const changeId = createOpenSpecChange(repoRoot);
+    openSddSession({ cwd: repoRoot, changeId, ttlMinutes: 30 });
+    runGit(repoRoot, ['config', '--local', 'pumuki.sdd.session.expiresAt', '2000-01-01T00:00:00.000Z']);
+    try {
+      const result = evaluateSddPolicy({ stage: 'PRE_COMMIT', repoRoot });
+      assert.equal(result.decision.allowed, false);
+      assert.equal(result.decision.code, 'SDD_SESSION_INVALID');
+      assert.equal(
+        result.decision.details?.command,
+        'npx --yes --package pumuki@latest pumuki sdd session --refresh --ttl-minutes=90'
+      );
+    } finally {
+      if (typeof previous === 'undefined') {
+        delete process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION;
+      } else {
+        process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION = previous;
+      }
+    }
   });
 });
 

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -7,13 +7,16 @@ import {
   OPENSPEC_VALIDATE_ALL_COMMAND,
   validateOpenSpecChanges,
 } from './openSpecCli';
-import { readSddSession } from './sessionStore';
+import { readSddSession, refreshSddSession } from './sessionStore';
 import type {
   SddDecision,
   SddEvaluateResult,
   SddStage,
   SddStatusPayload,
 } from './types';
+
+const SDD_SESSION_REFRESH_COMMAND =
+  'npx --yes --package pumuki@latest pumuki sdd session --refresh --ttl-minutes=90';
 
 const buildStatus = (repoRoot: string): SddStatusPayload => {
   const openspec = detectOpenSpecInstallation(repoRoot);
@@ -58,7 +61,13 @@ const activeChangeExists = (repoRoot: string, changeId: string): boolean =>
 const activeChangeArchived = (repoRoot: string, changeId: string): boolean =>
   existsSync(resolve(repoRoot, 'openspec', 'changes', 'archive', changeId));
 
-const evaluateSessionRequirements = (status: SddStatusPayload): SddDecision | undefined => {
+const evaluateSessionRequirements = (params: {
+  status: SddStatusPayload;
+  autoRefreshEnabled: boolean;
+  autoRefreshAttempted: boolean;
+  autoRefreshError?: string;
+}): SddDecision | undefined => {
+  const { status } = params;
   if (!status.session.active) {
     return blocked(
       'SDD_SESSION_MISSING',
@@ -66,9 +75,22 @@ const evaluateSessionRequirements = (status: SddStatusPayload): SddDecision | un
     );
   }
   if (!status.session.valid || !status.session.changeId) {
+    const details: Record<string, string | boolean> = {
+      command: SDD_SESSION_REFRESH_COMMAND,
+      autoRefreshEnabled: params.autoRefreshEnabled,
+      autoRefreshAttempted: params.autoRefreshAttempted,
+    };
+    if (params.autoRefreshError) {
+      details.autoRefreshError = params.autoRefreshError;
+    }
+    const message =
+      params.autoRefreshAttempted && params.autoRefreshError
+        ? `SDD session is invalid or expired. Auto-refresh failed (${params.autoRefreshError}). Run \`${SDD_SESSION_REFRESH_COMMAND}\` or reopen it.`
+        : `SDD session is invalid or expired. Run \`${SDD_SESSION_REFRESH_COMMAND}\` or reopen it.`;
     return blocked(
       'SDD_SESSION_INVALID',
-      'SDD session is invalid or expired. Run `pumuki sdd session --refresh` or reopen it.'
+      message,
+      details
     );
   }
   if (activeChangeArchived(status.repoRoot, status.session.changeId)) {
@@ -86,13 +108,45 @@ const evaluateSessionRequirements = (status: SddStatusPayload): SddDecision | un
   return undefined;
 };
 
+const shouldAttemptSessionAutoRefresh = (params: {
+  stage: SddStage;
+  status: SddStatusPayload;
+  autoRefreshEnabled: boolean;
+}): boolean =>
+  params.stage !== 'PRE_WRITE'
+  && params.autoRefreshEnabled
+  && params.status.session.active
+  && !!params.status.session.changeId
+  && !params.status.session.valid;
+
+const trySessionAutoRefresh = (repoRoot: string): {
+  refreshed: boolean;
+  error?: string;
+} => {
+  try {
+    refreshSddSession({
+      cwd: repoRoot,
+      ttlMinutes: 90,
+    });
+    return { refreshed: true };
+  } catch (error) {
+    return {
+      refreshed: false,
+      error: error instanceof Error ? error.message : 'Unknown auto-refresh error',
+    };
+  }
+};
+
 export const evaluateSddPolicy = (params: {
   stage: SddStage;
   repoRoot?: string;
 }): SddEvaluateResult => {
   const repoRoot = params.repoRoot ?? process.cwd();
   const bypassEnabled = process.env.PUMUKI_SDD_BYPASS === '1';
-  const status = buildStatus(repoRoot);
+  const autoRefreshEnabled = process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION !== '0';
+  let status = buildStatus(repoRoot);
+  let autoRefreshAttempted = false;
+  let autoRefreshError: string | undefined;
 
   if (bypassEnabled) {
     return {
@@ -141,7 +195,28 @@ export const evaluateSddPolicy = (params: {
     };
   }
 
-  const sessionDecision = evaluateSessionRequirements(status);
+  if (
+    shouldAttemptSessionAutoRefresh({
+      stage: params.stage,
+      status,
+      autoRefreshEnabled,
+    })
+  ) {
+    autoRefreshAttempted = true;
+    const refreshAttempt = trySessionAutoRefresh(repoRoot);
+    if (refreshAttempt.refreshed) {
+      status = buildStatus(repoRoot);
+    } else {
+      autoRefreshError = refreshAttempt.error;
+    }
+  }
+
+  const sessionDecision = evaluateSessionRequirements({
+    status,
+    autoRefreshEnabled,
+    autoRefreshAttempted,
+    autoRefreshError,
+  });
   if (sessionDecision) {
     return {
       stage: params.stage,


### PR DESCRIPTION
## Summary
- auto-refresh expired active SDD sessions for PRE_COMMIT/PRE_PUSH/CI before hard blocking
- add deterministic remediation command in SDD_SESSION_INVALID details/message
- support opt-out via PUMUKI_SDD_AUTO_REFRESH_SESSION=0
- add policy tests for auto-refresh success and disabled fallback behavior

## Validation
- npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/policy.test.ts integrations/lifecycle/__tests__/cli.test.ts
- npm run -s typecheck

Closes #486