### PR TITLE
feat(sdd): block empty validation scope in strict mode

### DIFF
--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -1024,6 +1024,7 @@ const resolveSddDecisionLocation = (
     case 'OPENSPEC_PROJECT_MISSING':
     case 'SDD_VALIDATION_FAILED':
     case 'SDD_VALIDATION_ERROR':
+    case 'SDD_VALIDATION_EMPTY_SCOPE':
       return 'openspec/changes:1';
     case 'SDD_CHANGE_MISSING':
       return changeId && changeId.trim().length > 0

--- a/integrations/sdd/__tests__/policy.test.ts
+++ b/integrations/sdd/__tests__/policy.test.ts
@@ -268,6 +268,51 @@ test('evaluateSddPolicy bloquea con SDD_VALIDATION_ERROR cuando exit code es cer
   });
 });
 
+test('evaluateSddPolicy bloquea con SDD_VALIDATION_EMPTY_SCOPE cuando items=0 en modo estricto', () => {
+  return withFixtureRepo('pumuki-sdd-empty-scope-strict-', (repoRoot) => {
+    writeOpenSpecBinary(repoRoot, {
+      validateExitCode: 0,
+      totals: { items: 0, failed: 0, passed: 0 },
+      issues: { errors: 0, warnings: 0, infos: 0 },
+    });
+    const changeId = createOpenSpecChange(repoRoot);
+    openSddSession({ cwd: repoRoot, changeId, ttlMinutes: 30 });
+
+    const result = evaluateSddPolicy({ stage: 'PRE_COMMIT', repoRoot });
+    assert.equal(result.decision.allowed, false);
+    assert.equal(result.decision.code, 'SDD_VALIDATION_EMPTY_SCOPE');
+    assert.equal(result.decision.details?.items, 0);
+  });
+});
+
+test('evaluateSddPolicy permite items=0 cuando strict empty scope está desactivado', () => {
+  return withFixtureRepo('pumuki-sdd-empty-scope-nonstrict-', (repoRoot) => {
+    const previous = process.env.PUMUKI_SDD_STRICT_EMPTY_ITEMS;
+    process.env.PUMUKI_SDD_STRICT_EMPTY_ITEMS = '0';
+    writeOpenSpecBinary(repoRoot, {
+      validateExitCode: 0,
+      totals: { items: 0, failed: 0, passed: 0 },
+      issues: { errors: 0, warnings: 0, infos: 0 },
+    });
+    const changeId = createOpenSpecChange(repoRoot);
+    openSddSession({ cwd: repoRoot, changeId, ttlMinutes: 30 });
+
+    try {
+      const result = evaluateSddPolicy({ stage: 'PRE_PUSH', repoRoot });
+      assert.equal(result.decision.allowed, true);
+      assert.equal(result.decision.code, 'ALLOWED');
+      assert.equal(result.decision.details?.validatedItems, 0);
+      assert.equal(result.decision.details?.emptyScope, true);
+    } finally {
+      if (typeof previous === 'undefined') {
+        delete process.env.PUMUKI_SDD_STRICT_EMPTY_ITEMS;
+      } else {
+        process.env.PUMUKI_SDD_STRICT_EMPTY_ITEMS = previous;
+      }
+    }
+  });
+});
+
 test('evaluateSddPolicy permite CI cuando validación OpenSpec es satisfactoria', () => {
   return withFixtureRepo('pumuki-sdd-validation-ok-', (repoRoot) => {
     writeOpenSpecBinary(repoRoot, {

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -144,6 +144,7 @@ export const evaluateSddPolicy = (params: {
   const repoRoot = params.repoRoot ?? process.cwd();
   const bypassEnabled = process.env.PUMUKI_SDD_BYPASS === '1';
   const autoRefreshEnabled = process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION !== '0';
+  const strictEmptyItemsEnabled = process.env.PUMUKI_SDD_STRICT_EMPTY_ITEMS !== '0';
   let status = buildStatus(repoRoot);
   let autoRefreshAttempted = false;
   let autoRefreshError: string | undefined;
@@ -252,6 +253,25 @@ export const evaluateSddPolicy = (params: {
     };
   }
 
+  if (strictEmptyItemsEnabled && validation.totals.items <= 0) {
+    return {
+      stage: params.stage,
+      status,
+      validation,
+      decision: blocked(
+        'SDD_VALIDATION_EMPTY_SCOPE',
+        'OpenSpec validation returned an empty scope (items=0) in strict mode. This is blocked to avoid false-green SDD gates.',
+        {
+          command: OPENSPEC_VALIDATE_ALL_COMMAND,
+          stage: params.stage,
+          items: validation.totals.items,
+          strictEmptyItemsEnabled,
+          overrideEnv: 'PUMUKI_SDD_STRICT_EMPTY_ITEMS=0',
+        }
+      ),
+    };
+  }
+
   return {
     stage: params.stage,
     status,
@@ -259,7 +279,10 @@ export const evaluateSddPolicy = (params: {
     decision: allowed('SDD validation passed for active changes.', {
       command: OPENSPEC_VALIDATE_ALL_COMMAND,
       passedItems: validation.totals.passed,
+      validatedItems: validation.totals.items,
       warnings: validation.issues.warnings,
+      emptyScope: validation.totals.items <= 0,
+      strictEmptyItemsEnabled,
     }),
   };
 };

--- a/integrations/sdd/types.ts
+++ b/integrations/sdd/types.ts
@@ -10,7 +10,8 @@ export type SddDecisionCode =
   | 'SDD_CHANGE_MISSING'
   | 'SDD_CHANGE_ARCHIVED'
   | 'SDD_VALIDATION_FAILED'
-  | 'SDD_VALIDATION_ERROR';
+  | 'SDD_VALIDATION_ERROR'
+  | 'SDD_VALIDATION_EMPTY_SCOPE';
 
 export type SddDecision = {
   allowed: boolean;


### PR DESCRIPTION
## Summary
- add strict empty-scope guard in SDD policy: block when validation returns `items=0`
- keep compatibility override via `PUMUKI_SDD_STRICT_EMPTY_ITEMS=0`
- surface new decision code `SDD_VALIDATION_EMPTY_SCOPE`
- extend SDD policy tests for strict and non-strict modes

## Issue
- closes #518

## Validation
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/policy.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`
