### PR TITLE
feat(lifecycle): add doctor --deep enterprise diagnostics

### DIFF
--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -230,6 +230,13 @@ test('parseLifecycleCliArgs interpreta comandos y flags soportados', () => {
     json: false,
     remoteChecks: true,
   });
+  assert.deepEqual(parseLifecycleCliArgs(['doctor', '--deep', '--json']), {
+    command: 'doctor',
+    purgeArtifacts: false,
+    updateSpec: undefined,
+    json: true,
+    doctorDeep: true,
+  });
   assert.deepEqual(parseLifecycleCliArgs(['status', '--json', '--remote-checks']), {
     command: 'status',
     purgeArtifacts: false,
@@ -417,6 +424,10 @@ test('parseLifecycleCliArgs rechaza help implícito y flags no soportados', () =
     () => parseLifecycleCliArgs(['install', '--remote-checks']),
     /only supported with "pumuki doctor" or "pumuki status"/i
   );
+  assert.throws(
+    () => parseLifecycleCliArgs(['status', '--deep']),
+    /only supported with "pumuki doctor"/i
+  );
 });
 
 test('runLifecycleCli retorna 1 ante argumentos inválidos', async () => {
@@ -530,6 +541,93 @@ test('runLifecycleCli doctor --remote-checks imprime resumen de bloqueadores rem
     assert.match(output, /\[pumuki\]\[remote-ci\] status=BLOCKED/i);
     assert.match(output, /REMOTE_CI_PROVIDER_QUOTA/i);
     assert.match(output, /remediation: increase quota/i);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli doctor --deep --json expone checks enterprise deterministas', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  try {
+    process.chdir(repo);
+    await withSilentConsole(() => runLifecycleCli(['install']));
+    mkdirSync(join(repo, '.pumuki'), { recursive: true });
+    writeFileSync(
+      join(repo, '.pumuki', 'adapter.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            pre_write: { command: 'npx --yes pumuki-pre-write' },
+            pre_commit: { command: 'npx --yes pumuki-pre-commit' },
+            pre_push: { command: 'npx --yes pumuki-pre-push' },
+            ci: { command: 'npx --yes pumuki-ci' },
+          },
+          mcp: {
+            enterprise: { command: 'npx --yes --package pumuki@latest pumuki-mcp-enterprise-stdio' },
+            evidence: { command: 'npx --yes --package pumuki@latest pumuki-mcp-evidence-stdio' },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+    writePreWriteEvidence(repo, 'main');
+
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli(['doctor', '--deep', '--json']);
+    assert.equal(code, 0);
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      deep?: {
+        enabled?: boolean;
+        checks?: Array<{ id?: string }>;
+      };
+    };
+    assert.equal(payload.deep?.enabled, true);
+    assert.equal(payload.deep?.checks?.some((check) => check.id === 'upstream-readiness'), true);
+    assert.equal(payload.deep?.checks?.some((check) => check.id === 'adapter-wiring'), true);
+    assert.equal(payload.deep?.checks?.some((check) => check.id === 'policy-drift'), true);
+    assert.equal(payload.deep?.checks?.some((check) => check.id === 'evidence-source-drift'), true);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli doctor --deep retorna 1 cuando hay bloqueo crítico deep', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  try {
+    process.chdir(repo);
+    await withSilentConsole(() => runLifecycleCli(['install']));
+    writeFileSync(join(repo, '.ai_evidence.json'), JSON.stringify({ version: '2.0' }, null, 2), 'utf8');
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli(['doctor', '--deep', '--json']);
+    assert.equal(code, 1);
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      deep?: {
+        blocking?: boolean;
+      };
+    };
+    assert.equal(payload.deep?.blocking, true);
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/__tests__/doctor.test.ts
+++ b/integrations/lifecycle/__tests__/doctor.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, realpathSync, unlinkSync } from 'node:fs';
+import { mkdirSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import type { AiEvidenceV2_1 } from '../../evidence/schema';
 import { withTempDir } from '../../__tests__/helpers/tempDir';
 import { PUMUKI_CONFIG_KEYS } from '../constants';
 import type { ILifecycleGitService } from '../gitService';
@@ -26,10 +27,15 @@ class FakeLifecycleGitService implements ILifecycleGitService {
   constructor(
     private readonly repoRoot: string,
     private readonly trackedNodeModules: ReadonlyArray<string> = [],
-    private readonly state: Record<string, string | undefined> = {}
+    private readonly state: Record<string, string | undefined> = {},
+    private readonly runGitResponses: Record<string, string> = {}
   ) {}
 
-  runGit(_args: ReadonlyArray<string>, _cwd: string): string {
+  runGit(args: ReadonlyArray<string>, _cwd: string): string {
+    const key = args.join(' ');
+    if (key in this.runGitResponses) {
+      return this.runGitResponses[key] ?? '';
+    }
     return '';
   }
 
@@ -58,6 +64,62 @@ class FakeLifecycleGitService implements ILifecycleGitService {
     return this.state[key];
   }
 }
+
+const sampleEvidence = (params: {
+  repoRoot: string;
+  branch: string;
+  upstream: string | null;
+  timestamp?: string;
+}): AiEvidenceV2_1 => ({
+  version: '2.1',
+  timestamp: params.timestamp ?? new Date().toISOString(),
+  snapshot: {
+    stage: 'PRE_COMMIT',
+    outcome: 'PASS',
+    findings: [],
+  },
+  ledger: [],
+  platforms: {},
+  rulesets: [],
+  human_intent: null,
+  ai_gate: {
+    status: 'ALLOWED',
+    violations: [],
+    human_intent: null,
+  },
+  severity_metrics: {
+    gate_status: 'ALLOWED',
+    total_violations: 0,
+    by_severity: {
+      CRITICAL: 0,
+      ERROR: 0,
+      WARN: 0,
+      INFO: 0,
+    },
+  },
+  repo_state: {
+    repo_root: params.repoRoot,
+    git: {
+      available: true,
+      branch: params.branch,
+      upstream: params.upstream,
+      ahead: 0,
+      behind: 0,
+      dirty: false,
+      staged: 0,
+      unstaged: 0,
+    },
+    lifecycle: {
+      installed: true,
+      package_version: '6.3.26',
+      lifecycle_version: '6.3.26',
+      hooks: {
+        pre_commit: 'managed',
+        pre_push: 'managed',
+      },
+    },
+  },
+});
 
 test('runLifecycleDoctor marca issue bloqueante cuando hay rutas trackeadas en node_modules', async () => {
   await withTempDir('pumuki-doctor-tracked-', async (repoRoot) => {
@@ -181,5 +243,126 @@ test('runLifecycleDoctor reporta error y warning cuando hay tracked node_modules
     assert.equal(report.issues[0]?.severity, 'error');
     assert.equal(report.issues[1]?.severity, 'warning');
     assert.equal(doctorHasBlockingIssues(report), true);
+  });
+});
+
+test('runLifecycleDoctor --deep reporta fallo bloqueante cuando evidence está ausente', async () => {
+  await withTempDir('pumuki-doctor-deep-missing-evidence-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.git', 'hooks'), { recursive: true });
+    installPumukiHooks(repoRoot);
+    const git = new FakeLifecycleGitService(
+      repoRoot,
+      [],
+      {
+        [PUMUKI_CONFIG_KEYS.installed]: 'true',
+        [PUMUKI_CONFIG_KEYS.version]: getCurrentPumukiVersion(),
+        [PUMUKI_CONFIG_KEYS.hooks]: 'pre-commit,pre-push',
+      },
+      {
+        'rev-parse --abbrev-ref --symbolic-full-name @{u}': '',
+        'rev-parse --abbrev-ref HEAD': 'feature/deep-evidence',
+      }
+    );
+
+    const report = runLifecycleDoctor({
+      cwd: repoRoot,
+      git,
+      deep: true,
+    });
+
+    assert.equal(report.deep?.enabled, true);
+    assert.equal(report.deep?.checks.some((check) => check.id === 'evidence-source-drift'), true);
+    assert.equal(report.deep?.checks.some((check) => check.id === 'evidence-source-drift' && check.status === 'fail'), true);
+    assert.equal(report.deep?.blocking, true);
+    assert.equal(doctorHasBlockingIssues(report), true);
+  });
+});
+
+test('runLifecycleDoctor --deep queda en PASS cuando upstream/adapter/policy/evidence están alineados', async () => {
+  await withTempDir('pumuki-doctor-deep-pass-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.git', 'hooks'), { recursive: true });
+    mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+    installPumukiHooks(repoRoot);
+
+    writeFileSync(
+      join(repoRoot, '.pumuki', 'adapter.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            pre_write: { command: 'npx --yes pumuki-pre-write' },
+            pre_commit: { command: 'npx --yes pumuki-pre-commit' },
+            pre_push: { command: 'npx --yes pumuki-pre-push' },
+            ci: { command: 'npx --yes pumuki-ci' },
+          },
+          mcp: {
+            enterprise: { command: 'npx --yes --package pumuki@latest pumuki-mcp-enterprise-stdio' },
+            evidence: { command: 'npx --yes --package pumuki@latest pumuki-mcp-evidence-stdio' },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    writeFileSync(
+      join(repoRoot, 'skills.policy.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          defaultBundleEnabled: true,
+          stages: {
+            PRE_COMMIT: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
+            PRE_PUSH: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
+            CI: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
+          },
+          bundles: {},
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const branch = 'feature/doctor-deep-pass';
+    const upstream = 'origin/feature/doctor-deep-pass';
+    writeFileSync(
+      join(repoRoot, '.ai_evidence.json'),
+      JSON.stringify(
+        sampleEvidence({
+          repoRoot,
+          branch,
+          upstream,
+        }),
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const git = new FakeLifecycleGitService(
+      repoRoot,
+      [],
+      {
+        [PUMUKI_CONFIG_KEYS.installed]: 'true',
+        [PUMUKI_CONFIG_KEYS.version]: getCurrentPumukiVersion(),
+        [PUMUKI_CONFIG_KEYS.hooks]: 'pre-commit,pre-push',
+      },
+      {
+        'rev-parse --abbrev-ref --symbolic-full-name @{u}': upstream,
+        'rev-parse --abbrev-ref HEAD': branch,
+      }
+    );
+
+    const report = runLifecycleDoctor({
+      cwd: repoRoot,
+      git,
+      deep: true,
+    });
+
+    assert.equal(report.deep?.enabled, true);
+    assert.equal(report.deep?.checks.every((check) => check.status === 'pass'), true);
+    assert.equal(report.deep?.blocking, false);
+    assert.equal(doctorHasBlockingIssues(report), false);
   });
 });

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -2,7 +2,11 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import type { GatePolicy } from '../../core/gate/GatePolicy';
 import { runPlatformGate } from '../git/runPlatformGate';
-import { runLifecycleDoctor, type LifecycleDoctorReport } from './doctor';
+import {
+  doctorHasBlockingIssues,
+  runLifecycleDoctor,
+  type LifecycleDoctorReport,
+} from './doctor';
 import { runLifecycleInstall } from './install';
 import { runLifecycleRemove } from './remove';
 import { readLifecycleStatus } from './status';
@@ -71,6 +75,7 @@ type ParsedArgs = {
   updateSpec?: string;
   json: boolean;
   remoteChecks?: boolean;
+  doctorDeep?: boolean;
   sddCommand?: SddCommand;
   loopCommand?: LoopCommand;
   loopSessionId?: string;
@@ -99,7 +104,7 @@ Pumuki lifecycle commands:
   pumuki uninstall [--purge-artifacts]
   pumuki remove
   pumuki update [--latest|--spec=<package-spec>]
-  pumuki doctor [--remote-checks]
+  pumuki doctor [--remote-checks] [--deep] [--json]
   pumuki status [--json] [--remote-checks]
   pumuki loop run --objective=<text> [--max-attempts=<n>] [--json]
   pumuki loop status --session=<session-id> [--json]
@@ -403,6 +408,7 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   let updateSpec: ParsedArgs['updateSpec'];
   let json = false;
   let remoteChecks = false;
+  let doctorDeep = false;
   let sddCommand: ParsedArgs['sddCommand'];
   let loopCommand: ParsedArgs['loopCommand'];
   let loopSessionId: ParsedArgs['loopSessionId'];
@@ -757,6 +763,10 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
       remoteChecks = true;
       continue;
     }
+    if (arg === '--deep') {
+      doctorDeep = true;
+      continue;
+    }
     if (arg === '--purge-artifacts') {
       purgeArtifacts = true;
       continue;
@@ -776,6 +786,9 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   if (remoteChecks && commandRaw !== 'doctor' && commandRaw !== 'status') {
     throw new Error(`--remote-checks is only supported with "pumuki doctor" or "pumuki status".\n\n${HELP_TEXT}`);
   }
+  if (doctorDeep && commandRaw !== 'doctor') {
+    throw new Error(`--deep is only supported with "pumuki doctor".\n\n${HELP_TEXT}`);
+  }
 
   return {
     command: commandRaw,
@@ -783,6 +796,7 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
     updateSpec,
     json,
     ...(remoteChecks ? { remoteChecks: true } : {}),
+    ...(doctorDeep ? { doctorDeep: true } : {}),
   };
 };
 
@@ -822,13 +836,29 @@ const printDoctorReport = (
     `[pumuki] hook pre-push: ${report.hookStatus['pre-push'].managedBlockPresent ? 'managed' : 'missing'}`
   );
 
-  if (report.issues.length === 0) {
+  for (const issue of report.issues) {
+    writeInfo(`[pumuki] ${issue.severity.toUpperCase()}: ${issue.message}`);
+  }
+
+  if (report.deep?.enabled) {
+    for (const check of report.deep.checks) {
+      writeInfo(
+        `[pumuki][doctor][deep] ${check.id}: status=${check.status.toUpperCase()} severity=${check.severity.toUpperCase()} ${check.message}`
+      );
+      if (check.status === 'fail' && check.remediation) {
+        writeInfo(`[pumuki][doctor][deep] remediation: ${check.remediation}`);
+      }
+    }
+  }
+
+  const hasBlocking = doctorHasBlockingIssues(report);
+  const hasWarnings =
+    report.issues.length > 0 ||
+    report.deep?.checks.some((check) => check.status === 'fail') === true;
+
+  if (!hasWarnings && !hasBlocking) {
     writeInfo('[pumuki] doctor verdict: PASS');
   } else {
-    for (const issue of report.issues) {
-      writeInfo(`[pumuki] ${issue.severity.toUpperCase()}: ${issue.message}`);
-    }
-    const hasBlocking = report.issues.some((issue) => issue.severity === 'error');
     writeInfo(`[pumuki] doctor verdict: ${hasBlocking ? 'BLOCKED' : 'WARN'}`);
   }
 
@@ -1168,14 +1198,31 @@ export const runLifecycleCli = async (
         return 0;
       }
       case 'doctor': {
-        const report = runLifecycleDoctor();
+        const report = runLifecycleDoctor({
+          deep: parsed.doctorDeep === true,
+        });
         const remoteCiDiagnostics = parsed.remoteChecks
           ? activeDependencies.collectRemoteCiDiagnostics({
               repoRoot: report.repoRoot,
             })
           : undefined;
-        printDoctorReport(report, remoteCiDiagnostics);
-        return report.issues.some((issue) => issue.severity === 'error') ? 1 : 0;
+        if (parsed.json) {
+          writeInfo(
+            JSON.stringify(
+              remoteCiDiagnostics
+                ? {
+                    ...report,
+                    remoteCiDiagnostics,
+                  }
+                : report,
+              null,
+              2
+            )
+          );
+        } else {
+          printDoctorReport(report, remoteCiDiagnostics);
+        }
+        return doctorHasBlockingIssues(report) ? 1 : 0;
       }
       case 'status': {
         const status = readLifecycleStatus();

--- a/integrations/lifecycle/doctor.ts
+++ b/integrations/lifecycle/doctor.ts
@@ -1,3 +1,7 @@
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { readEvidenceResult } from '../evidence/readEvidence';
+import { resolvePolicyForStage } from '../gate/stagePolicies';
 import { getPumukiHooksStatus } from './hookManager';
 import { LifecycleGitService, type ILifecycleGitService } from './gitService';
 import { getCurrentPumukiVersion } from './packageInfo';
@@ -10,6 +14,27 @@ export type DoctorIssue = {
   message: string;
 };
 
+export type DoctorDeepCheckId =
+  | 'upstream-readiness'
+  | 'adapter-wiring'
+  | 'policy-drift'
+  | 'evidence-source-drift';
+
+export type DoctorDeepCheck = {
+  id: DoctorDeepCheckId;
+  status: 'pass' | 'fail';
+  severity: 'info' | DoctorIssueSeverity;
+  message: string;
+  remediation?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type DoctorDeepReport = {
+  enabled: true;
+  checks: ReadonlyArray<DoctorDeepCheck>;
+  blocking: boolean;
+};
+
 export type LifecycleDoctorReport = {
   repoRoot: string;
   packageVersion: string;
@@ -17,6 +42,7 @@ export type LifecycleDoctorReport = {
   trackedNodeModulesPaths: ReadonlyArray<string>;
   hookStatus: ReturnType<typeof getPumukiHooksStatus>;
   issues: ReadonlyArray<DoctorIssue>;
+  deep?: DoctorDeepReport;
 };
 
 const buildDoctorIssues = (params: {
@@ -59,9 +85,408 @@ const buildDoctorIssues = (params: {
   return issues;
 };
 
+const DEEP_EVIDENCE_MAX_AGE_SECONDS = 1800;
+
+const toCanonicalPath = (value: string): string => {
+  try {
+    return realpathSync(value).replace(/\\/g, '/').toLowerCase();
+  } catch {
+    return resolve(value).replace(/\\/g, '/').toLowerCase();
+  }
+};
+
+const runGitSafely = (
+  git: ILifecycleGitService,
+  cwd: string,
+  args: ReadonlyArray<string>
+): string | undefined => {
+  try {
+    const output = git.runGit(args, cwd).trim();
+    return output.length > 0 ? output : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readNestedString = (
+  source: Record<string, unknown>,
+  path: ReadonlyArray<string>
+): string | undefined => {
+  let cursor: unknown = source;
+  for (const segment of path) {
+    if (!isRecord(cursor)) {
+      return undefined;
+    }
+    cursor = cursor[segment];
+  }
+  return typeof cursor === 'string' && cursor.trim().length > 0 ? cursor : undefined;
+};
+
+const buildDeepCheck = (
+  check: Omit<DoctorDeepCheck, 'status' | 'severity'> & {
+    status: DoctorDeepCheck['status'];
+    severity: DoctorDeepCheck['severity'];
+  }
+): DoctorDeepCheck => check;
+
+const evaluateUpstreamReadinessCheck = (params: {
+  git: ILifecycleGitService;
+  repoRoot: string;
+}): DoctorDeepCheck => {
+  const branch =
+    runGitSafely(params.git, params.repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD']) ?? 'unknown';
+  const upstream = runGitSafely(params.git, params.repoRoot, [
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{u}',
+  ]);
+  if (!upstream) {
+    return buildDeepCheck({
+      id: 'upstream-readiness',
+      status: 'fail',
+      severity: 'warning',
+      message: `Branch "${branch}" has no upstream tracking.`,
+      remediation: `Run "git push --set-upstream origin ${branch}" before relying on PRE_PUSH diagnostics.`,
+      metadata: {
+        branch,
+        upstream: null,
+      },
+    });
+  }
+  return buildDeepCheck({
+    id: 'upstream-readiness',
+    status: 'pass',
+    severity: 'info',
+    message: `Upstream tracking is configured (${upstream}).`,
+    metadata: {
+      branch,
+      upstream,
+    },
+  });
+};
+
+const evaluateAdapterWiringCheck = (repoRoot: string): DoctorDeepCheck => {
+  const adapterPath = join(repoRoot, '.pumuki', 'adapter.json');
+  if (!existsSync(adapterPath)) {
+    return buildDeepCheck({
+      id: 'adapter-wiring',
+      status: 'fail',
+      severity: 'warning',
+      message: 'Adapter wiring file .pumuki/adapter.json is missing.',
+      remediation: 'Run "pumuki adapter install --agent=codex" to scaffold adapter hooks and MCP wiring.',
+      metadata: {
+        path: adapterPath,
+      },
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(adapterPath, 'utf8')) as unknown;
+  } catch {
+    return buildDeepCheck({
+      id: 'adapter-wiring',
+      status: 'fail',
+      severity: 'error',
+      message: 'Adapter wiring file is not valid JSON.',
+      remediation: 'Re-run "pumuki adapter install --agent=codex" to repair adapter wiring contract.',
+      metadata: {
+        path: adapterPath,
+      },
+    });
+  }
+
+  if (!isRecord(parsed)) {
+    return buildDeepCheck({
+      id: 'adapter-wiring',
+      status: 'fail',
+      severity: 'error',
+      message: 'Adapter wiring payload must be an object.',
+      remediation: 'Re-run "pumuki adapter install --agent=codex" to restore adapter schema.',
+      metadata: {
+        path: adapterPath,
+      },
+    });
+  }
+
+  const requiredCommandPaths: ReadonlyArray<ReadonlyArray<string>> = [
+    ['hooks', 'pre_write', 'command'],
+    ['hooks', 'pre_commit', 'command'],
+    ['hooks', 'pre_push', 'command'],
+    ['hooks', 'ci', 'command'],
+    ['mcp', 'enterprise', 'command'],
+    ['mcp', 'evidence', 'command'],
+  ];
+  const missingPaths = requiredCommandPaths
+    .filter((path) => !readNestedString(parsed, path))
+    .map((path) => path.join('.'));
+
+  if (missingPaths.length > 0) {
+    return buildDeepCheck({
+      id: 'adapter-wiring',
+      status: 'fail',
+      severity: 'error',
+      message: `Adapter wiring is incomplete (missing: ${missingPaths.join(', ')}).`,
+      remediation: 'Re-run "pumuki adapter install --agent=codex" and keep generated commands unchanged.',
+      metadata: {
+        path: adapterPath,
+        missing_count: missingPaths.length,
+      },
+    });
+  }
+
+  return buildDeepCheck({
+    id: 'adapter-wiring',
+    status: 'pass',
+    severity: 'info',
+    message: 'Adapter wiring contract is valid.',
+    metadata: {
+      path: adapterPath,
+    },
+  });
+};
+
+const evaluatePolicyDriftCheck = (repoRoot: string): DoctorDeepCheck => {
+  const preCommitFirst = resolvePolicyForStage('PRE_COMMIT', repoRoot);
+  const preCommitSecond = resolvePolicyForStage('PRE_COMMIT', repoRoot);
+  const prePushFirst = resolvePolicyForStage('PRE_PUSH', repoRoot);
+  const prePushSecond = resolvePolicyForStage('PRE_PUSH', repoRoot);
+
+  const preCommitStable =
+    preCommitFirst.trace.hash === preCommitSecond.trace.hash &&
+    preCommitFirst.policy.blockOnOrAbove === preCommitSecond.policy.blockOnOrAbove &&
+    preCommitFirst.policy.warnOnOrAbove === preCommitSecond.policy.warnOnOrAbove;
+  const prePushStable =
+    prePushFirst.trace.hash === prePushSecond.trace.hash &&
+    prePushFirst.policy.blockOnOrAbove === prePushSecond.policy.blockOnOrAbove &&
+    prePushFirst.policy.warnOnOrAbove === prePushSecond.policy.warnOnOrAbove;
+
+  if (!preCommitStable || !prePushStable) {
+    return buildDeepCheck({
+      id: 'policy-drift',
+      status: 'fail',
+      severity: 'error',
+      message: 'Policy resolution is non-deterministic across repeated reads.',
+      remediation: 'Lock policy configuration and rerun doctor --deep after removing nondeterministic overrides.',
+      metadata: {
+        pre_commit_hash: preCommitFirst.trace.hash,
+        pre_push_hash: prePushFirst.trace.hash,
+      },
+    });
+  }
+
+  const usesDefault =
+    preCommitFirst.trace.source === 'default' || prePushFirst.trace.source === 'default';
+  if (usesDefault) {
+    return buildDeepCheck({
+      id: 'policy-drift',
+      status: 'fail',
+      severity: 'warning',
+      message: 'Policy is running on default fallback without explicit skills policy or hard-mode.',
+      remediation: 'Define skills.policy.json or .pumuki/hard-mode.json to avoid policy drift in enterprise environments.',
+      metadata: {
+        pre_commit_source: preCommitFirst.trace.source,
+        pre_push_source: prePushFirst.trace.source,
+      },
+    });
+  }
+
+  return buildDeepCheck({
+    id: 'policy-drift',
+    status: 'pass',
+    severity: 'info',
+    message: 'Policy resolution is deterministic and explicitly configured.',
+    metadata: {
+      pre_commit_source: preCommitFirst.trace.source,
+      pre_push_source: prePushFirst.trace.source,
+    },
+  });
+};
+
+const evaluateEvidenceSourceDriftCheck = (params: {
+  git: ILifecycleGitService;
+  repoRoot: string;
+}): DoctorDeepCheck => {
+  const evidenceResult = readEvidenceResult(params.repoRoot);
+  if (evidenceResult.kind === 'missing') {
+    return buildDeepCheck({
+      id: 'evidence-source-drift',
+      status: 'fail',
+      severity: 'error',
+      message: '.ai_evidence.json is missing.',
+      remediation: 'Regenerate evidence with a full audit before continuing with enterprise checks.',
+      metadata: {
+        path: evidenceResult.source_descriptor.path,
+      },
+    });
+  }
+
+  if (evidenceResult.kind === 'invalid') {
+    return buildDeepCheck({
+      id: 'evidence-source-drift',
+      status: 'fail',
+      severity: 'error',
+      message: `.ai_evidence.json is invalid${evidenceResult.version ? ` (version=${evidenceResult.version})` : ''}.`,
+      remediation: 'Repair evidence schema and regenerate evidence from this repository and branch.',
+      metadata: {
+        path: evidenceResult.source_descriptor.path,
+      },
+    });
+  }
+
+  const violations: string[] = [];
+  let severity: DoctorIssueSeverity = 'warning';
+  const toError = (): void => {
+    severity = 'error';
+  };
+
+  const nowMs = Date.now();
+  const timestampMs = Date.parse(evidenceResult.evidence.timestamp);
+  const ageSeconds = Number.isFinite(timestampMs)
+    ? Math.max(0, Math.floor((nowMs - timestampMs) / 1000))
+    : null;
+
+  if (!Number.isFinite(timestampMs)) {
+    toError();
+    violations.push('Evidence timestamp is invalid.');
+  } else if (timestampMs > nowMs) {
+    toError();
+    violations.push('Evidence timestamp is in the future.');
+  } else if (ageSeconds !== null && ageSeconds > DEEP_EVIDENCE_MAX_AGE_SECONDS) {
+    toError();
+    violations.push(
+      `Evidence is stale (${ageSeconds}s > ${DEEP_EVIDENCE_MAX_AGE_SECONDS}s).`
+    );
+  }
+
+  const currentBranch = runGitSafely(params.git, params.repoRoot, [
+    'rev-parse',
+    '--abbrev-ref',
+    'HEAD',
+  ]);
+  const currentUpstream = runGitSafely(params.git, params.repoRoot, [
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{u}',
+  ]);
+
+  const expectedEvidencePath = resolve(params.repoRoot, '.ai_evidence.json');
+  if (
+    toCanonicalPath(evidenceResult.source_descriptor.path) !==
+    toCanonicalPath(expectedEvidencePath)
+  ) {
+    toError();
+    violations.push(
+      `Evidence source path mismatch (${evidenceResult.source_descriptor.path} != ${expectedEvidencePath}).`
+    );
+  }
+
+  if (
+    evidenceResult.source_descriptor.digest &&
+    !/^sha256:[0-9a-f]{64}$/i.test(evidenceResult.source_descriptor.digest)
+  ) {
+    toError();
+    violations.push('Evidence digest format is invalid.');
+  }
+
+  const evidenceRepoRoot = evidenceResult.evidence.repo_state?.repo_root;
+  if (
+    typeof evidenceRepoRoot === 'string' &&
+    evidenceRepoRoot.trim().length > 0 &&
+    toCanonicalPath(evidenceRepoRoot) !== toCanonicalPath(params.repoRoot)
+  ) {
+    toError();
+    violations.push(`Evidence repo_root mismatch (${evidenceRepoRoot} != ${params.repoRoot}).`);
+  }
+
+  const evidenceBranch = evidenceResult.evidence.repo_state?.git?.branch;
+  if (
+    typeof evidenceBranch === 'string' &&
+    evidenceBranch.trim().length > 0 &&
+    typeof currentBranch === 'string' &&
+    currentBranch.trim().length > 0 &&
+    evidenceBranch !== currentBranch
+  ) {
+    toError();
+    violations.push(`Evidence branch mismatch (${evidenceBranch} != ${currentBranch}).`);
+  }
+
+  const evidenceUpstream = evidenceResult.evidence.repo_state?.git?.upstream;
+  if (
+    typeof evidenceUpstream === 'string' &&
+    evidenceUpstream.trim().length > 0 &&
+    typeof currentUpstream === 'string' &&
+    currentUpstream.trim().length > 0 &&
+    evidenceUpstream !== currentUpstream
+  ) {
+    violations.push(`Evidence upstream mismatch (${evidenceUpstream} != ${currentUpstream}).`);
+  }
+
+  if (violations.length > 0) {
+    return buildDeepCheck({
+      id: 'evidence-source-drift',
+      status: 'fail',
+      severity,
+      message: violations.join(' '),
+      remediation: 'Regenerate evidence in the current repository and branch before running enterprise gates.',
+      metadata: {
+        source_path: evidenceResult.source_descriptor.path,
+        evidence_age_seconds: ageSeconds,
+        current_branch: currentBranch ?? null,
+        current_upstream: currentUpstream ?? null,
+      },
+    });
+  }
+
+  return buildDeepCheck({
+    id: 'evidence-source-drift',
+    status: 'pass',
+    severity: 'info',
+    message: 'Evidence source metadata is aligned with repository state.',
+    metadata: {
+      source_path: evidenceResult.source_descriptor.path,
+      evidence_age_seconds: ageSeconds,
+      current_branch: currentBranch ?? null,
+      current_upstream: currentUpstream ?? null,
+    },
+  });
+};
+
+const buildDoctorDeepReport = (params: {
+  git: ILifecycleGitService;
+  repoRoot: string;
+}): DoctorDeepReport => {
+  const checks: DoctorDeepCheck[] = [
+    evaluateUpstreamReadinessCheck({
+      git: params.git,
+      repoRoot: params.repoRoot,
+    }),
+    evaluateAdapterWiringCheck(params.repoRoot),
+    evaluatePolicyDriftCheck(params.repoRoot),
+    evaluateEvidenceSourceDriftCheck({
+      git: params.git,
+      repoRoot: params.repoRoot,
+    }),
+  ];
+
+  return {
+    enabled: true,
+    checks,
+    blocking: checks.some(
+      (check) => check.status === 'fail' && check.severity === 'error'
+    ),
+  };
+};
+
 export const runLifecycleDoctor = (params?: {
   cwd?: string;
   git?: ILifecycleGitService;
+  deep?: boolean;
 }): LifecycleDoctorReport => {
   const git = params?.git ?? new LifecycleGitService();
   const cwd = params?.cwd ?? process.cwd();
@@ -75,6 +500,12 @@ export const runLifecycleDoctor = (params?: {
     hookStatus,
     lifecycleState,
   });
+  const deep = params?.deep
+    ? buildDoctorDeepReport({
+      git,
+      repoRoot,
+    })
+    : undefined;
 
   return {
     repoRoot,
@@ -83,8 +514,9 @@ export const runLifecycleDoctor = (params?: {
     trackedNodeModulesPaths,
     hookStatus,
     issues,
+    deep,
   };
 };
 
 export const doctorHasBlockingIssues = (report: LifecycleDoctorReport): boolean =>
-  report.issues.some((issue) => issue.severity === 'error');
+  report.issues.some((issue) => issue.severity === 'error') || report.deep?.blocking === true;


### PR DESCRIPTION
## Summary\n- add deterministic `doctor --deep` diagnostics for upstream, adapter wiring, policy drift, and evidence source drift\n- expose `--deep` in lifecycle CLI parsing/help and support `doctor --json` output with deep payload\n- keep doctor exit code aligned with critical findings (non-zero only on blocking errors)\n\n## Tests\n- npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/doctor.test.ts integrations/lifecycle/__tests__/cli.test.ts\n- npm run -s typecheck\n\nCloses #528