### PR TITLE
feat: emit ai_gate summary on successful hook runs

### DIFF
--- a/integrations/git/__tests__/hookGateSummary.test.ts
+++ b/integrations/git/__tests__/hookGateSummary.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { EvidenceReadResult } from '../../evidence/readEvidence';
+import { runPreCommitStage, runPrePushStage } from '../stageRunners';
+
+const POLICY_TRACE_HASH = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const buildValidEvidenceResult = (): EvidenceReadResult => ({
+  kind: 'valid',
+  evidence: {
+    timestamp: '2026-03-03T00:00:00.000Z',
+  } as Extract<EvidenceReadResult, { kind: 'valid' }>['evidence'],
+  source_descriptor: {
+    source: 'local-file',
+    path: '/repo/.ai_evidence.json',
+    digest: 'sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+    generated_at: '2026-03-03T00:00:00.000Z',
+  },
+});
+
+test('runPreCommitStage emite resumen mínimo del gate en éxito', async () => {
+  const summaries: string[] = [];
+
+  const exitCode = await runPreCommitStage({
+    resolvePolicyForStage: () => ({
+      policy: {
+        stage: 'STAGED',
+        blockOnOrAbove: 'ERROR',
+        warnOnOrAbove: 'WARN',
+      },
+      trace: {
+        source: 'default',
+        bundle: 'gate-policy.default.PRE_COMMIT',
+        hash: POLICY_TRACE_HASH,
+      },
+    }),
+    runPlatformGate: async () => 0,
+    resolveRepoRoot: () => '/repo',
+    readEvidenceResult: () => buildValidEvidenceResult(),
+    now: () => Date.parse('2026-03-03T00:00:30.000Z'),
+    writeHookGateSummary: (message) => {
+      summaries.push(message);
+    },
+    notifyAuditSummaryFromEvidence: () => {},
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(summaries.length, 1);
+  assert.match(summaries[0] ?? '', /\[pumuki\]\[hook-gate\]/);
+  assert.match(summaries[0] ?? '', /stage=PRE_COMMIT/);
+  assert.match(summaries[0] ?? '', /decision=ALLOW/);
+  assert.match(summaries[0] ?? '', /policy_hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/);
+  assert.match(summaries[0] ?? '', /evidence_kind=valid/);
+  assert.match(summaries[0] ?? '', /evidence_age_seconds=30/);
+});
+
+test('runPrePushStage respeta --quiet y suprime resumen mínimo en éxito', async () => {
+  const summaries: string[] = [];
+
+  const exitCode = await runPrePushStage({
+    resolveUpstreamRef: () => 'origin/feature/hook-summary',
+    resolvePolicyForStage: () => ({
+      policy: {
+        stage: 'RANGE',
+        blockOnOrAbove: 'ERROR',
+        warnOnOrAbove: 'WARN',
+      },
+      trace: {
+        source: 'default',
+        bundle: 'gate-policy.default.PRE_PUSH',
+        hash: POLICY_TRACE_HASH,
+      },
+    }),
+    runPlatformGate: async () => 0,
+    resolveRepoRoot: () => '/repo',
+    readEvidenceResult: () => buildValidEvidenceResult(),
+    isQuietMode: () => true,
+    writeHookGateSummary: (message) => {
+      summaries.push(message);
+    },
+    notifyAuditSummaryFromEvidence: () => {},
+  });
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(summaries, []);
+});

--- a/integrations/git/stageRunners.ts
+++ b/integrations/git/stageRunners.ts
@@ -8,9 +8,14 @@ import { runPlatformGate } from './runPlatformGate';
 import { GitService } from './GitService';
 import { emitAuditSummaryNotificationFromEvidence } from '../notifications/emitAuditSummaryNotification';
 import { readFileSync } from 'node:fs';
+import { readEvidenceResult } from '../evidence/readEvidence';
+import type { EvidenceReadResult } from '../evidence/readEvidence';
 
 const PRE_PUSH_UPSTREAM_REQUIRED_MESSAGE =
   'pumuki pre-push blocked: branch has no upstream tracking reference. Configure upstream first (for example: git push --set-upstream origin <branch>) and retry.';
+
+const PRE_COMMIT_EVIDENCE_MAX_AGE_SECONDS = 900;
+const PRE_PUSH_EVIDENCE_MAX_AGE_SECONDS = 1800;
 
 type StageRunnerDependencies = {
   resolvePolicyForStage: typeof resolvePolicyForStage;
@@ -24,6 +29,10 @@ type StageRunnerDependencies = {
     repoRoot: string;
     stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
   }) => void;
+  readEvidenceResult: (repoRoot: string) => EvidenceReadResult;
+  now: () => number;
+  writeHookGateSummary: (message: string) => void;
+  isQuietMode: () => boolean;
 };
 
 const defaultDependencies: StageRunnerDependencies = {
@@ -53,6 +62,12 @@ const defaultDependencies: StageRunnerDependencies = {
       stage,
     });
   },
+  readEvidenceResult,
+  now: () => Date.now(),
+  writeHookGateSummary: (message) => {
+    process.stdout.write(`${message}\n`);
+  },
+  isQuietMode: () => process.argv.includes('--quiet'),
 };
 
 const getDependencies = (
@@ -73,6 +88,45 @@ const notifyAuditSummaryForStage = (
 };
 
 const ZERO_HASH = /^0+$/;
+
+const toEvidenceAgeSeconds = (
+  result: EvidenceReadResult,
+  nowMs: number
+): number | null => {
+  if (result.kind !== 'valid') {
+    return null;
+  }
+  const parsed = Date.parse(result.evidence.timestamp);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  const raw = Math.floor((nowMs - parsed) / 1000);
+  return raw >= 0 ? raw : 0;
+};
+
+const emitSuccessfulHookGateSummary = (params: {
+  dependencies: StageRunnerDependencies;
+  stage: 'PRE_COMMIT' | 'PRE_PUSH';
+  policyTrace: {
+    bundle: string;
+    hash: string;
+  };
+  exitCode: number;
+}): void => {
+  if (params.exitCode !== 0 || params.dependencies.isQuietMode()) {
+    return;
+  }
+  const repoRoot = params.dependencies.resolveRepoRoot();
+  const evidence = params.dependencies.readEvidenceResult(repoRoot);
+  const evidenceAgeSeconds = toEvidenceAgeSeconds(evidence, params.dependencies.now());
+  const maxAgeSeconds =
+    params.stage === 'PRE_COMMIT'
+      ? PRE_COMMIT_EVIDENCE_MAX_AGE_SECONDS
+      : PRE_PUSH_EVIDENCE_MAX_AGE_SECONDS;
+  params.dependencies.writeHookGateSummary(
+    `[pumuki][hook-gate] stage=${params.stage} policy_bundle=${params.policyTrace.bundle} policy_hash=${params.policyTrace.hash} decision=ALLOW evidence_kind=${evidence.kind} evidence_age_seconds=${evidenceAgeSeconds ?? 'n/a'} max_age_seconds=${maxAgeSeconds}`
+  );
+};
 
 const shouldAllowBootstrapPrePush = (rawInput: string): boolean => {
   const lines = rawInput
@@ -110,6 +164,15 @@ export async function runPreCommitStage(
       kind: 'staged',
     },
   });
+  emitSuccessfulHookGateSummary({
+    dependencies: activeDependencies,
+    stage: 'PRE_COMMIT',
+    policyTrace: {
+      bundle: resolved.trace.bundle,
+      hash: resolved.trace.hash,
+    },
+    exitCode,
+  });
   notifyAuditSummaryForStage(activeDependencies, 'PRE_COMMIT');
   return exitCode;
 }
@@ -132,6 +195,15 @@ export async function runPrePushStage(
           toRef: 'HEAD',
         },
       });
+      emitSuccessfulHookGateSummary({
+        dependencies: activeDependencies,
+        stage: 'PRE_PUSH',
+        policyTrace: {
+          bundle: resolved.trace.bundle,
+          hash: resolved.trace.hash,
+        },
+        exitCode,
+      });
       notifyAuditSummaryForStage(activeDependencies, 'PRE_PUSH');
       return exitCode;
     }
@@ -149,6 +221,15 @@ export async function runPrePushStage(
       fromRef: upstreamRef,
       toRef: 'HEAD',
     },
+  });
+  emitSuccessfulHookGateSummary({
+    dependencies: activeDependencies,
+    stage: 'PRE_PUSH',
+    policyTrace: {
+      bundle: resolved.trace.bundle,
+      hash: resolved.trace.hash,
+    },
+    exitCode,
   });
   notifyAuditSummaryForStage(activeDependencies, 'PRE_PUSH');
   return exitCode;


### PR DESCRIPTION
## Summary
- emit a deterministic `[pumuki][hook-gate]` summary on successful `pre-commit` and `pre-push`
- include `stage`, `decision`, `policy_bundle`, `policy_hash`, and evidence freshness fields
- support `--quiet` to suppress summary output for automation flows

## Changes
- updated `integrations/git/stageRunners.ts` to produce success summaries only for hook stages
- reused `.ai_evidence.json` metadata to report evidence kind and age in seconds
- added focused regression tests in `integrations/git/__tests__/hookGateSummary.test.ts`

## Validation
- `npx --yes tsx@4.21.0 --test integrations/git/__tests__/hookGateSummary.test.ts`
- `npm run -s typecheck`

Fixes #524
