### PR TITLE
feat(lifecycle): detect remote CI blockers in doctor/status

### DIFF
--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -223,6 +223,20 @@ test('parseLifecycleCliArgs interpreta comandos y flags soportados', () => {
     updateSpec: undefined,
     json: false,
   });
+  assert.deepEqual(parseLifecycleCliArgs(['doctor', '--remote-checks']), {
+    command: 'doctor',
+    purgeArtifacts: false,
+    updateSpec: undefined,
+    json: false,
+    remoteChecks: true,
+  });
+  assert.deepEqual(parseLifecycleCliArgs(['status', '--json', '--remote-checks']), {
+    command: 'status',
+    purgeArtifacts: false,
+    updateSpec: undefined,
+    json: true,
+    remoteChecks: true,
+  });
 });
 
 test('parseLifecycleCliArgs soporta subcomandos SDD', () => {
@@ -399,11 +413,118 @@ test('parseLifecycleCliArgs rechaza help implícito y flags no soportados', () =
     () => parseLifecycleCliArgs(['install', '--bad-flag']),
     /Unsupported argument/i
   );
+  assert.throws(
+    () => parseLifecycleCliArgs(['install', '--remote-checks']),
+    /only supported with "pumuki doctor" or "pumuki status"/i
+  );
 });
 
 test('runLifecycleCli retorna 1 ante argumentos inválidos', async () => {
   const code = await withSilentConsole(() => runLifecycleCli(['--bad']));
   assert.equal(code, 1);
+});
+
+test('runLifecycleCli status --json --remote-checks añade diagnóstico remoto en payload', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  try {
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli(['status', '--json', '--remote-checks'], {
+      collectRemoteCiDiagnostics: () => ({
+        enabled: true,
+        provider: 'github',
+        status: 'blocked',
+        repoRoot: repo,
+        checkedAt: '2026-03-03T12:00:00.000Z',
+        branch: 'feature/remote-ci',
+        pr: {
+          number: 512,
+          url: 'https://github.com/org/repo/pull/512',
+          headRefName: 'feature/remote-ci',
+        },
+        checks: {
+          total: 2,
+          failing: 2,
+        },
+        blockers: [
+          {
+            code: 'REMOTE_CI_BILLING_LOCK',
+            severity: 'error',
+            message: 'billing lock',
+            remediation: 'unlock billing',
+            affectedChecks: ['Type Check'],
+            evidence: ['Type Check: billing issue'],
+          },
+        ],
+      }),
+    });
+    assert.equal(code, 0);
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      remoteCiDiagnostics?: { status?: string; blockers?: Array<{ code?: string }> };
+    };
+    assert.equal(payload.remoteCiDiagnostics?.status, 'blocked');
+    assert.equal(payload.remoteCiDiagnostics?.blockers?.[0]?.code, 'REMOTE_CI_BILLING_LOCK');
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli doctor --remote-checks imprime resumen de bloqueadores remotos', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  try {
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli(['doctor', '--remote-checks'], {
+      collectRemoteCiDiagnostics: () => ({
+        enabled: true,
+        provider: 'github',
+        status: 'blocked',
+        repoRoot: repo,
+        checkedAt: '2026-03-03T12:00:00.000Z',
+        checks: {
+          total: 1,
+          failing: 1,
+        },
+        blockers: [
+          {
+            code: 'REMOTE_CI_PROVIDER_QUOTA',
+            severity: 'error',
+            message: 'provider quota',
+            remediation: 'increase quota',
+            affectedChecks: ['security/snyk'],
+            evidence: ['security/snyk: quota reached'],
+          },
+        ],
+      }),
+    });
+    assert.equal(code, 0);
+    const output = printed.join('\n');
+    assert.match(output, /\[pumuki\]\[remote-ci\] status=BLOCKED/i);
+    assert.match(output, /REMOTE_CI_PROVIDER_QUOTA/i);
+    assert.match(output, /remediation: increase quota/i);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
 });
 
 test('runLifecycleCli sdd validate PRE_WRITE autocura recibo MCP faltante y permite continuar', async () => {

--- a/integrations/lifecycle/__tests__/remoteCiDiagnostics.test.ts
+++ b/integrations/lifecycle/__tests__/remoteCiDiagnostics.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  collectRemoteCiDiagnostics,
+  detectRemoteCiBlockers,
+  type RunRemoteCiCommand,
+} from '../remoteCiDiagnostics';
+
+test('detectRemoteCiBlockers detecta bloqueo por billing lock en checks fallidos', () => {
+  const blockers = detectRemoteCiBlockers([
+    {
+      name: 'Type Check',
+      state: 'FAILURE',
+      bucket: 'fail',
+      description:
+        'The job was not started because your account is locked due to a billing issue.',
+    },
+  ]);
+
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0]?.code, 'REMOTE_CI_BILLING_LOCK');
+  assert.equal(blockers[0]?.affectedChecks.includes('Type Check'), true);
+});
+
+test('detectRemoteCiBlockers detecta quota de proveedor y deduplica checks repetidos', () => {
+  const blockers = detectRemoteCiBlockers([
+    {
+      name: 'security/snyk (swiftenprofundidad)',
+      state: 'ERROR',
+      bucket: 'fail',
+      description: 'You have used your limit of private tests',
+    },
+    {
+      name: 'security/snyk (swiftenprofundidad)',
+      state: 'ERROR',
+      bucket: 'fail',
+      description: 'You have used your limit of private tests',
+    },
+  ]);
+
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0]?.code, 'REMOTE_CI_PROVIDER_QUOTA');
+  assert.equal(blockers[0]?.affectedChecks.length, 1);
+});
+
+test('detectRemoteCiBlockers ignora checks exitosos aunque contengan texto parecido', () => {
+  const blockers = detectRemoteCiBlockers([
+    {
+      name: 'lint',
+      state: 'SUCCESS',
+      bucket: 'pass',
+      description: 'billing issue resolved',
+    },
+  ]);
+
+  assert.deepEqual(blockers, []);
+});
+
+test('collectRemoteCiDiagnostics devuelve skipped cuando no hay PR abierta para la rama', () => {
+  const runCommand: RunRemoteCiCommand = ({ command, args }) => {
+    if (command === 'gh' && args[0] === '--version') {
+      return {
+        exitCode: 0,
+        stdout: 'gh version 2.80.0',
+        stderr: '',
+      };
+    }
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'no pull requests found for branch "feature/no-pr"',
+      };
+    }
+    if (command === 'git') {
+      return {
+        exitCode: 0,
+        stdout: 'feature/no-pr\n',
+        stderr: '',
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'unexpected command',
+    };
+  };
+
+  const diagnostics = collectRemoteCiDiagnostics({
+    repoRoot: '/tmp/repo',
+    runCommand,
+    now: () => new Date('2026-03-03T12:00:00.000Z'),
+  });
+
+  assert.equal(diagnostics.status, 'skipped');
+  assert.equal(diagnostics.reason, 'no_open_pr_for_branch');
+  assert.equal(diagnostics.branch, 'feature/no-pr');
+});
+
+test('collectRemoteCiDiagnostics clasifica blocked cuando detecta billing lock y quota', () => {
+  const runCommand: RunRemoteCiCommand = ({ command, args }) => {
+    if (command === 'git') {
+      return {
+        exitCode: 0,
+        stdout: 'feature/ci-diagnostics\n',
+        stderr: '',
+      };
+    }
+    if (command === 'gh' && args[0] === '--version') {
+      return {
+        exitCode: 0,
+        stdout: 'gh version 2.80.0',
+        stderr: '',
+      };
+    }
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          number: 512,
+          url: 'https://github.com/org/repo/pull/512',
+          headRefName: 'feature/ci-diagnostics',
+        }),
+        stderr: '',
+      };
+    }
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'checks') {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([
+          {
+            name: 'Type Check',
+            state: 'FAILURE',
+            bucket: 'fail',
+            description:
+              'The job was not started because your account is locked due to a billing issue.',
+          },
+          {
+            name: 'security/snyk (swiftenprofundidad)',
+            state: 'ERROR',
+            bucket: 'fail',
+            description: 'You have used your limit of private tests',
+          },
+        ]),
+        stderr: '',
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'unexpected command',
+    };
+  };
+
+  const diagnostics = collectRemoteCiDiagnostics({
+    repoRoot: '/tmp/repo',
+    runCommand,
+    now: () => new Date('2026-03-03T12:00:00.000Z'),
+  });
+
+  assert.equal(diagnostics.status, 'blocked');
+  assert.equal(diagnostics.pr?.number, 512);
+  assert.equal(diagnostics.checks.total, 2);
+  assert.equal(diagnostics.checks.failing, 2);
+  assert.deepEqual(
+    diagnostics.blockers.map((blocker) => blocker.code).sort((left, right) => left.localeCompare(right)),
+    ['REMOTE_CI_BILLING_LOCK', 'REMOTE_CI_PROVIDER_QUOTA']
+  );
+});

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -41,6 +41,10 @@ import {
   readHotspotsSaasIngestionAuditEvents,
   writeHotspotsSaasIngestionMetrics,
 } from './saasIngestionMetrics';
+import {
+  collectRemoteCiDiagnostics,
+  type RemoteCiDiagnostics,
+} from './remoteCiDiagnostics';
 
 type LifecycleCommand =
   | 'install'
@@ -66,6 +70,7 @@ type ParsedArgs = {
   purgeArtifacts: boolean;
   updateSpec?: string;
   json: boolean;
+  remoteChecks?: boolean;
   sddCommand?: SddCommand;
   loopCommand?: LoopCommand;
   loopSessionId?: string;
@@ -94,8 +99,8 @@ Pumuki lifecycle commands:
   pumuki uninstall [--purge-artifacts]
   pumuki remove
   pumuki update [--latest|--spec=<package-spec>]
-  pumuki doctor
-  pumuki status
+  pumuki doctor [--remote-checks]
+  pumuki status [--json] [--remote-checks]
   pumuki loop run --objective=<text> [--max-attempts=<n>] [--json]
   pumuki loop status --session=<session-id> [--json]
   pumuki loop stop --session=<session-id> [--json]
@@ -397,6 +402,7 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   let purgeArtifacts = false;
   let updateSpec: ParsedArgs['updateSpec'];
   let json = false;
+  let remoteChecks = false;
   let sddCommand: ParsedArgs['sddCommand'];
   let loopCommand: ParsedArgs['loopCommand'];
   let loopSessionId: ParsedArgs['loopSessionId'];
@@ -747,6 +753,10 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
       json = true;
       continue;
     }
+    if (arg === '--remote-checks') {
+      remoteChecks = true;
+      continue;
+    }
     if (arg === '--purge-artifacts') {
       purgeArtifacts = true;
       continue;
@@ -763,15 +773,43 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
     throw new Error(`Unsupported argument "${arg}".\n\n${HELP_TEXT}`);
   }
 
+  if (remoteChecks && commandRaw !== 'doctor' && commandRaw !== 'status') {
+    throw new Error(`--remote-checks is only supported with "pumuki doctor" or "pumuki status".\n\n${HELP_TEXT}`);
+  }
+
   return {
     command: commandRaw,
     purgeArtifacts,
     updateSpec,
     json,
+    ...(remoteChecks ? { remoteChecks: true } : {}),
   };
 };
 
-const printDoctorReport = (report: LifecycleDoctorReport): void => {
+const printRemoteCiDiagnostics = (diagnostics: RemoteCiDiagnostics): void => {
+  writeInfo(
+    `[pumuki][remote-ci] status=${diagnostics.status.toUpperCase()} checks=${diagnostics.checks.total} failing=${diagnostics.checks.failing}`
+  );
+  if (diagnostics.pr) {
+    writeInfo(
+      `[pumuki][remote-ci] pr=#${diagnostics.pr.number} branch=${diagnostics.pr.headRefName} url=${diagnostics.pr.url}`
+    );
+  }
+  if (diagnostics.reason) {
+    writeInfo(`[pumuki][remote-ci] reason=${diagnostics.reason}`);
+  }
+  for (const blocker of diagnostics.blockers) {
+    writeInfo(
+      `[pumuki][remote-ci] ${blocker.severity.toUpperCase()} ${blocker.code}: ${blocker.message}`
+    );
+    writeInfo(`[pumuki][remote-ci] remediation: ${blocker.remediation}`);
+  }
+};
+
+const printDoctorReport = (
+  report: LifecycleDoctorReport,
+  remoteCiDiagnostics?: RemoteCiDiagnostics
+): void => {
   writeInfo(`[pumuki] repo: ${report.repoRoot}`);
   writeInfo(`[pumuki] package version: ${report.packageVersion}`);
   writeInfo(
@@ -786,14 +824,17 @@ const printDoctorReport = (report: LifecycleDoctorReport): void => {
 
   if (report.issues.length === 0) {
     writeInfo('[pumuki] doctor verdict: PASS');
-    return;
+  } else {
+    for (const issue of report.issues) {
+      writeInfo(`[pumuki] ${issue.severity.toUpperCase()}: ${issue.message}`);
+    }
+    const hasBlocking = report.issues.some((issue) => issue.severity === 'error');
+    writeInfo(`[pumuki] doctor verdict: ${hasBlocking ? 'BLOCKED' : 'WARN'}`);
   }
 
-  for (const issue of report.issues) {
-    writeInfo(`[pumuki] ${issue.severity.toUpperCase()}: ${issue.message}`);
+  if (remoteCiDiagnostics) {
+    printRemoteCiDiagnostics(remoteCiDiagnostics);
   }
-  const hasBlocking = report.issues.some((issue) => issue.severity === 'error');
-  writeInfo(`[pumuki] doctor verdict: ${hasBlocking ? 'BLOCKED' : 'WARN'}`);
 };
 
 const PRE_WRITE_TELEMETRY_CHAIN = 'pumuki->mcp->ai_gate->ai_evidence';
@@ -833,11 +874,13 @@ type PreWriteOpenSpecBootstrapTrace = {
 type LifecycleCliDependencies = {
   emitAuditSummaryNotificationFromAiGate: typeof emitAuditSummaryNotificationFromAiGate;
   runPlatformGate: typeof runPlatformGate;
+  collectRemoteCiDiagnostics: typeof collectRemoteCiDiagnostics;
 };
 
 const defaultLifecycleCliDependencies: LifecycleCliDependencies = {
   emitAuditSummaryNotificationFromAiGate,
   runPlatformGate,
+  collectRemoteCiDiagnostics,
 };
 
 const PRE_WRITE_HINTS_BY_CODE: Readonly<Record<string, string>> = {
@@ -1124,13 +1167,34 @@ export const runLifecycleCli = async (
       }
       case 'doctor': {
         const report = runLifecycleDoctor();
-        printDoctorReport(report);
+        const remoteCiDiagnostics = parsed.remoteChecks
+          ? activeDependencies.collectRemoteCiDiagnostics({
+              repoRoot: report.repoRoot,
+            })
+          : undefined;
+        printDoctorReport(report, remoteCiDiagnostics);
         return report.issues.some((issue) => issue.severity === 'error') ? 1 : 0;
       }
       case 'status': {
         const status = readLifecycleStatus();
+        const remoteCiDiagnostics = parsed.remoteChecks
+          ? activeDependencies.collectRemoteCiDiagnostics({
+              repoRoot: status.repoRoot,
+            })
+          : undefined;
         if (parsed.json) {
-          writeInfo(JSON.stringify(status, null, 2));
+          writeInfo(
+            JSON.stringify(
+              remoteCiDiagnostics
+                ? {
+                    ...status,
+                    remoteCiDiagnostics,
+                  }
+                : status,
+              null,
+              2
+            )
+          );
         } else {
           writeInfo(`[pumuki] repo: ${status.repoRoot}`);
           writeInfo(`[pumuki] package version: ${status.packageVersion}`);
@@ -1142,6 +1206,9 @@ export const runLifecycleCli = async (
           writeInfo(
             `[pumuki] tracked node_modules paths: ${status.trackedNodeModulesCount}`
           );
+          if (remoteCiDiagnostics) {
+            printRemoteCiDiagnostics(remoteCiDiagnostics);
+          }
         }
         return 0;
       }

--- a/integrations/lifecycle/remoteCiDiagnostics.ts
+++ b/integrations/lifecycle/remoteCiDiagnostics.ts
@@ -1,0 +1,382 @@
+import { spawnSync } from 'node:child_process';
+
+export type RemoteCiCheckState = 'PENDING' | 'SUCCESS' | 'FAILURE' | 'ERROR' | 'SKIPPING' | string;
+
+export type RemoteCiCheck = {
+  name: string;
+  state: RemoteCiCheckState;
+  bucket?: string;
+  link?: string;
+  description?: string;
+};
+
+export type RemoteCiBlockerCode = 'REMOTE_CI_BILLING_LOCK' | 'REMOTE_CI_PROVIDER_QUOTA';
+
+export type RemoteCiBlocker = {
+  code: RemoteCiBlockerCode;
+  severity: 'error';
+  message: string;
+  remediation: string;
+  affectedChecks: ReadonlyArray<string>;
+  evidence: ReadonlyArray<string>;
+};
+
+export type RemoteCiDiagnosticsStatus = 'healthy' | 'blocked' | 'skipped' | 'degraded';
+
+export type RemoteCiDiagnostics = {
+  enabled: boolean;
+  provider: 'github';
+  status: RemoteCiDiagnosticsStatus;
+  repoRoot: string;
+  checkedAt: string;
+  branch?: string;
+  pr?: {
+    number: number;
+    url: string;
+    headRefName: string;
+  };
+  checks: {
+    total: number;
+    failing: number;
+  };
+  blockers: ReadonlyArray<RemoteCiBlocker>;
+  reason?: string;
+};
+
+export type RemoteCiCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type RunRemoteCiCommand = (params: {
+  cwd: string;
+  command: string;
+  args: ReadonlyArray<string>;
+}) => RemoteCiCommandResult;
+
+const BILLING_SIGNATURES: ReadonlyArray<RegExp> = [
+  /account is locked due to a billing issue/i,
+  /locked due to a billing issue/i,
+  /billing issue/i,
+];
+
+const QUOTA_SIGNATURES: ReadonlyArray<RegExp> = [
+  /used your limit of private tests/i,
+  /quota/i,
+  /out of credits/i,
+  /rate limit/i,
+  /payment required/i,
+  /credits exhausted/i,
+  /exceeded.*(quota|limit)/i,
+];
+
+const normalizeEvidence = (value: string): string => value.trim().replace(/\s+/g, ' ');
+
+const isFailingCheck = (check: RemoteCiCheck): boolean => {
+  const normalizedState = String(check.state ?? '').toUpperCase();
+  const normalizedBucket = String(check.bucket ?? '').toLowerCase();
+  if (normalizedBucket === 'fail') {
+    return true;
+  }
+  return normalizedState === 'FAILURE' || normalizedState === 'ERROR' || normalizedState === 'TIMED_OUT';
+};
+
+type BlockerAccumulator = {
+  checks: Set<string>;
+  evidence: Set<string>;
+};
+
+const appendBlockerSignal = (params: {
+  accumulator: Map<RemoteCiBlockerCode, BlockerAccumulator>;
+  code: RemoteCiBlockerCode;
+  checkName: string;
+  evidence: string;
+}): void => {
+  const current = params.accumulator.get(params.code) ?? {
+    checks: new Set<string>(),
+    evidence: new Set<string>(),
+  };
+  current.checks.add(params.checkName);
+  current.evidence.add(normalizeEvidence(params.evidence));
+  params.accumulator.set(params.code, current);
+};
+
+export const detectRemoteCiBlockers = (
+  checks: ReadonlyArray<RemoteCiCheck>
+): ReadonlyArray<RemoteCiBlocker> => {
+  const failingChecks = checks.filter(isFailingCheck);
+  const blockers = new Map<RemoteCiBlockerCode, BlockerAccumulator>();
+
+  for (const check of failingChecks) {
+    const checkName = check.name.trim().length > 0 ? check.name.trim() : 'unnamed-check';
+    const description = check.description ?? '';
+    const searchable = `${checkName}\n${description}\n${check.state ?? ''}\n${check.bucket ?? ''}`;
+
+    for (const signature of BILLING_SIGNATURES) {
+      if (!signature.test(searchable)) {
+        continue;
+      }
+      appendBlockerSignal({
+        accumulator: blockers,
+        code: 'REMOTE_CI_BILLING_LOCK',
+        checkName,
+        evidence: `${checkName}: ${description || 'missing description'}`,
+      });
+    }
+
+    for (const signature of QUOTA_SIGNATURES) {
+      if (!signature.test(searchable)) {
+        continue;
+      }
+      appendBlockerSignal({
+        accumulator: blockers,
+        code: 'REMOTE_CI_PROVIDER_QUOTA',
+        checkName,
+        evidence: `${checkName}: ${description || 'missing description'}`,
+      });
+    }
+  }
+
+  const rendered: RemoteCiBlocker[] = [];
+
+  if (blockers.has('REMOTE_CI_BILLING_LOCK')) {
+    const payload = blockers.get('REMOTE_CI_BILLING_LOCK');
+    rendered.push({
+      code: 'REMOTE_CI_BILLING_LOCK',
+      severity: 'error',
+      message: 'Remote CI blocked by billing/account lock before running real jobs.',
+      remediation:
+        'Resolve billing lock at GitHub account/organization level and rerun checks.',
+      affectedChecks: payload ? [...payload.checks].sort((left, right) => left.localeCompare(right)) : [],
+      evidence: payload ? [...payload.evidence].sort((left, right) => left.localeCompare(right)) : [],
+    });
+  }
+
+  if (blockers.has('REMOTE_CI_PROVIDER_QUOTA')) {
+    const payload = blockers.get('REMOTE_CI_PROVIDER_QUOTA');
+    rendered.push({
+      code: 'REMOTE_CI_PROVIDER_QUOTA',
+      severity: 'error',
+      message: 'Remote CI blocked by external provider quota/credits limit.',
+      remediation:
+        'Restore provider quota/credits (for example Snyk private checks) and rerun checks.',
+      affectedChecks: payload ? [...payload.checks].sort((left, right) => left.localeCompare(right)) : [],
+      evidence: payload ? [...payload.evidence].sort((left, right) => left.localeCompare(right)) : [],
+    });
+  }
+
+  return rendered;
+};
+
+const parseChecksPayload = (raw: string): RemoteCiCheck[] => {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Invalid gh pr checks payload: expected array.');
+  }
+  return parsed
+    .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object')
+    .map((entry) => ({
+      name: String(entry.name ?? ''),
+      state: String(entry.state ?? ''),
+      bucket: typeof entry.bucket === 'string' ? entry.bucket : undefined,
+      link: typeof entry.link === 'string' ? entry.link : undefined,
+      description: typeof entry.description === 'string' ? entry.description : undefined,
+    }));
+};
+
+type RemoteCiPrPayload = {
+  number: number;
+  url: string;
+  headRefName: string;
+};
+
+const parsePrPayload = (raw: string): RemoteCiPrPayload => {
+  const parsed = JSON.parse(raw) as {
+    number?: unknown;
+    url?: unknown;
+    headRefName?: unknown;
+  };
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof parsed.number !== 'number' ||
+    typeof parsed.url !== 'string' ||
+    typeof parsed.headRefName !== 'string'
+  ) {
+    throw new Error('Invalid gh pr view payload.');
+  }
+  return {
+    number: parsed.number,
+    url: parsed.url,
+    headRefName: parsed.headRefName,
+  };
+};
+
+const defaultRunRemoteCiCommand: RunRemoteCiCommand = (params) => {
+  const result = spawnSync(params.command, [...params.args], {
+    cwd: params.cwd,
+    encoding: 'utf8',
+  });
+  return {
+    exitCode: typeof result.status === 'number' ? result.status : 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+};
+
+const readCurrentBranch = (params: {
+  repoRoot: string;
+  runCommand: RunRemoteCiCommand;
+}): string | undefined => {
+  const response = params.runCommand({
+    cwd: params.repoRoot,
+    command: 'git',
+    args: ['rev-parse', '--abbrev-ref', 'HEAD'],
+  });
+  if (response.exitCode !== 0) {
+    return undefined;
+  }
+  const branch = response.stdout.trim();
+  return branch.length === 0 ? undefined : branch;
+};
+
+export const collectRemoteCiDiagnostics = (params: {
+  repoRoot: string;
+  runCommand?: RunRemoteCiCommand;
+  now?: () => Date;
+}): RemoteCiDiagnostics => {
+  const runCommand = params.runCommand ?? defaultRunRemoteCiCommand;
+  const now = params.now ?? (() => new Date());
+  const base: Omit<RemoteCiDiagnostics, 'status' | 'checks' | 'blockers'> = {
+    enabled: true,
+    provider: 'github',
+    repoRoot: params.repoRoot,
+    checkedAt: now().toISOString(),
+    branch: readCurrentBranch({
+      repoRoot: params.repoRoot,
+      runCommand,
+    }),
+  };
+
+  const ghVersion = runCommand({
+    cwd: params.repoRoot,
+    command: 'gh',
+    args: ['--version'],
+  });
+  if (ghVersion.exitCode !== 0) {
+    return {
+      ...base,
+      status: 'skipped',
+      checks: {
+        total: 0,
+        failing: 0,
+      },
+      blockers: [],
+      reason: 'gh_unavailable',
+    };
+  }
+
+  const prResponse = runCommand({
+    cwd: params.repoRoot,
+    command: 'gh',
+    args: ['pr', 'view', '--json', 'number,url,headRefName'],
+  });
+  if (prResponse.exitCode !== 0) {
+    const merged = `${prResponse.stdout}\n${prResponse.stderr}`.toLowerCase();
+    if (merged.includes('no pull requests found')) {
+      return {
+        ...base,
+        status: 'skipped',
+        checks: {
+          total: 0,
+          failing: 0,
+        },
+        blockers: [],
+        reason: 'no_open_pr_for_branch',
+      };
+    }
+    return {
+      ...base,
+      status: 'degraded',
+      checks: {
+        total: 0,
+        failing: 0,
+      },
+      blockers: [],
+      reason: 'pr_lookup_failed',
+    };
+  }
+
+  let pr: RemoteCiDiagnostics['pr'];
+  try {
+    pr = parsePrPayload(prResponse.stdout);
+  } catch {
+    return {
+      ...base,
+      status: 'degraded',
+      checks: {
+        total: 0,
+        failing: 0,
+      },
+      blockers: [],
+      reason: 'pr_payload_invalid',
+    };
+  }
+
+  const checksResponse = runCommand({
+    cwd: params.repoRoot,
+    command: 'gh',
+    args: [
+      'pr',
+      'checks',
+      String(pr.number),
+      '--json',
+      'name,state,bucket,link,description',
+    ],
+  });
+
+  if (checksResponse.exitCode !== 0) {
+    return {
+      ...base,
+      pr,
+      status: 'degraded',
+      checks: {
+        total: 0,
+        failing: 0,
+      },
+      blockers: [],
+      reason: 'checks_lookup_failed',
+    };
+  }
+
+  let checks: RemoteCiCheck[] = [];
+  try {
+    checks = parseChecksPayload(checksResponse.stdout);
+  } catch {
+    return {
+      ...base,
+      pr,
+      status: 'degraded',
+      checks: {
+        total: 0,
+        failing: 0,
+      },
+      blockers: [],
+      reason: 'checks_payload_invalid',
+    };
+  }
+
+  const blockers = detectRemoteCiBlockers(checks);
+  const failing = checks.filter(isFailingCheck).length;
+  return {
+    ...base,
+    pr,
+    status: blockers.length > 0 ? 'blocked' : 'healthy',
+    checks: {
+      total: checks.length,
+      failing,
+    },
+    blockers,
+  };
+};


### PR DESCRIPTION
## Summary
- add optional `--remote-checks` diagnostics to `pumuki doctor` and `pumuki status`
- detect known remote blockers from GH checks (`REMOTE_CI_BILLING_LOCK`, `REMOTE_CI_PROVIDER_QUOTA`)
- include actionable remediation output and JSON payload support via `status --json --remote-checks`
- add deterministic parsing/normalization tests and CLI integration tests

## Issue
- closes #512

## Evidence (RED/GREEN)
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/remoteCiDiagnostics.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

## Notes
- diagnostics are optional and only run when `--remote-checks` is explicitly requested
- local doctor exit code behavior is unchanged (still based on local blocking issues)
