### PR TITLE
fix(cli): return exit code 0 for explicit help invocations

### DIFF
--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -424,6 +424,16 @@ test('runLifecycleCli retorna 1 ante argumentos inválidos', async () => {
   assert.equal(code, 1);
 });
 
+test('runLifecycleCli retorna 0 para ayuda explícita en comando raíz', async () => {
+  const code = await withSilentConsole(() => runLifecycleCli(['--help']));
+  assert.equal(code, 0);
+});
+
+test('runLifecycleCli retorna 0 para ayuda explícita en subcomando', async () => {
+  const code = await withSilentConsole(() => runLifecycleCli(['sdd', '--help']));
+  assert.equal(code, 0);
+});
+
 test('runLifecycleCli status --json --remote-checks añade diagnóstico remoto en payload', async () => {
   const repo = createGitRepo();
   const previousCwd = process.cwd();

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -1692,9 +1692,10 @@ export const runLifecycleCli = async (
         return 1;
     }
   } catch (error) {
+    const isExplicitHelpInvocation = argv.some((arg) => arg === '--help' || arg === '-h');
     const message = error instanceof Error ? error.message : 'Unexpected lifecycle CLI error.';
     writeError(message);
-    return 1;
+    return isExplicitHelpInvocation ? 0 : 1;
   }
 };
 


### PR DESCRIPTION
## Summary
- keep invalid command paths returning non-zero
- return `0` for explicit help invocations (`--help`, `-h`) in root and nested commands
- add regression tests for root help and nested `sdd --help`

## Issue
- closes #515

## Validation
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`
