### PR TITLE
fix: prevent ios.no-force-unwrap false positives outside Swift scope

### DIFF
--- a/core/gate/conditionMatches.test.ts
+++ b/core/gate/conditionMatches.test.ts
@@ -108,3 +108,37 @@ test('conditionMatches soporta condiciones compuestas All, Any y Not', () => {
 
   assert.equal(conditionMatches(composedCondition, facts), true);
 });
+
+test('conditionMatches respeta include glob swift y no matchea archivos no swift', () => {
+  const scopedCondition: Condition = {
+    kind: 'All',
+    conditions: [
+      {
+        kind: 'FileContent',
+        contains: ['!'],
+      },
+      {
+        kind: 'Not',
+        condition: {
+          kind: 'FileContent',
+          contains: ['IBOutlet'],
+        },
+      },
+    ],
+  };
+  const scopedFacts = [
+    {
+      kind: 'FileContent' as const,
+      path: 'apps/admin-dashboard/middleware.ts',
+      content: 'if (token != null) { return NextResponse.next(); }',
+      source: 'repo',
+    },
+  ];
+
+  assert.equal(
+    conditionMatches(scopedCondition, scopedFacts, {
+      include: ['**/*.swift'],
+    }),
+    false
+  );
+});

--- a/core/gate/conditionMatches.ts
+++ b/core/gate/conditionMatches.ts
@@ -4,6 +4,7 @@ import type { Fact } from '../facts/Fact';
 import type { DependencyFact } from '../facts/DependencyFact';
 import type { FileChangeFact } from '../facts/FileChangeFact';
 import type { FileContentFact } from '../facts/FileContentFact';
+import { matchesScope } from './scopeMatcher';
 
 type RuleScope = RuleDefinition['scope'];
 
@@ -25,27 +26,6 @@ const isDependencyFact = (fact: FactInput): fact is DependencyFact =>
 
 const isHeuristicFact = (fact: FactInput): fact is Extract<Fact, { kind: 'Heuristic' }> =>
   fact.kind === 'Heuristic';
-
-const extractPrefix = (pattern: string): string => {
-  const wildcardIndex = pattern.indexOf('*');
-  return wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex);
-};
-
-const matchesAnyPrefix = (path: string, patterns: ReadonlyArray<string>): boolean => {
-  return patterns.some((pattern) => path.startsWith(extractPrefix(pattern)));
-};
-
-const matchesScope = (path: string, scope?: RuleScope): boolean => {
-  const include = scope?.include;
-  const exclude = scope?.exclude;
-  if (exclude && exclude.length > 0 && matchesAnyPrefix(path, exclude)) {
-    return false;
-  }
-  if (!include || include.length === 0) {
-    return true;
-  }
-  return matchesAnyPrefix(path, include);
-};
 
 const matchesFileChange = (
   condition: Extract<Condition, { kind: 'FileChange' }>,

--- a/core/gate/evaluateRules.test.ts
+++ b/core/gate/evaluateRules.test.ts
@@ -199,3 +199,49 @@ test('evaluateRules genera un finding por cada heuristica coincidente', () => {
   );
   assert.equal(findings.every((finding) => finding.matchedBy === 'Heuristic'), true);
 });
+
+test('evaluateRules no genera finding de iOS cuando el scope es swift y el archivo es TypeScript', () => {
+  const rules: RuleSet = [
+    {
+      id: 'ios.no-force-unwrap',
+      description: 'Disallows force unwraps in iOS code.',
+      severity: 'CRITICAL',
+      scope: {
+        include: ['**/*.swift'],
+      },
+      when: {
+        kind: 'All',
+        conditions: [
+          {
+            kind: 'FileContent',
+            contains: ['!'],
+          },
+          {
+            kind: 'Not',
+            condition: {
+              kind: 'FileContent',
+              contains: ['IBOutlet'],
+            },
+          },
+        ],
+      },
+      then: {
+        kind: 'Finding',
+        message: 'Force unwraps are not allowed in iOS code.',
+        code: 'IOS_NO_FORCE_UNWRAP',
+      },
+    },
+  ];
+  const facts = [
+    {
+      kind: 'FileContent',
+      path: 'apps/admin-dashboard/middleware.ts',
+      content: 'if (token != null) { return NextResponse.next(); }',
+      source: 'repo',
+    },
+  ] as const;
+
+  const findings = evaluateRules(rules, facts);
+
+  assert.deepEqual(findings, []);
+});

--- a/core/gate/evaluateRules.ts
+++ b/core/gate/evaluateRules.ts
@@ -7,6 +7,7 @@ import type { FileChangeFact } from '../facts/FileChangeFact';
 import type { FileContentFact } from '../facts/FileContentFact';
 import type { Finding } from './Finding';
 import { conditionMatches } from './conditionMatches';
+import { matchesScope } from './scopeMatcher';
 
 type FactInput = Fact | FileChangeFact | FileContentFact;
 
@@ -35,30 +36,6 @@ const toFinding = (
     matchedBy: target?.matchedBy,
     source: target?.source,
   };
-};
-
-const extractPrefix = (pattern: string): string => {
-  const wildcardIndex = pattern.indexOf('*');
-  return wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex);
-};
-
-const matchesAnyPrefix = (path: string, patterns: ReadonlyArray<string>): boolean => {
-  return patterns.some((pattern) => path.startsWith(extractPrefix(pattern)));
-};
-
-const matchesScope = (
-  path: string,
-  scope?: RuleDefinition['scope']
-): boolean => {
-  const include = scope?.include;
-  const exclude = scope?.exclude;
-  if (exclude && exclude.length > 0 && matchesAnyPrefix(path, exclude)) {
-    return false;
-  }
-  if (!include || include.length === 0) {
-    return true;
-  }
-  return matchesAnyPrefix(path, include);
 };
 
 const collectSimpleFindingTargets = (

--- a/core/gate/scopeMatcher.ts
+++ b/core/gate/scopeMatcher.ts
@@ -1,0 +1,85 @@
+type ScopePattern = {
+  include?: ReadonlyArray<string>;
+  exclude?: ReadonlyArray<string>;
+};
+
+const normalizePath = (value: string): string => {
+  return value.replace(/\\/g, '/');
+};
+
+const escapeRegex = (value: string): string => {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+};
+
+const toGlobRegex = (pattern: string): RegExp => {
+  let regex = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const current = pattern[index];
+    if (current === '*') {
+      const next = pattern[index + 1];
+      if (next === '*') {
+        const nextNext = pattern[index + 2];
+        if (nextNext === '/') {
+          regex += '(?:.*/)?';
+          index += 2;
+        } else {
+          regex += '.*';
+          index += 1;
+        }
+      } else {
+        regex += '[^/]*';
+      }
+      continue;
+    }
+    if (current === '?') {
+      regex += '[^/]';
+      continue;
+    }
+    regex += escapeRegex(current);
+  }
+  regex += '$';
+  return new RegExp(regex);
+};
+
+const extractPrefix = (pattern: string): string => {
+  const wildcardIndex = pattern.search(/[*?]/);
+  return wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex);
+};
+
+const isTrailingWildcardPattern = (pattern: string): boolean => {
+  const wildcardIndex = pattern.search(/[*?]/);
+  if (wildcardIndex === -1) {
+    return false;
+  }
+  const suffix = pattern.slice(wildcardIndex);
+  return /^[*?]+$/.test(suffix);
+};
+
+export const matchesPattern = (path: string, pattern: string): boolean => {
+  const normalizedPath = normalizePath(path);
+  const normalizedPattern = normalizePath(pattern);
+  const wildcardIndex = normalizedPattern.search(/[*?]/);
+  if (wildcardIndex === -1) {
+    return normalizedPath.startsWith(normalizedPattern);
+  }
+  if (isTrailingWildcardPattern(normalizedPattern)) {
+    return normalizedPath.startsWith(extractPrefix(normalizedPattern));
+  }
+  return toGlobRegex(normalizedPattern).test(normalizedPath);
+};
+
+const matchesAnyPattern = (path: string, patterns: ReadonlyArray<string>): boolean => {
+  return patterns.some((pattern) => matchesPattern(path, pattern));
+};
+
+export const matchesScope = (path: string, scope?: ScopePattern): boolean => {
+  const include = scope?.include;
+  const exclude = scope?.exclude;
+  if (exclude && exclude.length > 0 && matchesAnyPattern(path, exclude)) {
+    return false;
+  }
+  if (!include || include.length === 0) {
+    return true;
+  }
+  return matchesAnyPattern(path, include);
+};

--- a/integrations/git/__tests__/findingTraceability.test.ts
+++ b/integrations/git/__tests__/findingTraceability.test.ts
@@ -239,3 +239,66 @@ test('attachFindingTraceability mantiene finding sin contexto cuando la regla es
   assert.equal(traced[0]?.filePath, undefined);
   assert.equal(traced[0]?.lines, undefined);
 });
+
+test('attachFindingTraceability no adjunta contexto cuando scope iOS usa glob swift y el finding proviene de archivo TS', () => {
+  const rules: RuleSet = [
+    {
+      id: 'ios.no-force-unwrap',
+      description: 'Disallows force unwraps in iOS code.',
+      severity: 'CRITICAL',
+      when: {
+        kind: 'All',
+        conditions: [
+          {
+            kind: 'FileContent',
+            contains: ['!'],
+          },
+          {
+            kind: 'Not',
+            condition: {
+              kind: 'FileContent',
+              contains: ['IBOutlet'],
+            },
+          },
+        ],
+      },
+      then: {
+        kind: 'Finding',
+        code: 'IOS_NO_FORCE_UNWRAP',
+        message: 'Force unwraps are not allowed in iOS code.',
+      },
+      scope: {
+        include: ['**/*.swift'],
+      },
+    },
+  ];
+
+  const facts: ReadonlyArray<Fact> = [
+    {
+      kind: 'FileContent',
+      path: 'apps/admin-dashboard/middleware.ts',
+      content: 'if (token != null) { return NextResponse.next(); }',
+      source: 'git:staged',
+    },
+  ];
+
+  const findings: ReadonlyArray<Finding> = [
+    {
+      ruleId: 'ios.no-force-unwrap',
+      severity: 'CRITICAL',
+      code: 'IOS_NO_FORCE_UNWRAP',
+      message: 'Force unwraps are not allowed in iOS code.',
+      filePath: 'apps/admin-dashboard/middleware.ts',
+    },
+  ];
+
+  const traced = attachFindingTraceability({
+    findings,
+    rules,
+    facts,
+  });
+
+  assert.equal(traced[0]?.filePath, 'apps/admin-dashboard/middleware.ts');
+  assert.equal(traced[0]?.lines, undefined);
+  assert.equal(traced[0]?.matchedBy, undefined);
+});

--- a/integrations/git/findingTraceability.ts
+++ b/integrations/git/findingTraceability.ts
@@ -3,6 +3,7 @@ import type { Finding } from '../../core/gate/Finding';
 import type { Condition } from '../../core/rules/Condition';
 import type { RuleDefinition } from '../../core/rules/RuleDefinition';
 import type { RuleSet } from '../../core/rules/RuleSet';
+import { matchesScope } from '../../core/gate/scopeMatcher';
 
 type Trace = {
   matched: boolean;
@@ -13,27 +14,6 @@ type Trace = {
 };
 
 type RuleScope = RuleDefinition['scope'];
-
-const extractPrefix = (pattern: string): string => {
-  const wildcardIndex = pattern.indexOf('*');
-  return wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex);
-};
-
-const matchesAnyPrefix = (path: string, patterns: ReadonlyArray<string>): boolean => {
-  return patterns.some((pattern) => path.startsWith(extractPrefix(pattern)));
-};
-
-const matchesScope = (path: string, scope?: RuleScope): boolean => {
-  const include = scope?.include;
-  const exclude = scope?.exclude;
-  if (exclude && exclude.length > 0 && matchesAnyPrefix(path, exclude)) {
-    return false;
-  }
-  if (!include || include.length === 0) {
-    return true;
-  }
-  return matchesAnyPrefix(path, include);
-};
 
 const normalizePath = (path: string): string => path.replace(/\\/g, '/');
 


### PR DESCRIPTION
## Summary
- introduce a shared scope matcher that honors glob semantics for include/exclude patterns
- ensure `**/*.swift` does not match non-Swift files like `middleware.ts`
- reuse the matcher in rule evaluation, condition matching, and finding traceability

## Why
This closes false positive `ios.no-force-unwrap` findings triggered by TypeScript expressions like `token != null`.

Closes #538.

## Validation
- `npx --yes tsx@4.21.0 --test core/gate/conditionMatches.test.ts core/gate/evaluateRules.test.ts integrations/git/__tests__/findingTraceability.test.ts`
- `npm run -s typecheck`
