### PR TITLE
feat: expose evidence source metadata in AI gate outputs

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -110,6 +110,11 @@ Contract:
   - evidence `ai_gate.status = BLOCKED`
   - protected branch use (`main/master/develop/dev` by default)
 - Returns deterministic payload: `status`, `allowed`, `violations[]`, `evidence`, `repo_state`.
+- Evidence source contract (auditability):
+  - `evidence.source.source`
+  - `evidence.source.path`
+  - `evidence.source.digest`
+  - `evidence.source.generated_at`
 
 ## PRE_WRITE JSON envelope
 

--- a/integrations/evidence/readEvidence.test.ts
+++ b/integrations/evidence/readEvidence.test.ts
@@ -60,7 +60,15 @@ const sampleEvidence = (): AiEvidenceV2_1 => ({
 test('readEvidenceResult devuelve missing cuando no existe .ai_evidence.json', async () => {
   await withTempDir('pumuki-read-evidence-missing-', async (tempRoot) => {
     const result = readEvidenceResult(tempRoot);
-    assert.deepEqual(result, { kind: 'missing' });
+    assert.deepEqual(result, {
+      kind: 'missing',
+      source_descriptor: {
+        source: 'local-file',
+        path: join(tempRoot, '.ai_evidence.json'),
+        digest: null,
+        generated_at: null,
+      },
+    });
     assert.equal(readEvidence(tempRoot), undefined);
   });
 });
@@ -76,6 +84,10 @@ test('readEvidenceResult devuelve valid cuando el archivo tiene version 2.1', as
       assert.deepEqual(result.evidence, evidence);
       assert.equal(result.evidence.repo_state?.git.branch, 'feature/read-evidence');
       assert.equal(result.evidence.repo_state?.lifecycle.hooks.pre_push, 'managed');
+      assert.equal(result.source_descriptor.source, 'local-file');
+      assert.equal(result.source_descriptor.path, join(tempRoot, '.ai_evidence.json'));
+      assert.match(result.source_descriptor.digest ?? '', /^sha256:[0-9a-f]{64}$/);
+      assert.equal(result.source_descriptor.generated_at, evidence.timestamp);
     }
     assert.deepEqual(readEvidence(tempRoot), evidence);
   });
@@ -151,7 +163,14 @@ test('readEvidenceResult devuelve invalid y versión cuando el schema es de otra
     );
 
     const result = readEvidenceResult(tempRoot);
-    assert.deepEqual(result, { kind: 'invalid', version: '2.0' });
+    assert.equal(result.kind, 'invalid');
+    if (result.kind === 'invalid') {
+      assert.equal(result.version, '2.0');
+      assert.equal(result.source_descriptor.source, 'local-file');
+      assert.equal(result.source_descriptor.path, join(tempRoot, '.ai_evidence.json'));
+      assert.match(result.source_descriptor.digest ?? '', /^sha256:[0-9a-f]{64}$/);
+      assert.equal(result.source_descriptor.generated_at, null);
+    }
     assert.equal(readEvidence(tempRoot), undefined);
   });
 });
@@ -165,7 +184,14 @@ test('readEvidenceResult devuelve invalid sin versión cuando version no es stri
     );
 
     const result = readEvidenceResult(tempRoot);
-    assert.deepEqual(result, { kind: 'invalid', version: undefined });
+    assert.equal(result.kind, 'invalid');
+    if (result.kind === 'invalid') {
+      assert.equal(result.version, undefined);
+      assert.equal(result.source_descriptor.source, 'local-file');
+      assert.equal(result.source_descriptor.path, join(tempRoot, '.ai_evidence.json'));
+      assert.match(result.source_descriptor.digest ?? '', /^sha256:[0-9a-f]{64}$/);
+      assert.equal(result.source_descriptor.generated_at, null);
+    }
     assert.equal(readEvidence(tempRoot), undefined);
   });
 });
@@ -175,7 +201,14 @@ test('readEvidenceResult devuelve invalid sin versión cuando falta el campo ver
     writeFileSync(join(tempRoot, '.ai_evidence.json'), JSON.stringify({ payload: {} }, null, 2), 'utf8');
 
     const result = readEvidenceResult(tempRoot);
-    assert.deepEqual(result, { kind: 'invalid', version: undefined });
+    assert.equal(result.kind, 'invalid');
+    if (result.kind === 'invalid') {
+      assert.equal(result.version, undefined);
+      assert.equal(result.source_descriptor.source, 'local-file');
+      assert.equal(result.source_descriptor.path, join(tempRoot, '.ai_evidence.json'));
+      assert.match(result.source_descriptor.digest ?? '', /^sha256:[0-9a-f]{64}$/);
+      assert.equal(result.source_descriptor.generated_at, null);
+    }
     assert.equal(readEvidence(tempRoot), undefined);
   });
 });
@@ -185,7 +218,13 @@ test('readEvidenceResult devuelve invalid para JSON corrupto', async () => {
     writeFileSync(join(tempRoot, '.ai_evidence.json'), '{ invalid json', 'utf8');
 
     const result = readEvidenceResult(tempRoot);
-    assert.deepEqual(result, { kind: 'invalid' });
+    assert.equal(result.kind, 'invalid');
+    if (result.kind === 'invalid') {
+      assert.equal(result.source_descriptor.source, 'local-file');
+      assert.equal(result.source_descriptor.path, join(tempRoot, '.ai_evidence.json'));
+      assert.match(result.source_descriptor.digest ?? '', /^sha256:[0-9a-f]{64}$/);
+      assert.equal(result.source_descriptor.generated_at, null);
+    }
     assert.equal(readEvidence(tempRoot), undefined);
   });
 });

--- a/integrations/evidence/readEvidence.ts
+++ b/integrations/evidence/readEvidence.ts
@@ -1,42 +1,98 @@
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { AiEvidenceV2_1 } from './schema';
 
+export type EvidenceSourceDescriptor = {
+  source: 'local-file';
+  path: string;
+  digest: string | null;
+  generated_at: string | null;
+};
+
 export type EvidenceReadResult =
-  | { kind: 'missing' }
-  | { kind: 'invalid'; version?: string }
-  | { kind: 'valid'; evidence: AiEvidenceV2_1 };
+  | { kind: 'missing'; source_descriptor: EvidenceSourceDescriptor }
+  | { kind: 'invalid'; version?: string; source_descriptor: EvidenceSourceDescriptor }
+  | { kind: 'valid'; evidence: AiEvidenceV2_1; source_descriptor: EvidenceSourceDescriptor };
+
+const toDigest = (value: string): string =>
+  `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;
 
 export const readEvidenceResult = (repoRoot: string): EvidenceReadResult => {
   const evidencePath = resolve(repoRoot, '.ai_evidence.json');
   if (!existsSync(evidencePath)) {
-    return { kind: 'missing' };
+    return {
+      kind: 'missing',
+      source_descriptor: {
+        source: 'local-file',
+        path: evidencePath,
+        digest: null,
+        generated_at: null,
+      },
+    };
   }
 
+  let raw = '';
   try {
-    const parsed: unknown = JSON.parse(readFileSync(evidencePath, 'utf8'));
+    raw = readFileSync(evidencePath, 'utf8');
+  } catch {
+    return {
+      kind: 'invalid',
+      source_descriptor: {
+        source: 'local-file',
+        path: evidencePath,
+        digest: null,
+        generated_at: null,
+      },
+    };
+  }
+  const sourceDescriptorBase = {
+    source: 'local-file' as const,
+    path: evidencePath,
+    digest: toDigest(raw),
+  };
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
     if (
       typeof parsed === 'object' &&
       parsed !== null &&
       'version' in parsed &&
       (parsed as { version?: unknown }).version === '2.1'
     ) {
+      const evidence = parsed as AiEvidenceV2_1;
       return {
         kind: 'valid',
-        evidence: parsed as AiEvidenceV2_1,
+        evidence,
+        source_descriptor: {
+          ...sourceDescriptorBase,
+          generated_at: evidence.timestamp,
+        },
       };
     }
     const versionCandidate =
       typeof parsed === 'object' && parsed !== null && 'version' in parsed
         ? (parsed as { version?: unknown }).version
         : undefined;
+    const generatedAtCandidate =
+      typeof parsed === 'object' && parsed !== null && 'timestamp' in parsed
+        ? (parsed as { timestamp?: unknown }).timestamp
+        : undefined;
     return {
       kind: 'invalid',
       version: typeof versionCandidate === 'string' ? versionCandidate : undefined,
+      source_descriptor: {
+        ...sourceDescriptorBase,
+        generated_at: typeof generatedAtCandidate === 'string' ? generatedAtCandidate : null,
+      },
     };
   } catch {
     return {
       kind: 'invalid',
+      source_descriptor: {
+        ...sourceDescriptorBase,
+        generated_at: null,
+      },
     };
   }
 };

--- a/integrations/gate/__tests__/evaluateAiGate.test.ts
+++ b/integrations/gate/__tests__/evaluateAiGate.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { AiEvidenceV2_1 } from '../../evidence/schema';
+import type { EvidenceSourceDescriptor } from '../../evidence/readEvidence';
 import { evaluateAiGate } from '../evaluateAiGate';
 
 const sampleEvidence = (overrides: Partial<AiEvidenceV2_1> = {}): AiEvidenceV2_1 => ({
@@ -69,6 +70,32 @@ const sampleEvidence = (overrides: Partial<AiEvidenceV2_1> = {}): AiEvidenceV2_1
   ...overrides,
 });
 
+const sampleSourceDescriptor = (
+  overrides: Partial<EvidenceSourceDescriptor> = {}
+): EvidenceSourceDescriptor => ({
+  source: 'local-file',
+  path: '/repo/.ai_evidence.json',
+  digest: 'sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  generated_at: '2026-02-20T12:00:00.000Z',
+  ...overrides,
+});
+
+const missingEvidenceResult = () => ({
+  kind: 'missing' as const,
+  source_descriptor: sampleSourceDescriptor({
+    digest: null,
+    generated_at: null,
+  }),
+});
+
+const validEvidenceResult = (evidence: AiEvidenceV2_1) => ({
+  kind: 'valid' as const,
+  evidence,
+  source_descriptor: sampleSourceDescriptor({
+    generated_at: evidence.timestamp,
+  }),
+});
+
 test('evaluateAiGate bloquea cuando falta evidencia', () => {
   const result = evaluateAiGate(
     {
@@ -77,7 +104,7 @@ test('evaluateAiGate bloquea cuando falta evidencia', () => {
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({ kind: 'missing' }),
+      readEvidenceResult: () => missingEvidenceResult(),
       captureRepoState: () => sampleEvidence().repo_state!,
     }
   );
@@ -85,6 +112,12 @@ test('evaluateAiGate bloquea cuando falta evidencia', () => {
   assert.equal(result.status, 'BLOCKED');
   assert.equal(result.allowed, false);
   assert.equal(result.violations.some((item) => item.code === 'EVIDENCE_MISSING'), true);
+  assert.deepEqual((result.evidence as { source?: unknown }).source, {
+    source: 'local-file',
+    path: '/repo/.ai_evidence.json',
+    digest: null,
+    generated_at: null,
+  });
 });
 
 test('evaluateAiGate bloquea cuando evidencia está stale para PRE_WRITE', () => {
@@ -95,10 +128,7 @@ test('evaluateAiGate bloquea cuando evidencia está stale para PRE_WRITE', () =>
     },
     {
       now: () => Date.parse('2026-02-20T12:30:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: sampleEvidence({ timestamp: '2026-02-20T11:00:00.000Z' }),
-      }),
+      readEvidenceResult: () => validEvidenceResult(sampleEvidence({ timestamp: '2026-02-20T11:00:00.000Z' })),
       captureRepoState: () => sampleEvidence().repo_state!,
     }
   );
@@ -116,9 +146,9 @@ test('evaluateAiGate bloquea cuando evidencia válida ya está BLOCKED', () => {
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: sampleEvidence({
+      readEvidenceResult: () =>
+        validEvidenceResult(
+          sampleEvidence({
           snapshot: {
             stage: 'PRE_COMMIT',
             outcome: 'BLOCK',
@@ -155,8 +185,8 @@ test('evaluateAiGate bloquea cuando evidencia válida ya está BLOCKED', () => {
               INFO: 0,
             },
           },
-        }),
-      }),
+          })
+        ),
       captureRepoState: () => sampleEvidence().repo_state!,
     }
   );
@@ -177,10 +207,7 @@ test('evaluateAiGate bloquea en ramas protegidas por gitflow', () => {
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: sampleEvidence(),
-      }),
+      readEvidenceResult: () => validEvidenceResult(sampleEvidence()),
       captureRepoState: () => repoState,
     }
   );
@@ -201,6 +228,12 @@ test('evaluateAiGate permite continuar cuando evidencia está fresca y rama cump
       readEvidenceResult: () => ({
         kind: 'valid',
         evidence: sampleEvidence(),
+        source_descriptor: {
+          source: 'local-file',
+          path: '/repo/.ai_evidence.json',
+          digest: 'sha256:abc123',
+          generated_at: '2026-02-20T12:00:00.000Z',
+        },
       }),
       captureRepoState: () => sampleEvidence().repo_state!,
     }
@@ -209,6 +242,12 @@ test('evaluateAiGate permite continuar cuando evidencia está fresca y rama cump
   assert.equal(result.status, 'ALLOWED');
   assert.equal(result.allowed, true);
   assert.equal(result.violations.length, 0);
+  assert.deepEqual((result.evidence as { source?: unknown }).source, {
+    source: 'local-file',
+    path: '/repo/.ai_evidence.json',
+    digest: 'sha256:abc123',
+    generated_at: '2026-02-20T12:00:00.000Z',
+  });
 });
 
 test('evaluateAiGate bloquea PRE_WRITE cuando falta rules_coverage en evidencia válida', () => {
@@ -225,13 +264,11 @@ test('evaluateAiGate bloquea PRE_WRITE cuando falta rules_coverage en evidencia 
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: {
+      readEvidenceResult: () =>
+        validEvidenceResult({
           ...evidence,
           snapshot: snapshotWithoutCoverage,
-        },
-      }),
+        }),
       captureRepoState: () => sampleEvidence().repo_state!,
     }
   );
@@ -255,16 +292,14 @@ test('evaluateAiGate bloquea PRE_WRITE cuando repo root de evidencia no coincide
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: {
+      readEvidenceResult: () =>
+        validEvidenceResult({
           ...evidence,
           repo_state: {
             ...evidence.repo_state!,
             repo_root: '/other-repo',
           },
-        },
-      }),
+        }),
       captureRepoState: () => repoState,
     }
   );
@@ -289,9 +324,8 @@ test('evaluateAiGate bloquea PRE_WRITE ante incoherencias múltiples de evidenci
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: {
+      readEvidenceResult: () =>
+        validEvidenceResult({
           ...base,
           timestamp: '2026-02-20T13:00:00.000Z',
           snapshot: {
@@ -337,8 +371,7 @@ test('evaluateAiGate bloquea PRE_WRITE ante incoherencias múltiples de evidenci
               branch: 'feature/legacy-branch',
             },
           },
-        },
-      }),
+        }),
       captureRepoState: () => repoState,
     }
   );
@@ -363,10 +396,7 @@ test('evaluateAiGate bloquea PRE_WRITE cuando se requiere recibo MCP y no existe
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: sampleEvidence(),
-      }),
+      readEvidenceResult: () => validEvidenceResult(sampleEvidence()),
       captureRepoState: () => sampleEvidence().repo_state!,
       readMcpAiGateReceipt: () => ({
         kind: 'missing',
@@ -392,10 +422,7 @@ test('evaluateAiGate permite PRE_WRITE cuando hay recibo MCP fresco y válido', 
     },
     {
       now: () => Date.parse('2026-02-20T12:05:00.000Z'),
-      readEvidenceResult: () => ({
-        kind: 'valid',
-        evidence: sampleEvidence(),
-      }),
+      readEvidenceResult: () => validEvidenceResult(sampleEvidence()),
       captureRepoState: () => sampleEvidence().repo_state!,
       readMcpAiGateReceipt: () => ({
         kind: 'valid',

--- a/integrations/gate/evaluateAiGate.ts
+++ b/integrations/gate/evaluateAiGate.ts
@@ -4,6 +4,7 @@ import { captureRepoState } from '../evidence/repoState';
 import type { RepoState } from '../evidence/schema';
 import { resolvePolicyForStage } from './stagePolicies';
 import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { SkillsStage } from '../config/skillsLock';
 import {
   readMcpAiGateReceipt,
@@ -38,6 +39,12 @@ export type AiGateCheckResult = {
     kind: EvidenceReadResult['kind'];
     max_age_seconds: number;
     age_seconds: number | null;
+    source: {
+      source: string;
+      path: string;
+      digest: string | null;
+      generated_at: string | null;
+    };
   };
   mcp_receipt: {
     required: boolean;
@@ -276,6 +283,27 @@ const collectEvidenceViolations = (
   return { violations, ageSeconds };
 };
 
+const toEvidenceSourceDescriptor = (
+  result: EvidenceReadResult,
+  repoRoot: string
+): AiGateCheckResult['evidence']['source'] => {
+  if ('source_descriptor' in result) {
+    return {
+      source: result.source_descriptor.source,
+      path: result.source_descriptor.path,
+      digest: result.source_descriptor.digest,
+      generated_at: result.source_descriptor.generated_at,
+    };
+  }
+
+  return {
+    source: 'local-file',
+    path: resolve(repoRoot, '.ai_evidence.json'),
+    digest: null,
+    generated_at: null,
+  };
+};
+
 const collectGitflowViolations = (
   repoState: RepoState,
   protectedBranches: ReadonlySet<string>
@@ -478,6 +506,7 @@ export const evaluateAiGate = (
       kind: evidenceResult.kind,
       max_age_seconds: maxAgeSecondsByStage[params.stage],
       age_seconds: evidenceAssessment.ageSeconds,
+      source: toEvidenceSourceDescriptor(evidenceResult, params.repoRoot),
     },
     mcp_receipt: {
       required: mcpReceiptAssessment.required,

--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -853,6 +853,7 @@ test('runLifecycleCli sdd validate PRE_WRITE sin --json renderiza panel legacy d
     const output = printed.join('\n');
     assert.match(output, /PRE-FLIGHT CHECK/);
     assert.match(output, /MCP receipt: required=yes kind=valid/);
+    assert.match(output, /Evidence source: source=local-file/);
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/__tests__/lifecycle.test.ts
+++ b/integrations/lifecycle/__tests__/lifecycle.test.ts
@@ -116,6 +116,12 @@ test('runLifecycleCli PRE_WRITE --json mantiene salida encadenada con ai_gate cu
       ai_gate?: {
         evidence?: {
           kind?: string;
+          source?: {
+            source?: string;
+            path?: string;
+            digest?: string | null;
+            generated_at?: string | null;
+          };
         };
       };
     };
@@ -123,6 +129,10 @@ test('runLifecycleCli PRE_WRITE --json mantiene salida encadenada con ai_gate cu
     assert.equal(decisionCode, 'OPENSPEC_MISSING');
     assert.equal(typeof payload.ai_gate, 'object');
     assert.equal(payload.ai_gate?.evidence?.kind, 'missing');
+    assert.equal(payload.ai_gate?.evidence?.source?.source, 'local-file');
+    assert.match(payload.ai_gate?.evidence?.source?.path ?? '', /\.ai_evidence\.json$/);
+    assert.equal(payload.ai_gate?.evidence?.source?.digest ?? null, null);
+    assert.equal(payload.ai_gate?.evidence?.source?.generated_at ?? null, null);
     assert.equal(payload.telemetry?.chain, 'pumuki->mcp->ai_gate->ai_evidence');
     assert.equal(payload.telemetry?.mcp_tool, 'ai_gate_check');
   } finally {

--- a/integrations/lifecycle/__tests__/preWriteAutomation.test.ts
+++ b/integrations/lifecycle/__tests__/preWriteAutomation.test.ts
@@ -82,6 +82,12 @@ const buildAiGate = (violations: AiGateViolation[]): AiGateCheckResult => {
       kind: 'valid',
       max_age_seconds: 300,
       age_seconds: 5,
+      source: {
+        source: 'local-file',
+        path: '/repo/.ai_evidence.json',
+        digest: 'sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        generated_at: '2026-03-03T00:00:00.000Z',
+      },
     },
     mcp_receipt: {
       required: true,

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -981,6 +981,7 @@ const buildPreWriteValidationPanel = (params: {
     `Branch: ${git.branch ?? 'unknown'} · Upstream: ${git.upstream ?? 'none'}`,
     `Worktree: dirty=${git.dirty ? 'yes' : 'no'} staged=${git.staged} unstaged=${git.unstaged} ahead=${git.ahead} behind=${git.behind}`,
     `Evidence: kind=${params.aiGate.evidence.kind} age=${params.aiGate.evidence.age_seconds ?? 'n/a'}s max=${params.aiGate.evidence.max_age_seconds}s`,
+    `Evidence source: source=${params.aiGate.evidence.source.source} path=${params.aiGate.evidence.source.path} digest=${params.aiGate.evidence.source.digest ?? 'null'} generated_at=${params.aiGate.evidence.source.generated_at ?? 'null'}`,
     `MCP receipt: required=${receipt.required ? 'yes' : 'no'} kind=${receipt.kind} age=${receipt.age_seconds ?? 'n/a'}s max=${receipt.max_age_seconds ?? 'n/a'}s`,
     `Auto-heal: attempted=${params.automation.attempted ? 'yes' : 'no'} actions=${params.automation.actions.length}`,
     `Violations: ${params.aiGate.violations.length}`,

--- a/scripts/framework-menu-consumer-preflight-lib.ts
+++ b/scripts/framework-menu-consumer-preflight-lib.ts
@@ -212,6 +212,7 @@ export const formatConsumerPreflight = (
     `Branch: ${git.branch ?? 'unknown'} · Upstream: ${git.upstream ?? 'none'}`,
     `Worktree: dirty=${git.dirty ? 'yes' : 'no'} staged=${git.staged} unstaged=${git.unstaged} ahead=${git.ahead} behind=${git.behind}`,
     `Evidence: kind=${evidence.kind} age=${evidence.age_seconds ?? 'n/a'}s max=${evidence.max_age_seconds}s`,
+    `Evidence source: source=${evidence.source.source} path=${evidence.source.path} digest=${evidence.source.digest ?? 'null'} generated_at=${evidence.source.generated_at ?? 'null'}`,
     `Gate: ${preflight.status} (${preflight.result.violations.length} violations)`,
   ];
   lines.push(...buildBlockingCauseLines(preflight));


### PR DESCRIPTION
## Summary
- expose deterministic evidence source metadata contract in AI gate payloads
- include `source/path/digest/generated_at` in PRE_WRITE legacy panels and consumer preflight output
- document contract in API reference and add regression tests for valid/degraded evidence states

## Changes
- extended `readEvidenceResult` with `source_descriptor` for `missing|invalid|valid`
- propagated source contract to `evaluateAiGate().evidence.source`
- updated CLI panel rendering to print evidence source metadata
- added/updated tests for gate, evidence parser, prewrite automation and lifecycle output

## Validation (RED -> GREEN)
- `npx --yes tsx@4.21.0 --test integrations/evidence/readEvidence.test.ts integrations/gate/__tests__/evaluateAiGate.test.ts integrations/lifecycle/__tests__/preWriteAutomation.test.ts integrations/lifecycle/__tests__/lifecycle.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

Fixes #521
