### PR TITLE
feat: formal gate waivers with TTL owner reason (#534)

### DIFF
--- a/integrations/git/__tests__/gateWaiver.test.ts
+++ b/integrations/git/__tests__/gateWaiver.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { withTempDir } from '../../__tests__/helpers/tempDir';
+import { resolveActiveGateWaiver } from '../gateWaiver';
+
+test('resolveActiveGateWaiver aplica waiver válido por stage y branch', async () => {
+  await withTempDir('pumuki-gate-waiver-valid-', async (repoRoot) => {
+    const waiverDir = join(repoRoot, '.pumuki', 'waivers');
+    mkdirSync(waiverDir, { recursive: true });
+    writeFileSync(
+      join(waiverDir, 'gate.json'),
+      JSON.stringify(
+        {
+          version: '1',
+          waivers: [
+            {
+              id: 'waiver-valid-1',
+              stage: 'PRE_PUSH',
+              reason: 'maintenance window',
+              owner: 'tech-lead',
+              approved_at: '2026-03-03T20:00:00.000Z',
+              expires_at: '2099-12-31T23:59:59.000Z',
+              branch: 'feature/x',
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const result = resolveActiveGateWaiver({
+      repoRoot,
+      stage: 'PRE_PUSH',
+      branch: 'feature/x',
+    });
+
+    assert.equal(result.kind, 'applied');
+    if (result.kind === 'applied') {
+      assert.equal(result.waiver.id, 'waiver-valid-1');
+      assert.equal(result.waiver.owner, 'tech-lead');
+    }
+  });
+});
+
+test('resolveActiveGateWaiver devuelve expired cuando el waiver de stage está caducado', async () => {
+  await withTempDir('pumuki-gate-waiver-expired-', async (repoRoot) => {
+    const waiverDir = join(repoRoot, '.pumuki', 'waivers');
+    mkdirSync(waiverDir, { recursive: true });
+    writeFileSync(
+      join(waiverDir, 'gate.json'),
+      JSON.stringify(
+        {
+          version: '1',
+          waivers: [
+            {
+              id: 'waiver-expired-1',
+              stage: 'PRE_COMMIT',
+              reason: 'legacy stabilization',
+              owner: 'platform-owner',
+              approved_at: '2024-01-01T00:00:00.000Z',
+              expires_at: '2024-01-15T00:00:00.000Z',
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const result = resolveActiveGateWaiver({
+      repoRoot,
+      stage: 'PRE_COMMIT',
+      branch: 'feature/x',
+      now: new Date('2026-03-03T00:00:00.000Z'),
+    });
+
+    assert.equal(result.kind, 'expired');
+    if (result.kind === 'expired') {
+      assert.equal(result.waiver.id, 'waiver-expired-1');
+    }
+  });
+});
+
+test('resolveActiveGateWaiver devuelve invalid para waiver malformado', async () => {
+  await withTempDir('pumuki-gate-waiver-invalid-', async (repoRoot) => {
+    const waiverDir = join(repoRoot, '.pumuki', 'waivers');
+    mkdirSync(waiverDir, { recursive: true });
+    writeFileSync(
+      join(waiverDir, 'gate.json'),
+      JSON.stringify(
+        {
+          version: '1',
+          waivers: [
+            {
+              id: 'waiver-invalid-1',
+              stage: 'CI',
+              reason: 'missing owner field',
+              approved_at: '2026-03-03T20:00:00.000Z',
+              expires_at: '2099-12-31T23:59:59.000Z',
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const result = resolveActiveGateWaiver({
+      repoRoot,
+      stage: 'CI',
+      branch: 'feature/x',
+    });
+
+    assert.equal(result.kind, 'invalid');
+    if (result.kind === 'invalid') {
+      assert.match(result.reason, /expected string/i);
+    }
+  });
+});

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -1449,7 +1449,7 @@ test('runPlatformGate bloquea cuando el scope de archivos exige skills activas/e
   let emittedArgs:
     | {
       findings: ReadonlyArray<Finding>;
-      gateOutcome: 'ALLOW' | 'WARN' | 'BLOCK';
+      gateOutcome: 'PASS' | 'ALLOW' | 'WARN' | 'BLOCK';
     }
     | undefined;
 
@@ -1608,6 +1608,302 @@ test('runPlatformGate permite cuando el scope de archivos tiene prefijos de skil
       (finding) => finding.ruleId === 'governance.skills.scope-compliance.incomplete'
     ),
     false
+  );
+});
+
+test('runPlatformGate permite continuar cuando existe waiver de gate válido para stage bloqueante', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'repo' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedArgs:
+    | {
+      findings: ReadonlyArray<Finding>;
+      gateOutcome: 'PASS' | 'ALLOW' | 'WARN' | 'BLOCK';
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: 0,
+          filesScanned: 0,
+          rulesTotal: 1,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 0,
+          projectRules: 1,
+          matchedRules: 1,
+          unmatchedRules: 0,
+          unevaluatedRules: 0,
+          activeRuleIds: ['project.blocking.rule'],
+          evaluatedRuleIds: ['project.blocking.rule'],
+          matchedRuleIds: ['project.blocking.rule'],
+          unmatchedRuleIds: [],
+          unevaluatedRuleIds: [],
+        },
+        findings: [
+          {
+            ruleId: 'project.blocking.rule',
+            severity: 'ERROR',
+            code: 'PROJECT_BLOCKING_RULE',
+            message: 'blocking test rule',
+            filePath: 'src/blocking.ts',
+          },
+        ],
+      }),
+      evaluateGate: () => ({ outcome: 'BLOCK' }),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      resolveActiveGateWaiver: () => ({
+        kind: 'applied',
+        path: '.pumuki/waivers/gate.json',
+        waiver: {
+          id: 'waiver-1',
+          stage: 'PRE_PUSH',
+          reason: 'maintenance',
+          owner: 'tech-lead',
+          approved_at: '2026-03-03T20:00:00.000Z',
+          expires_at: '2099-12-31T23:59:59.000Z',
+        },
+      }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedArgs = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  assert.equal(emittedArgs?.gateOutcome, 'PASS');
+  assert.equal(
+    emittedArgs?.findings.some((finding) => finding.ruleId === 'governance.waiver.applied'),
+    true
+  );
+});
+
+test('runPlatformGate bloquea cuando el waiver de gate está expirado', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'repo' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedArgs:
+    | {
+      findings: ReadonlyArray<Finding>;
+      gateOutcome: 'ALLOW' | 'WARN' | 'BLOCK';
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: 0,
+          filesScanned: 0,
+          rulesTotal: 1,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 0,
+          projectRules: 1,
+          matchedRules: 1,
+          unmatchedRules: 0,
+          unevaluatedRules: 0,
+          activeRuleIds: ['project.blocking.rule'],
+          evaluatedRuleIds: ['project.blocking.rule'],
+          matchedRuleIds: ['project.blocking.rule'],
+          unmatchedRuleIds: [],
+          unevaluatedRuleIds: [],
+        },
+        findings: [
+          {
+            ruleId: 'project.blocking.rule',
+            severity: 'ERROR',
+            code: 'PROJECT_BLOCKING_RULE',
+            message: 'blocking test rule',
+            filePath: 'src/blocking.ts',
+          },
+        ],
+      }),
+      evaluateGate: () => ({ outcome: 'BLOCK' }),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      resolveActiveGateWaiver: () => ({
+        kind: 'expired',
+        path: '.pumuki/waivers/gate.json',
+        waiver: {
+          id: 'waiver-expired',
+          stage: 'PRE_PUSH',
+          reason: 'expired maintenance',
+          owner: 'tech-lead',
+          approved_at: '2024-01-01T00:00:00.000Z',
+          expires_at: '2024-01-15T00:00:00.000Z',
+        },
+      }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedArgs = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  assert.equal(emittedArgs?.gateOutcome, 'BLOCK');
+  assert.equal(
+    emittedArgs?.findings.some((finding) => finding.ruleId === 'governance.waiver.expired'),
+    true
+  );
+});
+
+test('runPlatformGate bloquea cuando el waiver de gate es inválido', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'repo' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedArgs:
+    | {
+      findings: ReadonlyArray<Finding>;
+      gateOutcome: 'ALLOW' | 'WARN' | 'BLOCK';
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: 0,
+          filesScanned: 0,
+          rulesTotal: 1,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 0,
+          projectRules: 1,
+          matchedRules: 1,
+          unmatchedRules: 0,
+          unevaluatedRules: 0,
+          activeRuleIds: ['project.blocking.rule'],
+          evaluatedRuleIds: ['project.blocking.rule'],
+          matchedRuleIds: ['project.blocking.rule'],
+          unmatchedRuleIds: [],
+          unevaluatedRuleIds: [],
+        },
+        findings: [
+          {
+            ruleId: 'project.blocking.rule',
+            severity: 'ERROR',
+            code: 'PROJECT_BLOCKING_RULE',
+            message: 'blocking test rule',
+            filePath: 'src/blocking.ts',
+          },
+        ],
+      }),
+      evaluateGate: () => ({ outcome: 'BLOCK' }),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      resolveActiveGateWaiver: () => ({
+        kind: 'invalid',
+        path: '.pumuki/waivers/gate.json',
+        reason: 'invalid schema: owner is required',
+      }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedArgs = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  assert.equal(emittedArgs?.gateOutcome, 'BLOCK');
+  assert.equal(
+    emittedArgs?.findings.some((finding) => finding.ruleId === 'governance.waiver.invalid'),
+    true
   );
 });
 

--- a/integrations/git/gateWaiver.ts
+++ b/integrations/git/gateWaiver.ts
@@ -1,0 +1,143 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+import { z } from 'zod';
+
+const gateWaiverEntrySchema = z.object({
+  id: z.string().min(1),
+  stage: z.enum(['PRE_COMMIT', 'PRE_PUSH', 'CI']),
+  reason: z.string().min(1),
+  owner: z.string().min(1),
+  approved_at: z.string().datetime({ offset: true }),
+  expires_at: z.string().datetime({ offset: true }),
+  branch: z.string().min(1).optional(),
+});
+
+const gateWaiverFileSchema = z.object({
+  version: z.literal('1'),
+  waivers: z.array(gateWaiverEntrySchema),
+});
+
+export type GateWaiverEntry = z.infer<typeof gateWaiverEntrySchema>;
+
+export type GateWaiverResult =
+  | {
+      kind: 'none';
+      path: string;
+    }
+  | {
+      kind: 'invalid';
+      path: string;
+      reason: string;
+    }
+  | {
+      kind: 'expired';
+      path: string;
+      waiver: GateWaiverEntry;
+    }
+  | {
+      kind: 'applied';
+      path: string;
+      waiver: GateWaiverEntry;
+    };
+
+const DEFAULT_GATE_WAIVER_PATH = '.pumuki/waivers/gate.json';
+
+export const resolveGateWaiverPath = (repoRoot: string): string => {
+  const candidate = process.env.PUMUKI_GATE_WAIVER_PATH?.trim();
+  if (!candidate) {
+    return resolve(repoRoot, DEFAULT_GATE_WAIVER_PATH);
+  }
+  if (isAbsolute(candidate)) {
+    return candidate;
+  }
+  return resolve(repoRoot, candidate);
+};
+
+const parseDate = (value: string): Date | null => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+};
+
+export const resolveActiveGateWaiver = (params: {
+  repoRoot: string;
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  branch: string | null;
+  now?: Date;
+}): GateWaiverResult => {
+  const path = resolveGateWaiverPath(params.repoRoot);
+  if (!existsSync(path)) {
+    return {
+      kind: 'none',
+      path,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    const validation = gateWaiverFileSchema.safeParse(parsed);
+    if (!validation.success) {
+      return {
+        kind: 'invalid',
+        path,
+        reason: validation.error.issues[0]?.message ?? 'invalid_schema',
+      };
+    }
+
+    const now = params.now ?? new Date();
+    let expiredCandidate: GateWaiverEntry | undefined;
+
+    for (const waiver of validation.data.waivers) {
+      if (waiver.stage !== params.stage) {
+        continue;
+      }
+      if (waiver.branch && params.branch && waiver.branch !== params.branch) {
+        continue;
+      }
+      if (waiver.branch && !params.branch) {
+        continue;
+      }
+
+      const expiresAt = parseDate(waiver.expires_at);
+      if (!expiresAt) {
+        return {
+          kind: 'invalid',
+          path,
+          reason: `invalid expires_at for waiver ${waiver.id}`,
+        };
+      }
+      if (expiresAt.getTime() <= now.getTime()) {
+        if (!expiredCandidate) {
+          expiredCandidate = waiver;
+        }
+        continue;
+      }
+      return {
+        kind: 'applied',
+        path,
+        waiver,
+      };
+    }
+
+    if (expiredCandidate) {
+      return {
+        kind: 'expired',
+        path,
+        waiver: expiredCandidate,
+      };
+    }
+
+    return {
+      kind: 'none',
+      path,
+    };
+  } catch (error) {
+    return {
+      kind: 'invalid',
+      path,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+};

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -9,6 +9,10 @@ import type { ResolvedStagePolicy } from '../gate/stagePolicies';
 import type { DetectedPlatforms } from '../platform/detectPlatforms';
 import { GitService, type IGitService } from './GitService';
 import { EvidenceService, type IEvidenceService } from './EvidenceService';
+import {
+  resolveActiveGateWaiver,
+  type GateWaiverResult,
+} from './gateWaiver';
 import { evaluatePlatformGateFindings } from './runPlatformGateEvaluation';
 import {
   countScannedFilesFromFacts,
@@ -50,6 +54,11 @@ export type GateDependencies = {
     stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI',
     repoRoot: string
   ) => Pick<SddDecision, 'allowed' | 'code' | 'message'>;
+  resolveActiveGateWaiver: (params: {
+    repoRoot: string;
+    stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+    branch: string | null;
+  }) => GateWaiverResult;
 };
 
 const defaultServices: GateServices = {
@@ -114,6 +123,12 @@ const defaultDependencies: GateDependencies = {
       stage,
       repoRoot,
     }).decision,
+  resolveActiveGateWaiver: ({ repoRoot, stage, branch }) =>
+    resolveActiveGateWaiver({
+      repoRoot,
+      stage,
+      branch,
+    }),
 };
 
 const resolveCurrentBranch = (git: IGitService, repoRoot: string): string | null => {
@@ -327,6 +342,51 @@ const toSkillsScopeComplianceBlockingFinding = (params: {
     source: 'skills-scope-compliance',
   };
 };
+
+const toGateWaiverAppliedFinding = (params: {
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  waiver: Extract<GateWaiverResult, { kind: 'applied' }>['waiver'];
+}): Finding => ({
+  ruleId: 'governance.waiver.applied',
+  severity: 'INFO',
+  code: 'GATE_WAIVER_APPLIED',
+  message:
+    `Gate waiver applied at ${params.stage}: waiver_id=${params.waiver.id} owner=${params.waiver.owner} ` +
+    `expires_at=${params.waiver.expires_at}.`,
+  filePath: '.pumuki/waivers/gate.json',
+  matchedBy: 'GateWaiverGuard',
+  source: 'gate-waiver',
+});
+
+const toGateWaiverExpiredFinding = (params: {
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  waiver: Extract<GateWaiverResult, { kind: 'expired' }>['waiver'];
+}): Finding => ({
+  ruleId: 'governance.waiver.expired',
+  severity: 'ERROR',
+  code: 'GATE_WAIVER_EXPIRED',
+  message:
+    `Gate waiver expired at ${params.stage}: waiver_id=${params.waiver.id} owner=${params.waiver.owner} ` +
+    `expired_at=${params.waiver.expires_at}. Provide a valid waiver or fix blocking findings.`,
+  filePath: '.pumuki/waivers/gate.json',
+  matchedBy: 'GateWaiverGuard',
+  source: 'gate-waiver',
+});
+
+const toGateWaiverInvalidFinding = (params: {
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  reason: string;
+}): Finding => ({
+  ruleId: 'governance.waiver.invalid',
+  severity: 'ERROR',
+  code: 'GATE_WAIVER_INVALID',
+  message:
+    `Gate waiver file is invalid at ${params.stage}: ${params.reason}. ` +
+    'Fix waiver schema or remove invalid waiver before continuing.',
+  filePath: '.pumuki/waivers/gate.json',
+  matchedBy: 'GateWaiverGuard',
+  source: 'gate-waiver',
+});
 
 const toPlatformSkillsCoverageBlockingFinding = (params: {
   stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
@@ -595,7 +655,7 @@ export async function runPlatformGate(params: {
       ]
       : findings;
   const decision = dependencies.evaluateGate([...effectiveFindings], params.policy);
-  const gateOutcome =
+  const baseGateOutcome =
     sddBlockingFinding ||
     unsupportedSkillsMappingFinding ||
     platformSkillsCoverageFinding ||
@@ -604,13 +664,53 @@ export async function runPlatformGate(params: {
     hasTddBddBlockingFinding
       ? 'BLOCK'
       : decision.outcome;
+  const gateWaiverStage =
+    params.policy.stage === 'PRE_COMMIT' ||
+    params.policy.stage === 'PRE_PUSH' ||
+    params.policy.stage === 'CI'
+      ? params.policy.stage
+      : undefined;
+  const gateWaiverResult = gateWaiverStage
+    ? dependencies.resolveActiveGateWaiver({
+        repoRoot,
+        stage: gateWaiverStage,
+        branch: currentBranch,
+      })
+    : ({
+        kind: 'none',
+        path: '.pumuki/waivers/gate.json',
+      } as const);
+  let gateWaiverFinding: Finding | undefined;
+  let gateOutcome = baseGateOutcome;
+  if (baseGateOutcome === 'BLOCK' && gateWaiverStage) {
+    if (gateWaiverResult.kind === 'applied') {
+      gateWaiverFinding = toGateWaiverAppliedFinding({
+        stage: gateWaiverStage,
+        waiver: gateWaiverResult.waiver,
+      });
+      gateOutcome = 'PASS';
+    } else if (gateWaiverResult.kind === 'expired') {
+      gateWaiverFinding = toGateWaiverExpiredFinding({
+        stage: gateWaiverStage,
+        waiver: gateWaiverResult.waiver,
+      });
+    } else if (gateWaiverResult.kind === 'invalid') {
+      gateWaiverFinding = toGateWaiverInvalidFinding({
+        stage: gateWaiverStage,
+        reason: gateWaiverResult.reason,
+      });
+    }
+  }
+  const findingsWithWaiver = gateWaiverFinding
+    ? [...effectiveFindings, gateWaiverFinding]
+    : effectiveFindings;
   const shadowFlagRaw = process.env.PUMUKI_OPERATIONAL_MEMORY_SHADOW_ENABLED?.trim().toLowerCase();
   const isMemoryShadowEnabled = shadowFlagRaw === '1' || shadowFlagRaw === 'true';
   let memoryShadowRecommendation: OperationalMemoryShadowRecommendation | undefined;
   if (isMemoryShadowEnabled) {
     try {
       memoryShadowRecommendation = dependencies.buildMemoryShadowRecommendation({
-        findings: effectiveFindings,
+        findings: findingsWithWaiver,
         ...(tddBddSnapshot ? { tddBddSnapshot } : {}),
       });
     } catch (error) {
@@ -653,7 +753,7 @@ export async function runPlatformGate(params: {
     stage: params.policy.stage,
     auditMode,
     policyTrace: params.policyTrace,
-    findings: effectiveFindings,
+    findings: findingsWithWaiver,
     gateOutcome,
     filesScanned,
     evaluationMetrics,
@@ -670,7 +770,7 @@ export async function runPlatformGate(params: {
   });
 
   if (gateOutcome === 'BLOCK') {
-    dependencies.printGateFindings(effectiveFindings);
+    dependencies.printGateFindings(findingsWithWaiver);
     return 1;
   }
 


### PR DESCRIPTION
## Summary
- add formal gate waiver resolver (`.pumuki/waivers/gate.json`) with schema validation
- require `owner`, `reason`, `approved_at`, `expires_at`, `stage` and optional `branch`
- classify waiver status as `applied`, `expired`, `invalid`, `none`
- integrate waiver flow in `runPlatformGate` for PRE_COMMIT/PRE_PUSH/CI
- apply valid waiver to unblock with auditable INFO finding
- keep blocking when waiver is invalid or expired with explicit ERROR findings
- add tests for valid/expired/malformed waiver and gate integration

## Validation
- npx --yes tsx@4.21.0 --test integrations/git/__tests__/gateWaiver.test.ts integrations/git/__tests__/runPlatformGate.test.ts
- npm run -s typecheck

Closes #534
