### PR TITLE
fix: canonicalize SDD changeId casing in session lifecycle

### DIFF
--- a/integrations/sdd/__tests__/sessionStore.test.ts
+++ b/integrations/sdd/__tests__/sessionStore.test.ts
@@ -44,7 +44,7 @@ test('open/read/refresh/close session persists state per repository', () => {
     process.chdir(repo);
 
     const opened = openSddSession({
-      changeId: 'add-auth-feature',
+      changeId: 'Add-Auth-Feature',
       ttlMinutes: 30,
     });
     assert.equal(opened.active, true);
@@ -67,6 +67,27 @@ test('open/read/refresh/close session persists state per repository', () => {
     assert.equal(closed.active, false);
     assert.equal(closed.valid, false);
     assert.equal(closed.changeId, undefined);
+  } finally {
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('readSddSession normaliza changeId legado en mayúsculas a lowercase canónico', () => {
+  const repo = createRepoWithOpenSpecChange();
+  const previousCwd = process.cwd();
+  try {
+    process.chdir(repo);
+    openSddSession({
+      changeId: 'add-auth-feature',
+      ttlMinutes: 30,
+    });
+    runGit(repo, ['config', '--local', 'pumuki.sdd.session.change', 'ADD-AUTH-FEATURE']);
+
+    const readBack = readSddSession();
+    assert.equal(readBack.active, true);
+    assert.equal(readBack.changeId, 'add-auth-feature');
+    assert.equal(readBack.valid, true);
   } finally {
     process.chdir(previousCwd);
     rmSync(repo, { recursive: true, force: true });

--- a/integrations/sdd/sessionStore.ts
+++ b/integrations/sdd/sessionStore.ts
@@ -29,6 +29,9 @@ const parsePositiveMinutes = (value?: number): number =>
     ? Math.floor(value as number)
     : DEFAULT_TTL_MINUTES;
 
+const normalizeChangeId = (value: string): string =>
+  value.trim().toLowerCase();
+
 const computeValidity = (expiresAt?: string): {
   valid: boolean;
   remainingSeconds?: number;
@@ -52,7 +55,11 @@ const readConfig = (
   git: ILifecycleGitService
 ): SddSessionState => {
   const active = git.localConfig(repoRoot, SDD_KEYS.active) === 'true';
-  const changeId = git.localConfig(repoRoot, SDD_KEYS.change) ?? undefined;
+  const rawChangeId = git.localConfig(repoRoot, SDD_KEYS.change);
+  const changeId =
+    typeof rawChangeId === 'string' && rawChangeId.trim().length > 0
+      ? normalizeChangeId(rawChangeId)
+      : undefined;
   const updatedAt = git.localConfig(repoRoot, SDD_KEYS.updatedAt) ?? undefined;
   const expiresAt = git.localConfig(repoRoot, SDD_KEYS.expiresAt) ?? undefined;
   const ttlRaw = git.localConfig(repoRoot, SDD_KEYS.ttlMinutes);
@@ -102,7 +109,10 @@ export const openSddSession = (params: {
 }): SddSessionState => {
   const git = params.git ?? new LifecycleGitService();
   const repoRoot = resolveRepoRoot(params.cwd ?? process.cwd(), git);
-  const changeId = params.changeId.trim();
+  const changeId = normalizeChangeId(params.changeId);
+  if (changeId.length === 0) {
+    throw new Error('OpenSpec change id is required.');
+  }
   const changeState = ensureChangePath(repoRoot, changeId);
   if (!changeState.exists) {
     throw new Error(`OpenSpec change "${changeId}" not found in openspec/changes.`);


### PR DESCRIPTION
## Summary
- canonicalize SDD `changeId` to lowercase across session open/read/refresh lifecycle
- preserve compatibility by normalizing legacy mixed/uppercase session values on read
- add regression tests for mixed-case input and legacy uppercase config values

## Changes
- `integrations/sdd/sessionStore.ts`
  - added `normalizeChangeId()`
  - normalize `changeId` in `openSddSession`
  - normalize persisted config values in `readConfig`
  - added validation for empty `changeId`
- `integrations/sdd/__tests__/sessionStore.test.ts`
  - updated lifecycle test to open with mixed-case input and assert lowercase canonical output
  - added regression test for legacy uppercase config normalization

## Validation
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/sessionStore.test.ts integrations/sdd/__tests__/policy.test.ts`
- `npm run -s typecheck`

Fixes #526
