### PR TITLE
feat: enforce SDD change completeness contract in PRE_PUSH/CI (#532)

### DIFF
--- a/integrations/sdd/__tests__/policy.test.ts
+++ b/integrations/sdd/__tests__/policy.test.ts
@@ -74,10 +74,24 @@ process.exit(0);
   }
 };
 
-const createOpenSpecChange = (repoRoot: string, changeId = 'add-auth-feature'): string => {
+const createOpenSpecChange = (
+  repoRoot: string,
+  changeId = 'add-auth-feature',
+  options?: {
+    withCompleteness?: boolean;
+  }
+): string => {
   const changePath = join(repoRoot, 'openspec', 'changes', changeId);
   mkdirSync(changePath, { recursive: true });
   writeFileSync(join(changePath, 'proposal.md'), '# proposal\n', 'utf8');
+  if (options?.withCompleteness !== false) {
+    writeFileSync(join(changePath, 'tasks.md'), '- [ ] implementar flujo\n', 'utf8');
+    writeFileSync(
+      join(changePath, 'scenario.feature'),
+      'Feature: SDD completeness contract\n  Scenario: baseline scenario\n    Given a valid change\n    Then the completeness contract should pass\n',
+      'utf8'
+    );
+  }
   return changeId;
 };
 
@@ -225,6 +239,30 @@ test('evaluateSddPolicy permite PRE_WRITE con sesión válida sin ejecutar valid
     assert.equal(result.decision.allowed, true);
     assert.equal(result.decision.code, 'ALLOWED');
     assert.equal(result.validation, undefined);
+  });
+});
+
+test('evaluateSddPolicy bloquea con SDD_CHANGE_INCOMPLETE en PRE_PUSH cuando falta contrato mínimo del change', () => {
+  return withFixtureRepo('pumuki-sdd-change-incomplete-', (repoRoot) => {
+    writeOpenSpecBinary(repoRoot, {
+      validateExitCode: 0,
+      totals: { items: 2, failed: 0, passed: 2 },
+      issues: { errors: 0, warnings: 0, infos: 0 },
+    });
+    const changeId = createOpenSpecChange(repoRoot, 'add-auth-feature', {
+      withCompleteness: false,
+    });
+    openSddSession({ cwd: repoRoot, changeId, ttlMinutes: 30 });
+
+    const result = evaluateSddPolicy({ stage: 'PRE_PUSH', repoRoot });
+    assert.equal(result.decision.allowed, false);
+    assert.equal(result.decision.code, 'SDD_CHANGE_INCOMPLETE');
+    assert.equal(result.decision.details?.changeId, 'add-auth-feature');
+    assert.equal(result.decision.details?.contractVersion, '1.0');
+    assert.deepEqual(result.decision.details?.missingRequirements, [
+      'tasks.md',
+      'scenario.feature',
+    ]);
   });
 });
 

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
   detectOpenSpecInstallation,
@@ -17,6 +17,7 @@ import type {
 
 const SDD_SESSION_REFRESH_COMMAND =
   'npx --yes --package pumuki@latest pumuki sdd session --refresh --ttl-minutes=90';
+const SDD_COMPLETENESS_CONTRACT_VERSION = '1.0';
 
 const buildStatus = (repoRoot: string): SddStatusPayload => {
   const openspec = detectOpenSpecInstallation(repoRoot);
@@ -60,6 +61,49 @@ const activeChangeExists = (repoRoot: string, changeId: string): boolean =>
 
 const activeChangeArchived = (repoRoot: string, changeId: string): boolean =>
   existsSync(resolve(repoRoot, 'openspec', 'changes', 'archive', changeId));
+
+const evaluateActiveChangeCompleteness = (params: {
+  repoRoot: string;
+  changeId: string;
+}): {
+  complete: boolean;
+  missingRequirements: string[];
+} => {
+  const changeRoot = resolve(params.repoRoot, 'openspec', 'changes', params.changeId);
+  const proposalPath = resolve(changeRoot, 'proposal.md');
+  const tasksPath = resolve(changeRoot, 'tasks.md');
+  const scenarioPath = resolve(changeRoot, 'scenario.feature');
+  const missingRequirements: string[] = [];
+
+  if (!existsSync(proposalPath)) {
+    missingRequirements.push('proposal.md');
+  }
+  if (!existsSync(tasksPath)) {
+    missingRequirements.push('tasks.md');
+  }
+  if (!existsSync(scenarioPath)) {
+    missingRequirements.push('scenario.feature');
+  } else {
+    try {
+      const scenarioContent = readFileSync(scenarioPath, 'utf8');
+      const hasFeatureHeader = /^\s*Feature:\s+/im.test(scenarioContent);
+      const hasScenarioBody = /^\s*Scenario(?: Outline)?:\s+/im.test(scenarioContent);
+      if (!hasFeatureHeader) {
+        missingRequirements.push('scenario.feature#Feature');
+      }
+      if (!hasScenarioBody) {
+        missingRequirements.push('scenario.feature#Scenario');
+      }
+    } catch {
+      missingRequirements.push('scenario.feature#readable');
+    }
+  }
+
+  return {
+    complete: missingRequirements.length === 0,
+    missingRequirements,
+  };
+};
 
 const evaluateSessionRequirements = (params: {
   status: SddStatusPayload;
@@ -145,6 +189,7 @@ export const evaluateSddPolicy = (params: {
   const bypassEnabled = process.env.PUMUKI_SDD_BYPASS === '1';
   const autoRefreshEnabled = process.env.PUMUKI_SDD_AUTO_REFRESH_SESSION !== '0';
   const strictEmptyItemsEnabled = process.env.PUMUKI_SDD_STRICT_EMPTY_ITEMS !== '0';
+  const strictCompletenessEnabled = process.env.PUMUKI_SDD_ENFORCE_COMPLETENESS !== '0';
   let status = buildStatus(repoRoot);
   let autoRefreshAttempted = false;
   let autoRefreshError: string | undefined;
@@ -272,6 +317,38 @@ export const evaluateSddPolicy = (params: {
     };
   }
 
+  const activeChangeId = status.session.changeId;
+  if (
+    strictCompletenessEnabled &&
+    activeChangeId &&
+    (params.stage === 'PRE_PUSH' || params.stage === 'CI')
+  ) {
+    const completeness = evaluateActiveChangeCompleteness({
+      repoRoot,
+      changeId: activeChangeId,
+    });
+    if (!completeness.complete) {
+      return {
+        stage: params.stage,
+        status,
+        validation,
+        decision: blocked(
+          'SDD_CHANGE_INCOMPLETE',
+          'Active SDD change is incomplete for strict PRE_PUSH/CI enforcement. Ensure proposal/tasks/scenario contract is complete before continuing.',
+          {
+            command: OPENSPEC_VALIDATE_ALL_COMMAND,
+            stage: params.stage,
+            changeId: activeChangeId,
+            contractVersion: SDD_COMPLETENESS_CONTRACT_VERSION,
+            missingRequirements: completeness.missingRequirements,
+            strictCompletenessEnabled,
+            overrideEnv: 'PUMUKI_SDD_ENFORCE_COMPLETENESS=0',
+          }
+        ),
+      };
+    }
+  }
+
   return {
     stage: params.stage,
     status,
@@ -283,6 +360,8 @@ export const evaluateSddPolicy = (params: {
       warnings: validation.issues.warnings,
       emptyScope: validation.totals.items <= 0,
       strictEmptyItemsEnabled,
+      strictCompletenessEnabled,
+      completenessContractVersion: SDD_COMPLETENESS_CONTRACT_VERSION,
     }),
   };
 };

--- a/integrations/sdd/types.ts
+++ b/integrations/sdd/types.ts
@@ -11,7 +11,8 @@ export type SddDecisionCode =
   | 'SDD_CHANGE_ARCHIVED'
   | 'SDD_VALIDATION_FAILED'
   | 'SDD_VALIDATION_ERROR'
-  | 'SDD_VALIDATION_EMPTY_SCOPE';
+  | 'SDD_VALIDATION_EMPTY_SCOPE'
+  | 'SDD_CHANGE_INCOMPLETE';
 
 export type SddDecision = {
   allowed: boolean;


### PR DESCRIPTION
## Summary
- add strict completeness contract for active SDD change in PRE_PUSH/CI
- require `proposal.md`, `tasks.md`, and `scenario.feature` with `Feature:` + `Scenario:` markers
- block with explicit code `SDD_CHANGE_INCOMPLETE` and machine-readable details (`missingRequirements`, `contractVersion`)
- keep override hook via `PUMUKI_SDD_ENFORCE_COMPLETENESS=0`
- add regression tests in `policy.test.ts`

## Validation
- npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/policy.test.ts
- npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/cli.test.ts integrations/sdd/__tests__/types.test.ts
- npm run -s typecheck

Closes #532
