### PR TITLE
fix: avoid false positives in legacy surface package checker

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T18` (ejecutar issue prioritaria `#487` sobre falso positivo de superficie legacy).
+- Task activa (`🚧`): `P12.F1.T19` (merge/cierre de `#487` y sincronización canónica RuralGO tras PR `#510`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T19` (merge/cierre de `#487` y sincronización canónica RuralGO tras PR `#510`).
+- Task activa (`🚧`): `P12.F1.T20` (ejecutar issue `#488` mientras `#487` queda bloqueada por billing lock en CI remota).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -965,9 +965,27 @@ Criterio de salida F5:
   - evidencia:
     - `git commit -m \"docs(validation): mark sdd session refresh issue fixed via #508\"`
     - `git push origin HEAD:feature/rgo-1590-01-ios-physical-signoff`
-- 🚧 `P12.F1.T18` Ejecutar siguiente issue prioritaria del backlog canónico (`#487`, falso positivo de superficie legacy).
+- ✅ `P12.F1.T18` Ejecutar issue prioritaria `#487` (falso positivo de superficie legacy) en Pumuki.
+  - cierre ejecutado:
+    - rama creada: `bugfix/487-legacy-surface-allowlist`.
+    - fix aplicado en `scripts/package-manifest-lib.ts`:
+      - allowlist canónica para superficies runtime legacy oficiales.
+      - bloqueo mantenido para cualquier `legacy/*` no allowlisted.
+    - test de regresión RED/GREEN:
+      - `scripts/__tests__/package-manifest-lib.test.ts` (nuevo caso canónico legacy).
+    - PR abierta: `#510` (pendiente merge).
+    - commit: `1da8c60`.
+  - evidencia:
+    - RED: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts` (falla inicial en caso canónico legacy).
+    - GREEN: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts scripts/__tests__/check-package-manifest.test.ts`
+    - gate: `npm run -s typecheck`
+    - gate: `npm run -s validation:package-manifest`
+    - PR: `gh pr create --base develop --head bugfix/487-legacy-surface-allowlist ...` => `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510`
+- 🚧 `P12.F1.T19` Completar cierre administrativo de `#487` y sincronización canónica RuralGO tras merge.
   - objetivo inmediato:
-    - abrir rama `bugfix/487-legacy-surface-allowlist` y arrancar RED del checker `ci:no-legacy-surface`.
+    - mergear PR `#510` cuando lo autorices.
+    - cerrar issue `#487` con referencia de merge.
+    - actualizar canónico `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` (`REPORTED -> FIXED`).
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -981,11 +981,23 @@ Criterio de salida F5:
     - gate: `npm run -s typecheck`
     - gate: `npm run -s validation:package-manifest`
     - PR: `gh pr create --base develop --head bugfix/487-legacy-surface-allowlist ...` => `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510`
-- 🚧 `P12.F1.T19` Completar cierre administrativo de `#487` y sincronización canónica RuralGO tras merge.
+- ⛔ `P12.F1.T19` Completar cierre administrativo de `#487` y sincronización canónica RuralGO tras merge.
+  - bloqueo actual (externo):
+    - los checks de GitHub Actions no arrancan por bloqueo de facturación del repositorio.
+    - evidencia exacta (annotation check-run `65623298147`):
+      - `The job was not started because your account is locked due to a billing issue.`
+    - impacto: no se puede mergear PR `#510` sin bypassear gates.
+  - estado de implementación:
+    - fix ya listo en PR `#510`.
+    - issue `#487` pendiente de cierre administrativo tras merge.
+  - evidencia registrada:
+    - `gh pr view 510 --json mergeStateStatus,statusCheckRollup`
+    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65623298147/annotations`
+    - comentario de bloqueo en PR: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510#issuecomment-3993566439`
+- 🚧 `P12.F1.T20` Ejecutar issue `#488` (cobertura de guards AST/skills por plataforma) mientras se desbloquea CI de `#487`.
   - objetivo inmediato:
-    - mergear PR `#510` cuando lo autorices.
-    - cerrar issue `#487` con referencia de merge.
-    - actualizar canónico `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` (`REPORTED -> FIXED`).
+    - abrir rama `feature/488-platform-coverage-guards`.
+    - arrancar RED con test que falle para cobertura incompleta iOS/web/backend/android.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/scripts/__tests__/package-manifest-lib.test.ts
+++ b/scripts/__tests__/package-manifest-lib.test.ts
@@ -44,3 +44,15 @@ test('inspectPackageManifestPaths reports forbidden bundle entries', () => {
     '.audit-reports/package-smoke/summary.md',
   ]);
 });
+
+test('inspectPackageManifestPaths permite superficies legacy oficiales canónicas', () => {
+  const filePaths = [
+    ...REQUIRED_PACKAGE_PATHS,
+    'legacy/scripts/hooks-system/infrastructure/cascade-hooks/verify-adapter-hooks-runtime.sh',
+    'legacy/scripts/hooks-system/infrastructure/cascade-hooks/run-hook-with-node.sh',
+    'legacy/scripts/hooks-system/infrastructure/cascade-hooks/collect-runtime-diagnostics.sh',
+  ];
+
+  const report = inspectPackageManifestPaths(filePaths);
+  assert.deepEqual(report.forbiddenMatches, []);
+});

--- a/scripts/package-manifest-lib.ts
+++ b/scripts/package-manifest-lib.ts
@@ -15,8 +15,15 @@ export const REQUIRED_PACKAGE_PATHS = [
   'integrations/evidence/buildEvidence.ts',
 ];
 
+export const CANONICAL_ALLOWED_LEGACY_PATHS = new Set([
+  'legacy/scripts/hooks-system/infrastructure/cascade-hooks/verify-adapter-hooks-runtime.sh',
+  'legacy/scripts/hooks-system/infrastructure/cascade-hooks/run-hook-with-node.sh',
+  'legacy/scripts/hooks-system/infrastructure/cascade-hooks/collect-runtime-diagnostics.sh',
+]);
+
+const LEGACY_ROOT_PATTERN = /^legacy\//;
+
 export const FORBIDDEN_PACKAGE_PATTERNS: RegExp[] = [
-  /^legacy\//,
   /\/__tests__\//,
   /^docs\/validation\/archive\//,
   /^\.audit-reports\//,
@@ -34,9 +41,13 @@ export const inspectPackageManifestPaths = (
   const missingRequired = REQUIRED_PACKAGE_PATHS.filter(
     (requiredPath) => !filePaths.includes(requiredPath)
   );
-  const forbiddenMatches = filePaths.filter((path) =>
-    FORBIDDEN_PACKAGE_PATTERNS.some((pattern) => pattern.test(path))
-  );
+  const forbiddenMatches = filePaths.filter((path) => {
+    if (LEGACY_ROOT_PATTERN.test(path)) {
+      return !CANONICAL_ALLOWED_LEGACY_PATHS.has(path);
+    }
+
+    return FORBIDDEN_PACKAGE_PATTERNS.some((pattern) => pattern.test(path));
+  });
 
   return {
     missingRequired,


### PR DESCRIPTION
## Summary
- allow canonical legacy runtime surfaces in `inspectPackageManifestPaths`
- keep blocking any non-allowlisted `legacy/*` path
- add regression test for canonical legacy surfaces to prevent false positives

## RED -> GREEN evidence
- RED: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts` (failed in `inspectPackageManifestPaths permite superficies legacy oficiales canónicas`)
- GREEN: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts scripts/__tests__/check-package-manifest.test.ts`
- Gate: `npm run -s typecheck`
- Gate: `npm run -s validation:package-manifest`

## Issue
Closes #487
