### PR TITLE
feat: add platform skills coverage guards for detected scopes

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T18` (ejecutar issue prioritaria `#487` sobre falso positivo de superficie legacy).
+- Task activa (`🚧`): `P12.F1.T21` (cierre de `#488` + sync canónico RuralGO tras merge, dependiente de desbloqueo CI remota).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T21` (cierre de `#488` + sync canónico RuralGO tras merge, dependiente de desbloqueo CI remota).
+- Task activa (`🚧`): `P12.F1.T20` (ejecutar issue `#488` mientras `#487` queda bloqueada por billing lock en CI remota).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -965,9 +965,51 @@ Criterio de salida F5:
   - evidencia:
     - `git commit -m \"docs(validation): mark sdd session refresh issue fixed via #508\"`
     - `git push origin HEAD:feature/rgo-1590-01-ios-physical-signoff`
-- 🚧 `P12.F1.T18` Ejecutar siguiente issue prioritaria del backlog canónico (`#487`, falso positivo de superficie legacy).
+- ✅ `P12.F1.T18` Ejecutar issue prioritaria `#487` (falso positivo de superficie legacy) en Pumuki.
+  - cierre ejecutado:
+    - rama: `bugfix/487-legacy-surface-allowlist`.
+    - fix en `scripts/package-manifest-lib.ts`:
+      - allowlist explícita para superficies legacy oficiales de runtime.
+      - bloqueo mantenido para cualquier `legacy/*` no allowlisted.
+    - test de regresión añadido en `scripts/__tests__/package-manifest-lib.test.ts`.
+    - PR: `#510` abierta.
+    - commit: `1da8c60`.
+  - evidencia:
+    - RED: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts` (falla inicial caso canónico legacy).
+    - GREEN: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts scripts/__tests__/check-package-manifest.test.ts`
+    - `npm run -s typecheck`
+    - `npm run -s validation:package-manifest`
+- ⛔ `P12.F1.T19` Completar merge/cierre de `#487` y sincronización canónica RuralGO.
+  - bloqueo actual (externo):
+    - GitHub Actions no inicia jobs por bloqueo de facturación del repositorio.
+    - annotation real (check-run `65623298147`):
+      - `The job was not started because your account is locked due to a billing issue.`
+    - impacto: no merge de `#510` sin bypass de gates (no permitido).
+  - evidencia:
+    - `gh pr view 510 --json mergeStateStatus,statusCheckRollup`
+    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65623298147/annotations`
+    - comentario en PR: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510#issuecomment-3993566439`
+- ✅ `P12.F1.T20` Ejecutar issue prioritaria `#488` (guards de cobertura AST/skills por plataforma).
+  - cierre ejecutado:
+    - rama: `feature/488-platform-coverage-guards`.
+    - fix en `integrations/git/runPlatformGate.ts`:
+      - nuevo guard `governance.skills.platform-coverage.incomplete` para PRE_COMMIT/PRE_PUSH/CI.
+      - exige bundles mínimos por plataforma detectada (iOS triplete, backend, frontend, android).
+      - exige cobertura de reglas skills activas/evaluadas por prefijo `skills.<platform>.`.
+    - tests de regresión:
+      - bloquea cuando iOS detectado no cumple triplete/cobertura.
+      - permite cuando plataformas detectadas cumplen bundles + reglas.
+    - PR: `#511` abierta.
+    - commit: `6b0c6dd`.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts`
+    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/runPlatformGateEvaluation.test.ts`
+    - `npm run -s typecheck`
+- 🚧 `P12.F1.T21` Cerrar administrativamente `#488` y consolidar sync canónico en RuralGO tras merge.
   - objetivo inmediato:
-    - abrir rama `bugfix/487-legacy-surface-allowlist` y arrancar RED del checker `ci:no-legacy-surface`.
+    - monitorizar estado CI remota por billing lock.
+    - mergear `#511` sin bypass cuando CI quede operativa.
+    - actualizar canónico `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` de `REPORTED -> FIXED`.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1010,6 +1010,19 @@ Criterio de salida F5:
     - monitorizar estado CI remota por billing lock.
     - mergear `#511` sin bypass cuando CI quede operativa.
     - actualizar canónico `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` de `REPORTED -> FIXED`.
+  - ejecución actual:
+    - `#510` y `#511` siguen en `mergeStateStatus=UNSTABLE` por fallo transversal de checks remotos.
+    - evidencia de bloqueo repetida (2026-03-03):
+      - PR `#510`: check-run `65623545770` -> `The job was not started because your account is locked due to a billing issue.`
+      - PR `#511`: check-run `65624109075` -> `The job was not started because your account is locked due to a billing issue.`
+    - comentarios de trazabilidad añadidos:
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/511#issuecomment-3993591432`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/488#issuecomment-3993592053`
+  - evidencia:
+    - `gh pr view 510 --json mergeStateStatus,statusCheckRollup`
+    - `gh pr view 511 --json mergeStateStatus,statusCheckRollup`
+    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65623545770/annotations`
+    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65624109075/annotations`
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -967,62 +967,37 @@ Criterio de salida F5:
     - `git push origin HEAD:feature/rgo-1590-01-ios-physical-signoff`
 - ✅ `P12.F1.T18` Ejecutar issue prioritaria `#487` (falso positivo de superficie legacy) en Pumuki.
   - cierre ejecutado:
-    - rama: `bugfix/487-legacy-surface-allowlist`.
-    - fix en `scripts/package-manifest-lib.ts`:
-      - allowlist explícita para superficies legacy oficiales de runtime.
+    - rama creada: `bugfix/487-legacy-surface-allowlist`.
+    - fix aplicado en `scripts/package-manifest-lib.ts`:
+      - allowlist canónica para superficies runtime legacy oficiales.
       - bloqueo mantenido para cualquier `legacy/*` no allowlisted.
-    - test de regresión añadido en `scripts/__tests__/package-manifest-lib.test.ts`.
-    - PR: `#510` abierta.
+    - test de regresión RED/GREEN:
+      - `scripts/__tests__/package-manifest-lib.test.ts` (nuevo caso canónico legacy).
+    - PR abierta: `#510` (pendiente merge).
     - commit: `1da8c60`.
   - evidencia:
-    - RED: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts` (falla inicial caso canónico legacy).
+    - RED: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts` (falla inicial en caso canónico legacy).
     - GREEN: `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts scripts/__tests__/check-package-manifest.test.ts`
-    - `npm run -s typecheck`
-    - `npm run -s validation:package-manifest`
-- ⛔ `P12.F1.T19` Completar merge/cierre de `#487` y sincronización canónica RuralGO.
+    - gate: `npm run -s typecheck`
+    - gate: `npm run -s validation:package-manifest`
+    - PR: `gh pr create --base develop --head bugfix/487-legacy-surface-allowlist ...` => `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510`
+- ⛔ `P12.F1.T19` Completar cierre administrativo de `#487` y sincronización canónica RuralGO tras merge.
   - bloqueo actual (externo):
-    - GitHub Actions no inicia jobs por bloqueo de facturación del repositorio.
-    - annotation real (check-run `65623298147`):
+    - los checks de GitHub Actions no arrancan por bloqueo de facturación del repositorio.
+    - evidencia exacta (annotation check-run `65623298147`):
       - `The job was not started because your account is locked due to a billing issue.`
-    - impacto: no merge de `#510` sin bypass de gates (no permitido).
-  - evidencia:
+    - impacto: no se puede mergear PR `#510` sin bypassear gates.
+  - estado de implementación:
+    - fix ya listo en PR `#510`.
+    - issue `#487` pendiente de cierre administrativo tras merge.
+  - evidencia registrada:
     - `gh pr view 510 --json mergeStateStatus,statusCheckRollup`
     - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65623298147/annotations`
-    - comentario en PR: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510#issuecomment-3993566439`
-- ✅ `P12.F1.T20` Ejecutar issue prioritaria `#488` (guards de cobertura AST/skills por plataforma).
-  - cierre ejecutado:
-    - rama: `feature/488-platform-coverage-guards`.
-    - fix en `integrations/git/runPlatformGate.ts`:
-      - nuevo guard `governance.skills.platform-coverage.incomplete` para PRE_COMMIT/PRE_PUSH/CI.
-      - exige bundles mínimos por plataforma detectada (iOS triplete, backend, frontend, android).
-      - exige cobertura de reglas skills activas/evaluadas por prefijo `skills.<platform>.`.
-    - tests de regresión:
-      - bloquea cuando iOS detectado no cumple triplete/cobertura.
-      - permite cuando plataformas detectadas cumplen bundles + reglas.
-    - PR: `#511` abierta.
-    - commit: `6b0c6dd`.
-  - evidencia:
-    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts`
-    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/runPlatformGateEvaluation.test.ts`
-    - `npm run -s typecheck`
-- 🚧 `P12.F1.T21` Cerrar administrativamente `#488` y consolidar sync canónico en RuralGO tras merge.
+    - comentario de bloqueo en PR: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/510#issuecomment-3993566439`
+- 🚧 `P12.F1.T20` Ejecutar issue `#488` (cobertura de guards AST/skills por plataforma) mientras se desbloquea CI de `#487`.
   - objetivo inmediato:
-    - monitorizar estado CI remota por billing lock.
-    - mergear `#511` sin bypass cuando CI quede operativa.
-    - actualizar canónico `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` de `REPORTED -> FIXED`.
-  - ejecución actual:
-    - `#510` y `#511` siguen en `mergeStateStatus=UNSTABLE` por fallo transversal de checks remotos.
-    - evidencia de bloqueo repetida (2026-03-03):
-      - PR `#510`: check-run `65623545770` -> `The job was not started because your account is locked due to a billing issue.`
-      - PR `#511`: check-run `65624109075` -> `The job was not started because your account is locked due to a billing issue.`
-    - comentarios de trazabilidad añadidos:
-      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/511#issuecomment-3993591432`
-      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/488#issuecomment-3993592053`
-  - evidencia:
-    - `gh pr view 510 --json mergeStateStatus,statusCheckRollup`
-    - `gh pr view 511 --json mergeStateStatus,statusCheckRollup`
-    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65623545770/annotations`
-    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/check-runs/65624109075/annotations`
+    - abrir rama `feature/488-platform-coverage-guards`.
+    - arrancar RED con test que falle para cobertura incompleta iOS/web/backend/android.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -61,7 +61,7 @@ test('runPlatformGate devuelve 1 e imprime findings cuando evaluateGate retorna 
     },
   ];
   const evaluationResult = {
-    detectedPlatforms: { backend: { detected: true, confidence: 'HIGH' as const } },
+    detectedPlatforms: {},
     skillsRuleSet: {
       rules: [],
       activeBundles: [],
@@ -980,7 +980,15 @@ test('runPlatformGate mantiene cobertura completa por stage en modo gate', async
           detectedPlatforms: { backend: { detected: true, confidence: 'HIGH' } },
           skillsRuleSet: {
             rules: [],
-            activeBundles: [],
+            activeBundles: [
+              {
+                name: 'backend-guidelines',
+                version: '1.0.0',
+                source: 'file:docs/codex-skills/windsurf-rules-backend.md',
+                hash: 'a'.repeat(64),
+                rules: [],
+              },
+            ],
             mappedHeuristicRuleIds: new Set<string>(),
             requiresHeuristicFacts: false,
             unsupportedAutoRuleIds: [],
@@ -1040,6 +1048,7 @@ test('runPlatformGate mantiene cobertura completa por stage en modo gate', async
         (finding) =>
           finding.ruleId === 'governance.rules.coverage.incomplete'
           || finding.ruleId === 'governance.skills.detector-mapping.incomplete'
+          || finding.ruleId === 'governance.skills.platform-coverage.incomplete'
       ),
       false
     );
@@ -1149,6 +1158,243 @@ test('runPlatformGate bloquea cuando existen reglas AUTO de skills sin detector 
     'skills.backend.guideline.backend.verificar-que-no-viole-solid-srp-ocp-lsp-isp-dip',
   ]);
   assert.equal(emittedArgs?.rulesCoverage?.counts?.unsupported_auto, 1);
+});
+
+test('runPlatformGate bloquea cuando iOS detectado no tiene triplete de bundles y cobertura de reglas skills', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'repo' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedArgs:
+    | {
+        findings: ReadonlyArray<Finding>;
+        gateOutcome: 'ALLOW' | 'WARN' | 'BLOCK';
+      }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: { ios: { detected: true, confidence: 'HIGH' } },
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [
+            {
+              name: 'ios-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-ios.md',
+              hash: 'a'.repeat(64),
+              rules: [],
+            },
+          ],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: 0,
+          filesScanned: 0,
+          rulesTotal: 0,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 0,
+          projectRules: 0,
+          matchedRules: 0,
+          unmatchedRules: 0,
+          unevaluatedRules: 0,
+          activeRuleIds: [],
+          evaluatedRuleIds: [],
+          matchedRuleIds: [],
+          unmatchedRuleIds: [],
+          unevaluatedRuleIds: [],
+        },
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedArgs = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  assert.equal(emittedArgs?.gateOutcome, 'BLOCK');
+  const coverageFinding = emittedArgs?.findings.find(
+    (finding) => finding.ruleId === 'governance.skills.platform-coverage.incomplete'
+  );
+  assert.ok(coverageFinding);
+  assert.equal(coverageFinding.severity, 'ERROR');
+  assert.match(coverageFinding.message, /ios/i);
+  assert.match(coverageFinding.message, /ios-concurrency-guidelines/i);
+  assert.match(coverageFinding.message, /ios-swiftui-expert-guidelines/i);
+});
+
+test('runPlatformGate permite cuando plataformas detectadas tienen bundles y reglas skills activas/evaluadas', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'repo' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedArgs:
+    | {
+        findings: ReadonlyArray<Finding>;
+        gateOutcome: 'ALLOW' | 'WARN' | 'BLOCK';
+      }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {
+          ios: { detected: true, confidence: 'HIGH' },
+          backend: { detected: true, confidence: 'HIGH' },
+          frontend: { detected: true, confidence: 'HIGH' },
+          android: { detected: true, confidence: 'HIGH' },
+        },
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [
+            {
+              name: 'ios-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-ios.md',
+              hash: 'a'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-concurrency-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swift-concurrency.md',
+              hash: 'b'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-swiftui-expert-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swiftui-expert-skill.md',
+              hash: 'c'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'backend-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-backend.md',
+              hash: 'd'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'frontend-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-frontend.md',
+              hash: 'e'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'android-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-android.md',
+              hash: 'f'.repeat(64),
+              rules: [],
+            },
+          ],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: 0,
+          filesScanned: 0,
+          rulesTotal: 4,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 4,
+          projectRules: 0,
+          matchedRules: 0,
+          unmatchedRules: 4,
+          unevaluatedRules: 0,
+          activeRuleIds: [
+            'skills.ios.no-force-try',
+            'skills.backend.no-empty-catch',
+            'skills.frontend.no-empty-catch',
+            'skills.android.no-runblocking',
+          ],
+          evaluatedRuleIds: [
+            'skills.ios.no-force-try',
+            'skills.backend.no-empty-catch',
+            'skills.frontend.no-empty-catch',
+            'skills.android.no-runblocking',
+          ],
+          matchedRuleIds: [],
+          unmatchedRuleIds: [
+            'skills.ios.no-force-try',
+            'skills.backend.no-empty-catch',
+            'skills.frontend.no-empty-catch',
+            'skills.android.no-runblocking',
+          ],
+          unevaluatedRuleIds: [],
+        },
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedArgs = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  assert.equal(emittedArgs?.gateOutcome, 'ALLOW');
+  assert.equal(
+    emittedArgs?.findings.some(
+      (finding) => finding.ruleId === 'governance.skills.platform-coverage.incomplete'
+    ),
+    false
+  );
 });
 
 test('runPlatformGate bloquea por policy TDD/BDD en cambios nuevos sin contrato de evidencia', async () => {

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -188,6 +188,89 @@ const toSkillsUnsupportedAutoRulesBlockingFinding = (params: {
   };
 };
 
+const PLATFORM_SKILLS_RULE_PREFIXES: Record<
+  'ios' | 'android' | 'backend' | 'frontend',
+  string
+> = {
+  ios: 'skills.ios.',
+  android: 'skills.android.',
+  backend: 'skills.backend.',
+  frontend: 'skills.frontend.',
+};
+
+const PLATFORM_REQUIRED_SKILLS_BUNDLES: Record<
+  'ios' | 'android' | 'backend' | 'frontend',
+  ReadonlyArray<string>
+> = {
+  ios: [
+    'ios-guidelines',
+    'ios-concurrency-guidelines',
+    'ios-swiftui-expert-guidelines',
+  ],
+  android: ['android-guidelines'],
+  backend: ['backend-guidelines'],
+  frontend: ['frontend-guidelines'],
+};
+
+const toPlatformSkillsCoverageBlockingFinding = (params: {
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  detectedPlatforms: DetectedPlatforms;
+  activeBundles: ReadonlyArray<SkillsRuleSetLoadResult['activeBundles'][number]>;
+  activeRuleIds: ReadonlyArray<string>;
+  evaluatedRuleIds: ReadonlyArray<string>;
+}): Finding | undefined => {
+  const detectedPlatformKeys = (
+    ['ios', 'android', 'backend', 'frontend'] as const
+  ).filter((platform) => params.detectedPlatforms[platform]?.detected === true);
+
+  if (detectedPlatformKeys.length === 0) {
+    return undefined;
+  }
+
+  const activeBundleNames = new Set(params.activeBundles.map((bundle) => bundle.name));
+  const gaps: string[] = [];
+
+  for (const platform of detectedPlatformKeys) {
+    const requiredBundles = PLATFORM_REQUIRED_SKILLS_BUNDLES[platform];
+    const missingBundles = requiredBundles.filter((bundleName) => !activeBundleNames.has(bundleName));
+    const rulePrefix = PLATFORM_SKILLS_RULE_PREFIXES[platform];
+    const hasActiveRules = params.activeRuleIds.some((ruleId) => ruleId.startsWith(rulePrefix));
+    const hasEvaluatedRules = params.evaluatedRuleIds.some((ruleId) => ruleId.startsWith(rulePrefix));
+
+    if (missingBundles.length === 0 && hasActiveRules && hasEvaluatedRules) {
+      continue;
+    }
+
+    const reasons: string[] = [];
+    if (missingBundles.length > 0) {
+      reasons.push(`missing_bundles=[${missingBundles.join(', ')}]`);
+    }
+    if (!hasActiveRules) {
+      reasons.push(`active_rules_prefix=${rulePrefix} missing`);
+    }
+    if (!hasEvaluatedRules) {
+      reasons.push(`evaluated_rules_prefix=${rulePrefix} missing`);
+    }
+    gaps.push(`${platform}{${reasons.join('; ')}}`);
+  }
+
+  if (gaps.length === 0) {
+    return undefined;
+  }
+
+  return {
+    ruleId: 'governance.skills.platform-coverage.incomplete',
+    severity: 'ERROR',
+    code: 'SKILLS_PLATFORM_COVERAGE_INCOMPLETE_HIGH',
+    message:
+      `Platform skills coverage incomplete at ${params.stage}: ${gaps.join(' | ')}. ` +
+      'Activate required bundles and ensure platform skill rules are active/evaluated.',
+    filePath: '.ai_evidence.json',
+    matchedBy: 'SkillsPlatformCoverageGuard',
+    source: 'skills-platform-coverage',
+  };
+};
+
 export async function runPlatformGate(params: {
   policy: GatePolicy;
   auditMode?: 'gate' | 'engine';
@@ -307,6 +390,18 @@ export async function runPlatformGate(params: {
         unsupportedAutoRuleIds: skillsRuleSet.unsupportedAutoRuleIds ?? [],
       })
       : undefined;
+  const platformSkillsCoverageFinding =
+    params.policy.stage === 'PRE_COMMIT' ||
+    params.policy.stage === 'PRE_PUSH' ||
+    params.policy.stage === 'CI'
+      ? toPlatformSkillsCoverageBlockingFinding({
+          stage: params.policy.stage,
+          detectedPlatforms,
+          activeBundles: skillsRuleSet.activeBundles,
+          activeRuleIds: coverage?.activeRuleIds ?? [],
+          evaluatedRuleIds: coverage?.evaluatedRuleIds ?? [],
+        })
+      : undefined;
   const rulesCoverage = coverage
     ? {
       stage: params.policy.stage,
@@ -352,13 +447,18 @@ export async function runPlatformGate(params: {
     ? [
       sddBlockingFinding,
       ...(unsupportedSkillsMappingFinding ? [unsupportedSkillsMappingFinding] : []),
+      ...(platformSkillsCoverageFinding ? [platformSkillsCoverageFinding] : []),
       ...(coverageBlockingFinding ? [coverageBlockingFinding] : []),
       ...tddBddEvaluation.findings,
       ...findings,
     ]
-    : unsupportedSkillsMappingFinding || coverageBlockingFinding || tddBddEvaluation.findings.length > 0
+    : unsupportedSkillsMappingFinding
+      || platformSkillsCoverageFinding
+      || coverageBlockingFinding
+      || tddBddEvaluation.findings.length > 0
       ? [
         ...(unsupportedSkillsMappingFinding ? [unsupportedSkillsMappingFinding] : []),
+        ...(platformSkillsCoverageFinding ? [platformSkillsCoverageFinding] : []),
         ...(coverageBlockingFinding ? [coverageBlockingFinding] : []),
         ...tddBddEvaluation.findings,
         ...findings,
@@ -368,6 +468,7 @@ export async function runPlatformGate(params: {
   const gateOutcome =
     sddBlockingFinding ||
     unsupportedSkillsMappingFinding ||
+    platformSkillsCoverageFinding ||
     coverageBlockingFinding ||
     hasTddBddBlockingFinding
       ? 'BLOCK'


### PR DESCRIPTION
## Summary
- add platform skills coverage guard in `runPlatformGate` for PRE_COMMIT/PRE_PUSH/CI
- enforce required bundle coverage per detected platform (iOS triplet, backend, frontend, android)
- enforce active/evaluated skill rule coverage per detected platform prefix (`skills.<platform>.`)
- add regression tests for block/allow paths

## RED -> GREEN evidence
- RED: `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts` (failed due missing expectations after new guard)
- GREEN: `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts`
- GREEN: `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/runPlatformGateEvaluation.test.ts`
- Gate: `npm run -s typecheck`

## Issue
Closes #488
