### PR TITLE
feat: policy-as-code trace metadata and strict validation guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,39 @@ Rule modes:
 9. Provider-agnostic adapter scaffolding (`codex`, `claude`, `cursor`, `windsurf`, `opencode`).
 10. Optional MCP servers for evidence and enterprise context.
 
+## Policy-as-Code (Enterprise)
+
+Pumuki supports a signed and versioned stage-policy contract at:
+
+- `.pumuki/policy-as-code.json`
+
+Minimal contract:
+
+```json
+{
+  "version": "1.0",
+  "source": "default",
+  "expires_at": "2026-12-31T23:59:59.000Z",
+  "signatures": {
+    "PRE_COMMIT": "<sha256-hex>",
+    "PRE_PUSH": "<sha256-hex>",
+    "CI": "<sha256-hex>"
+  }
+}
+```
+
+Runtime behavior:
+
+- If the contract is missing, Pumuki computes deterministic local metadata and still emits `policy_version`, `policy_signature`, and `policy_source`.
+- If present, the contract is validated against active runtime policy for source/stage/signature.
+- Validation states are emitted as `valid`, `invalid`, `expired`, or `unknown-source`.
+- `PUMUKI_POLICY_STRICT=1` turns non-valid states into blocking findings (`governance.policy-as-code.invalid`).
+
+Operational fallback:
+
+- Keep strict mode disabled while bootstrapping a repo without a canonical contract.
+- Enable strict mode once contract generation/signatures are part of your baseline pipeline.
+
 ## Framework Maintainer Flow (This Repo)
 
 Use this only when working in the Pumuki framework repository itself:

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T40` (ejecutar implementación técnica de `#543` policy-as-code versionada/firmada con RED->GREEN->REFACTOR).
+- Task activa (`🚧`): `P12.F1.T40` (ejecutar implementación técnica de `#543` policy-as-code versionada/firmada con RED->GREEN->REFACTOR; pendiente cierre por checks remotos).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T40` (ejecutar implementación técnica de `#543` policy-as-code versionada/firmada con RED->GREEN->REFACTOR; pendiente cierre por checks remotos).
+- Task activa (`🚧`): `P12.F1.T41` (desbloquear cierre administrativo de `#543`: merge de `#545` + cierre issue cuando checks remotos estén operativos).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T38` (crear issue de policy-as-code versionada/firmada y trazarla en canónicos).
+- Task activa (`🚧`): `P12.F1.T40` (ejecutar implementación técnica de `#543` policy-as-code versionada/firmada con RED->GREEN->REFACTOR).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1243,7 +1243,7 @@ Criterio de salida F5:
     - `gh issue create --title "[P2][OPS] Telemetría estructurada exportable (JSONL/OTel) para auditoría enterprise" ...`
     - edición de `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`
     - edición de `R_GO/ruralgo-master-plan.md`
-- 🚧 `P12.F1.T40` Ejecutar implementación técnica de la mejora estratégica `#543` (policy-as-code versionada/firmada) en Pumuki con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
+- ⛔ `P12.F1.T40` Ejecutar implementación técnica de la mejora estratégica `#543` (policy-as-code versionada/firmada) en Pumuki con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
   - avance en curso:
     - rama de implementación: `feature/543-policy-as-code-signed`.
     - commits técnicos:
@@ -1266,7 +1266,7 @@ Criterio de salida F5:
     - `gh pr checks 545 --json name,state,bucket,link,description`
     - `gh run view 22647944444 --job 65640392393 --log`
 
-- ⏳ `P12.F1.T41` Desbloquear cierre administrativo de `#543` (merge PR `#545` + cierre issue `#543`) cuando los checks remotos vuelvan a estado operativo.
+- 🚧 `P12.F1.T41` Desbloquear cierre administrativo de `#543` (merge PR `#545` + cierre issue `#543`) cuando los checks remotos vuelvan a estado operativo.
   - salida esperada:
     - PR `#545` mergeada en `develop`.
     - issue `#543` en estado `CLOSED` con referencia de PR/commit de merge.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1271,6 +1271,14 @@ Criterio de salida F5:
     - PR `#545` mergeada en `develop`.
     - issue `#543` en estado `CLOSED` con referencia de PR/commit de merge.
     - trazabilidad actualizada en tracking activo.
+  - bloqueo reproducido (comando/error):
+    - comando: `gh pr checks 545 --json name,state,bucket,link,description`
+    - error observado: `security/snyk (swiftenprofundidad) => ERROR: You have used your limit of private tests`.
+    - comando: `gh run view 22647944444 --job 65640392393 --log`
+    - error observado: `log not found: 65640392393`.
+  - corrección mínima propuesta:
+    - restaurar cuota/permisos de `Snyk` para checks de PR o desactivar temporalmente ese check como requerido.
+    - asegurar retención/publicación de logs de Actions para permitir diagnóstico de fallos reales.
 
 - ⏳ `P12.F1.T42` Sincronizar canónico RuralGO tras cierre de `#543` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1244,6 +1244,13 @@ Criterio de salida F5:
     - edición de `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`
     - edición de `R_GO/ruralgo-master-plan.md`
 - 🚧 `P12.F1.T40` Ejecutar implementación técnica de la mejora estratégica `#543` (policy-as-code versionada/firmada) en Pumuki con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
+  - avance en curso:
+    - rama de implementación: `feature/543-policy-as-code-signed`.
+    - commit técnico principal: `a24bf6c` (`feat(gate): add policy-as-code trace metadata and strict validation guard`).
+    - PR abierta: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/545`.
+    - tests/verificación ejecutados en verde:
+      - `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/EvidenceService.test.ts`
+      - `npm run -s typecheck`
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1246,11 +1246,36 @@ Criterio de salida F5:
 - 🚧 `P12.F1.T40` Ejecutar implementación técnica de la mejora estratégica `#543` (policy-as-code versionada/firmada) en Pumuki con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
   - avance en curso:
     - rama de implementación: `feature/543-policy-as-code-signed`.
-    - commit técnico principal: `a24bf6c` (`feat(gate): add policy-as-code trace metadata and strict validation guard`).
+    - commits técnicos:
+      - `a24bf6c` (`feat(gate): add policy-as-code trace metadata and strict validation guard`).
+      - `594a83c` (`feat(policy): add contract expiry validation and strict blocking coverage`).
     - PR abierta: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/545`.
     - tests/verificación ejecutados en verde:
-      - `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/EvidenceService.test.ts`
+      - `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/git/__tests__/EvidenceService.test.ts`
       - `npm run -s typecheck`
+    - alcance DoD cubierto en branch:
+      - contrato `policy-as-code` con validación runtime `valid/invalid/expired/unknown-source`.
+      - bloqueo strict (`PUMUKI_POLICY_STRICT=1`) con códigos explícitos de policy.
+      - documentación operativa mínima añadida en `README.md`.
+  - bloqueo actual:
+    - checks remotos de GitHub Actions en `#545` fallan de forma sistémica y sin logs recuperables (`log not found` en `gh run view --log`).
+    - `security/snyk` reporta límite de cuota privada (`You have used your limit of private tests`).
+    - pendiente decisión de merge cuando se desbloquee infraestructura/checks remotos.
+  - evidencia:
+    - `gh pr view 545 --json state,mergeStateStatus,statusCheckRollup,headRefOid,url`
+    - `gh pr checks 545 --json name,state,bucket,link,description`
+    - `gh run view 22647944444 --job 65640392393 --log`
+
+- ⏳ `P12.F1.T41` Desbloquear cierre administrativo de `#543` (merge PR `#545` + cierre issue `#543`) cuando los checks remotos vuelvan a estado operativo.
+  - salida esperada:
+    - PR `#545` mergeada en `develop`.
+    - issue `#543` en estado `CLOSED` con referencia de PR/commit de merge.
+    - trazabilidad actualizada en tracking activo.
+
+- ⏳ `P12.F1.T42` Sincronizar canónico RuralGO tras cierre de `#543` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
+  - salida esperada:
+    - `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` actualizado a `FIXED` para `PUMUKI-INC-055`.
+    - `R_GO/ruralgo-master-plan.md` con leyenda actualizada (solo 1 `🚧` activa) y referencia de issue/PR/commit.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1280,11 +1280,14 @@ Criterio de salida F5:
     - issue `#543` en estado `CLOSED` con referencia de PR/commit de merge.
     - trazabilidad actualizada en tracking activo.
   - bloqueo reproducido (comando/error):
+    - comando: `gh run view 22648051050`
+    - error observado: `The job was not started because your account is locked due to a billing issue.` (anotación repetida en todos los jobs de `CI`).
     - comando: `gh pr checks 545 --json name,state,bucket,link,description`
     - error observado: `security/snyk (swiftenprofundidad) => ERROR: You have used your limit of private tests`.
     - comando: `gh run view 22647944444 --job 65640392393 --log`
     - error observado: `log not found: 65640392393`.
   - corrección mínima propuesta:
+    - desbloquear billing de la cuenta/organización de GitHub Actions (el run no inicia jobs por lock de facturación).
     - restaurar cuota/permisos de `Snyk` para checks de PR o desactivar temporalmente ese check como requerido.
     - asegurar retención/publicación de logs de Actions para permitir diagnóstico de fallos reales.
   - evidencia adicional:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1267,6 +1267,7 @@ Criterio de salida F5:
     - `gh run view 22647944444 --job 65640392393 --log`
 
 - 🚧 `P12.F1.T41` Desbloquear cierre administrativo de `#543` (merge PR `#545` + cierre issue `#543`) cuando los checks remotos vuelvan a estado operativo.
+  - issue operativa de soporte creada: `#546` (`ops: unblock remote PR checks (snyk quota + missing job logs)`).
   - salida esperada:
     - PR `#545` mergeada en `develop`.
     - issue `#543` en estado `CLOSED` con referencia de PR/commit de merge.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1213,7 +1213,37 @@ Criterio de salida F5:
     - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO push origin HEAD`
     - `npx --yes --package pumuki@latest pumuki-pre-commit` (hook gate `ALLOW/PASS` durante commit en `R_GO`)
     - `npx --yes --package pumuki@latest pumuki-pre-push` (hook gate `ALLOW/PASS` durante push en `R_GO`)
-- 🚧 `P12.F1.T38` Crear issue de mejora estratégica pendiente: policy-as-code versionada/firmada (backlog enterprise) y dejarla trazada en canónico + master plan.
+- ✅ `P12.F1.T38` Crear issue de mejora estratégica pendiente: policy-as-code versionada/firmada (backlog enterprise) y dejarla trazada en canónico + master plan.
+  - cierre ejecutado:
+    - issue creada en `ast-intelligence-hooks`: `#543` -> `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/543`.
+    - canónico RuralGO actualizado:
+      - `PUMUKI-INC-055` añadido como `REPORTED (#543)`.
+      - consolidación por causa raíz extendida con fila `policy-as-code`.
+      - trazabilidad de ejecución extendida con fila `REPORTED` para issue `#543`.
+    - master plan RuralGO actualizado:
+      - `ruralgo-master-plan.md` con `Issue #538` en `✅`.
+      - mejora estratégica `policy-as-code` promovida a `🚧` con referencia a `#543`.
+  - evidencia:
+    - `gh issue create --title "feature: policy-as-code versionada y firmada para gates enterprise" ...`
+    - edición de `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`
+    - edición de `R_GO/ruralgo-master-plan.md`
+    - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO commit -m "docs(validation): sync canonical feedback for issue 538"`
+    - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO push origin HEAD`
+- ✅ `P12.F1.T39` Ejecutar siguiente mejora estratégica: crear issue de telemetría estructurada exportable (JSONL/OTel) y trazarla en canónico + master plan.
+  - cierre ejecutado:
+    - issue creada en `ast-intelligence-hooks`: `#544` -> `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/544`.
+    - canónico RuralGO actualizado:
+      - `PUMUKI-INC-056` añadido como `⏳ REPORTED (#544)`.
+      - consolidación por causa raíz extendida con fila `telemetría estructurada exportable`.
+      - trazabilidad de ejecución extendida con fila `REPORTED` para issue `#544`.
+    - master plan RuralGO actualizado:
+      - `ruralgo-master-plan.md` mantiene `#543` como única `🚧`.
+      - mejora estratégica `telemetría` mantiene estado `⏳` y añade referencia a `Issue #544`.
+  - evidencia:
+    - `gh issue create --title "[P2][OPS] Telemetría estructurada exportable (JSONL/OTel) para auditoría enterprise" ...`
+    - edición de `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`
+    - edición de `R_GO/ruralgo-master-plan.md`
+- 🚧 `P12.F1.T40` Ejecutar implementación técnica de la mejora estratégica `#543` (policy-as-code versionada/firmada) en Pumuki con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1268,6 +1268,13 @@ Criterio de salida F5:
 
 - 🚧 `P12.F1.T41` Desbloquear cierre administrativo de `#543` (merge PR `#545` + cierre issue `#543`) cuando los checks remotos vuelvan a estado operativo.
   - issue operativa de soporte creada: `#546` (`ops: unblock remote PR checks (snyk quota + missing job logs)`).
+  - avance ejecutado:
+    - reintento de runs fallidos lanzado en lote (`gh run rerun <run_id> --failed`) para descartar flake.
+    - resultados tras rerun: `run_attempt=2` y estado `completed/failure` en todos los workflows afectados (sin recuperación automática).
+    - diagnóstico estructural confirmado en GitHub Actions:
+      - jobs de `CI` con `steps_count=0` en attempt 2.
+      - ZIP de logs del run disponible, pero solo contiene `system.txt` (sin logs de pasos de ejecución).
+    - issue `#543` y PR `#545` actualizadas con comentario de progreso y bloqueo remoto.
   - salida esperada:
     - PR `#545` mergeada en `develop`.
     - issue `#543` en estado `CLOSED` con referencia de PR/commit de merge.
@@ -1280,6 +1287,11 @@ Criterio de salida F5:
   - corrección mínima propuesta:
     - restaurar cuota/permisos de `Snyk` para checks de PR o desactivar temporalmente ese check como requerido.
     - asegurar retención/publicación de logs de Actions para permitir diagnóstico de fallos reales.
+  - evidencia adicional:
+    - `python3 /Users/juancarlosmerlosalbarracin/.codex/skills/gh-fix-ci/scripts/inspect_pr_checks.py --repo . --pr 545 --json`
+    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22648051050/jobs --jq '.jobs[] | {id,run_attempt,name,status,conclusion,steps_count:(.steps|length)}'`
+    - `gh api repos/SwiftEnProfundidad/ast-intelligence-hooks/actions/runs/22648051050/logs > /tmp/gh-logs/run-22648051050.zip`
+    - `unzip -l /tmp/gh-logs/run-22648051050.zip`
 
 - ⏳ `P12.F1.T42` Sincronizar canónico RuralGO tras cierre de `#543` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/integrations/evidence/schema.ts
+++ b/integrations/evidence/schema.ts
@@ -89,7 +89,7 @@ export type RulesetState = {
   version?: string;
   signature?: string;
   source?: string;
-  validation_status?: 'valid' | 'invalid' | 'unknown-source';
+  validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source';
   validation_code?: string;
 };
 

--- a/integrations/evidence/schema.ts
+++ b/integrations/evidence/schema.ts
@@ -86,6 +86,11 @@ export type RulesetState = {
   platform: string;
   bundle: string;
   hash: string;
+  version?: string;
+  signature?: string;
+  source?: string;
+  validation_status?: 'valid' | 'invalid' | 'unknown-source';
+  validation_code?: string;
 };
 
 export type HumanIntentConfidence = 'high' | 'medium' | 'low' | 'unset';

--- a/integrations/gate/__tests__/stagePolicies.test.ts
+++ b/integrations/gate/__tests__/stagePolicies.test.ts
@@ -94,6 +94,68 @@ test('resolvePolicyForStage marks unknown-source when policy-as-code contract so
   });
 });
 
+test('resolvePolicyForStage marks expired when policy-as-code contract is out of date', async () => {
+  await withTempDir('pumuki-stage-policy-contract-expired-', async (repoRoot) => {
+    const baseline = resolvePolicyForStage('PRE_PUSH', repoRoot);
+    const prePushSignature = baseline.trace.signature;
+    assert.ok(prePushSignature);
+
+    mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.pumuki', 'policy-as-code.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          source: 'default',
+          expires_at: '2000-01-01T00:00:00.000Z',
+          signatures: {
+            PRE_COMMIT: 'a'.repeat(64),
+            PRE_PUSH: prePushSignature,
+            CI: 'c'.repeat(64),
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const resolved = resolvePolicyForStage('PRE_PUSH', repoRoot);
+    assert.equal(resolved.trace.validation?.status, 'expired');
+    assert.equal(resolved.trace.validation?.code, 'POLICY_AS_CODE_CONTRACT_EXPIRED');
+    assert.equal(resolved.trace.policySource, 'file:.pumuki/policy-as-code.json');
+  });
+});
+
+test('resolvePolicyForStage marks invalid when policy-as-code contract expiry is malformed', async () => {
+  await withTempDir('pumuki-stage-policy-contract-invalid-expiry-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.pumuki', 'policy-as-code.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          source: 'default',
+          expires_at: 'not-an-iso-date',
+          signatures: {
+            PRE_COMMIT: 'a'.repeat(64),
+            PRE_PUSH: 'b'.repeat(64),
+            CI: 'c'.repeat(64),
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const resolved = resolvePolicyForStage('PRE_PUSH', repoRoot);
+    assert.equal(resolved.trace.validation?.status, 'invalid');
+    assert.equal(resolved.trace.validation?.code, 'POLICY_AS_CODE_CONTRACT_INVALID');
+    assert.equal(resolved.trace.policySource, 'file:.pumuki/policy-as-code.json');
+  });
+});
+
 test('applyHeuristicSeverityForStage promueve heurísticas a ERROR en PRE_COMMIT/PRE_PUSH/CI', () => {
   const rules: RuleSet = [
     {

--- a/integrations/gate/__tests__/stagePolicies.test.ts
+++ b/integrations/gate/__tests__/stagePolicies.test.ts
@@ -21,6 +21,11 @@ test('resolvePolicyForStage returns default PRE_PUSH policy when skills policy i
     assert.equal(resolved.trace.source, 'default');
     assert.equal(resolved.trace.bundle, 'gate-policy.default.PRE_PUSH');
     assert.match(resolved.trace.hash, /^[a-f0-9]{64}$/i);
+    assert.equal(resolved.trace.version, 'policy-as-code/default@1.0');
+    assert.match(resolved.trace.signature ?? '', /^[a-f0-9]{64}$/i);
+    assert.equal(resolved.trace.policySource, 'computed-local');
+    assert.equal(resolved.trace.validation?.status, 'valid');
+    assert.equal(resolved.trace.validation?.code, 'POLICY_AS_CODE_VALID');
   });
 });
 
@@ -52,6 +57,40 @@ test('resolvePolicyForStage applies PRE_PUSH override from skills.policy.json', 
     assert.equal(resolved.trace.source, 'skills.policy');
     assert.equal(resolved.trace.bundle, 'gate-policy.skills.policy.PRE_PUSH');
     assert.match(resolved.trace.hash, /^[a-f0-9]{64}$/i);
+    assert.equal(resolved.trace.version, 'policy-as-code/skills.policy@1.0');
+    assert.match(resolved.trace.signature ?? '', /^[a-f0-9]{64}$/i);
+    assert.equal(resolved.trace.policySource, 'computed-local');
+    assert.equal(resolved.trace.validation?.status, 'valid');
+    assert.equal(resolved.trace.validation?.code, 'POLICY_AS_CODE_VALID');
+  });
+});
+
+test('resolvePolicyForStage marks unknown-source when policy-as-code contract source mismatches', async () => {
+  await withTempDir('pumuki-stage-policy-contract-unknown-source-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.pumuki', 'policy-as-code.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          source: 'skills.policy',
+          signatures: {
+            PRE_COMMIT: 'a'.repeat(64),
+            PRE_PUSH: 'b'.repeat(64),
+            CI: 'c'.repeat(64),
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const resolved = resolvePolicyForStage('PRE_PUSH', repoRoot);
+    assert.equal(resolved.trace.source, 'default');
+    assert.equal(resolved.trace.validation?.status, 'unknown-source');
+    assert.equal(resolved.trace.validation?.code, 'POLICY_AS_CODE_UNKNOWN_SOURCE');
+    assert.equal(resolved.trace.policySource, 'file:.pumuki/policy-as-code.json');
   });
 });
 

--- a/integrations/gate/stagePolicies.ts
+++ b/integrations/gate/stagePolicies.ts
@@ -48,10 +48,11 @@ export type ResolvedStagePolicy = {
     signature?: string;
     policySource?: string;
     validation?: {
-      status: 'valid' | 'invalid' | 'unknown-source';
+      status: 'valid' | 'invalid' | 'expired' | 'unknown-source';
       code:
         | 'POLICY_AS_CODE_VALID'
         | 'POLICY_AS_CODE_CONTRACT_INVALID'
+        | 'POLICY_AS_CODE_CONTRACT_EXPIRED'
         | 'POLICY_AS_CODE_SIGNATURE_MISMATCH'
         | 'POLICY_AS_CODE_UNKNOWN_SOURCE';
       message: string;
@@ -201,6 +202,7 @@ type PolicyAsCodeContract = {
   version: '1.0';
   source: 'default' | 'skills.policy' | 'hard-mode';
   signatures: Record<SkillsStage, string>;
+  expires_at?: string;
 };
 
 const isObject = (value: unknown): value is Record<string, unknown> => {
@@ -209,6 +211,13 @@ const isObject = (value: unknown): value is Record<string, unknown> => {
 
 const isSha256Hex = (value: unknown): value is string => {
   return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value);
+};
+
+const isIsoDateString = (value: unknown): value is string => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return Number.isFinite(Date.parse(value));
 };
 
 const policyStrictModeFromEnv = (): boolean => {
@@ -234,6 +243,9 @@ const isPolicyAsCodeContract = (value: unknown): value is PolicyAsCodeContract =
     return false;
   }
   if (!isObject(value.signatures)) {
+    return false;
+  }
+  if (typeof value.expires_at !== 'undefined' && !isIsoDateString(value.expires_at)) {
     return false;
   }
   return (
@@ -353,6 +365,23 @@ const resolvePolicyAsCodeTraceMetadata = (params: {
           strict,
         },
       };
+    }
+
+    if (typeof raw.expires_at === 'string') {
+      const expiresAtTimestamp = Date.parse(raw.expires_at);
+      if (Number.isFinite(expiresAtTimestamp) && Date.now() >= expiresAtTimestamp) {
+        return {
+          version: `policy-as-code/${raw.source}@${raw.version}`,
+          signature: stageSignature,
+          policySource: `file:${POLICY_AS_CODE_CONTRACT_PATH}`,
+          validation: {
+            status: 'expired',
+            code: 'POLICY_AS_CODE_CONTRACT_EXPIRED',
+            message: `Policy-as-code contract expired at ${raw.expires_at}.`,
+            strict,
+          },
+        };
+      }
     }
 
     return {

--- a/integrations/gate/stagePolicies.ts
+++ b/integrations/gate/stagePolicies.ts
@@ -44,6 +44,19 @@ export type ResolvedStagePolicy = {
     source: 'default' | 'skills.policy' | 'hard-mode';
     bundle: string;
     hash: string;
+    version?: string;
+    signature?: string;
+    policySource?: string;
+    validation?: {
+      status: 'valid' | 'invalid' | 'unknown-source';
+      code:
+        | 'POLICY_AS_CODE_VALID'
+        | 'POLICY_AS_CODE_CONTRACT_INVALID'
+        | 'POLICY_AS_CODE_SIGNATURE_MISMATCH'
+        | 'POLICY_AS_CODE_UNKNOWN_SOURCE';
+      message: string;
+      strict: boolean;
+    };
   };
 };
 
@@ -181,6 +194,192 @@ const hardModePolicyProfileByStage: Record<
 };
 
 const HARD_MODE_CONFIG_PATH = '.pumuki/hard-mode.json';
+const POLICY_AS_CODE_CONTRACT_PATH = '.pumuki/policy-as-code.json';
+const POLICY_AS_CODE_VERSION = '1.0';
+
+type PolicyAsCodeContract = {
+  version: '1.0';
+  source: 'default' | 'skills.policy' | 'hard-mode';
+  signatures: Record<SkillsStage, string>;
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const isSha256Hex = (value: unknown): value is string => {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/i.test(value);
+};
+
+const policyStrictModeFromEnv = (): boolean => {
+  const raw = process.env.PUMUKI_POLICY_STRICT?.trim().toLowerCase();
+  if (!raw) {
+    return false;
+  }
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+};
+
+const isPolicyAsCodeContract = (value: unknown): value is PolicyAsCodeContract => {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.version !== '1.0') {
+    return false;
+  }
+  if (
+    value.source !== 'default' &&
+    value.source !== 'skills.policy' &&
+    value.source !== 'hard-mode'
+  ) {
+    return false;
+  }
+  if (!isObject(value.signatures)) {
+    return false;
+  }
+  return (
+    isSha256Hex(value.signatures.PRE_COMMIT) &&
+    isSha256Hex(value.signatures.PRE_PUSH) &&
+    isSha256Hex(value.signatures.CI)
+  );
+};
+
+const createPolicyAsCodeSignature = (params: {
+  stage: SkillsStage;
+  source: 'default' | 'skills.policy' | 'hard-mode';
+  bundle: string;
+  hash: string;
+  version: string;
+}): string => {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        stage: params.stage,
+        source: params.source,
+        bundle: params.bundle,
+        hash: params.hash,
+        version: params.version,
+      })
+    )
+    .digest('hex');
+};
+
+const resolvePolicyAsCodeTraceMetadata = (params: {
+  stage: SkillsStage;
+  source: 'default' | 'skills.policy' | 'hard-mode';
+  bundle: string;
+  hash: string;
+  repoRoot: string;
+}): {
+  version: string;
+  signature: string;
+  policySource: string;
+  validation: NonNullable<ResolvedStagePolicy['trace']['validation']>;
+} => {
+  const strict = policyStrictModeFromEnv();
+  const computedVersion = `policy-as-code/${params.source}@${POLICY_AS_CODE_VERSION}`;
+  const computedSignature = createPolicyAsCodeSignature({
+    stage: params.stage,
+    source: params.source,
+    bundle: params.bundle,
+    hash: params.hash,
+    version: POLICY_AS_CODE_VERSION,
+  });
+  const contractPath = join(params.repoRoot, POLICY_AS_CODE_CONTRACT_PATH);
+
+  if (!existsSync(contractPath)) {
+    return {
+      version: computedVersion,
+      signature: computedSignature,
+      policySource: 'computed-local',
+      validation: {
+        status: 'valid',
+        code: 'POLICY_AS_CODE_VALID',
+        message: 'Policy-as-code metadata generated from active runtime policy.',
+        strict,
+      },
+    };
+  }
+
+  try {
+    const raw: unknown = JSON.parse(readFileSync(contractPath, 'utf8'));
+    if (!isPolicyAsCodeContract(raw)) {
+      return {
+        version: computedVersion,
+        signature: computedSignature,
+        policySource: `file:${POLICY_AS_CODE_CONTRACT_PATH}`,
+        validation: {
+          status: 'invalid',
+          code: 'POLICY_AS_CODE_CONTRACT_INVALID',
+          message: 'Policy-as-code contract is malformed.',
+          strict,
+        },
+      };
+    }
+
+    if (raw.source !== params.source) {
+      return {
+        version: `policy-as-code/${raw.source}@${raw.version}`,
+        signature: raw.signatures[params.stage],
+        policySource: `file:${POLICY_AS_CODE_CONTRACT_PATH}`,
+        validation: {
+          status: 'unknown-source',
+          code: 'POLICY_AS_CODE_UNKNOWN_SOURCE',
+          message:
+            `Policy-as-code contract source mismatch: expected=${params.source} actual=${raw.source}.`,
+          strict,
+        },
+      };
+    }
+
+    const expectedSignature = createPolicyAsCodeSignature({
+      stage: params.stage,
+      source: params.source,
+      bundle: params.bundle,
+      hash: params.hash,
+      version: raw.version,
+    });
+    const stageSignature = raw.signatures[params.stage];
+
+    if (stageSignature !== expectedSignature) {
+      return {
+        version: `policy-as-code/${raw.source}@${raw.version}`,
+        signature: stageSignature,
+        policySource: `file:${POLICY_AS_CODE_CONTRACT_PATH}`,
+        validation: {
+          status: 'invalid',
+          code: 'POLICY_AS_CODE_SIGNATURE_MISMATCH',
+          message:
+            'Policy-as-code signature mismatch for active stage against runtime policy trace.',
+          strict,
+        },
+      };
+    }
+
+    return {
+      version: `policy-as-code/${raw.source}@${raw.version}`,
+      signature: stageSignature,
+      policySource: `file:${POLICY_AS_CODE_CONTRACT_PATH}`,
+      validation: {
+        status: 'valid',
+        code: 'POLICY_AS_CODE_VALID',
+        message: 'Policy-as-code contract verified successfully.',
+        strict,
+      },
+    };
+  } catch {
+    return {
+      version: computedVersion,
+      signature: computedSignature,
+      policySource: `file:${POLICY_AS_CODE_CONTRACT_PATH}`,
+      validation: {
+        status: 'invalid',
+        code: 'POLICY_AS_CODE_CONTRACT_INVALID',
+        message: 'Policy-as-code contract cannot be parsed as JSON.',
+        strict,
+      },
+    };
+  }
+};
 
 const toHardModeProfileName = (value: unknown): HardModeProfileName | null => {
   if (typeof value !== 'string') {
@@ -301,18 +500,30 @@ export const resolvePolicyForStage = (
     const bundle = profileName
       ? `gate-policy.hard-mode.${profileName}.${stage}`
       : `gate-policy.hard-mode.${stage}`;
+    const hash = createPolicyTraceHash({
+      stage,
+      source: 'hard-mode',
+      blockOnOrAbove: hardModePolicy.blockOnOrAbove,
+      warnOnOrAbove: hardModePolicy.warnOnOrAbove,
+      sourcePolicyHash: profileName ?? undefined,
+    });
+    const policyAsCode = resolvePolicyAsCodeTraceMetadata({
+      stage,
+      source: 'hard-mode',
+      bundle,
+      hash,
+      repoRoot,
+    });
     return {
       policy: hardModePolicy,
       trace: {
         source: 'hard-mode',
         bundle,
-        hash: createPolicyTraceHash({
-          stage,
-          source: 'hard-mode',
-          blockOnOrAbove: hardModePolicy.blockOnOrAbove,
-          warnOnOrAbove: hardModePolicy.warnOnOrAbove,
-          sourcePolicyHash: profileName ?? undefined,
-        }),
+        hash,
+        version: policyAsCode.version,
+        signature: policyAsCode.signature,
+        policySource: policyAsCode.policySource,
+        validation: policyAsCode.validation,
       },
     };
   }
@@ -322,17 +533,30 @@ export const resolvePolicyForStage = (
   const stageOverride = loadedPolicy?.stages[stage];
 
   if (!stageOverride) {
+    const bundle = `gate-policy.default.${stage}`;
+    const hash = createPolicyTraceHash({
+      stage,
+      source: 'default',
+      blockOnOrAbove: defaults.blockOnOrAbove,
+      warnOnOrAbove: defaults.warnOnOrAbove,
+    });
+    const policyAsCode = resolvePolicyAsCodeTraceMetadata({
+      stage,
+      source: 'default',
+      bundle,
+      hash,
+      repoRoot,
+    });
     return {
       policy: defaults,
       trace: {
         source: 'default',
-        bundle: `gate-policy.default.${stage}`,
-        hash: createPolicyTraceHash({
-          stage,
-          source: 'default',
-          blockOnOrAbove: defaults.blockOnOrAbove,
-          warnOnOrAbove: defaults.warnOnOrAbove,
-        }),
+        bundle,
+        hash,
+        version: policyAsCode.version,
+        signature: policyAsCode.signature,
+        policySource: policyAsCode.policySource,
+        validation: policyAsCode.validation,
       },
     };
   }
@@ -343,18 +567,31 @@ export const resolvePolicyForStage = (
     warnOnOrAbove: stageOverride.warnOnOrAbove,
   };
 
+  const bundle = `gate-policy.skills.policy.${stage}`;
+  const hash = createPolicyTraceHash({
+    stage,
+    source: 'skills.policy',
+    blockOnOrAbove: resolvedPolicy.blockOnOrAbove,
+    warnOnOrAbove: resolvedPolicy.warnOnOrAbove,
+    sourcePolicyHash: createSkillsPolicyDeterministicHash(loadedPolicy),
+  });
+  const policyAsCode = resolvePolicyAsCodeTraceMetadata({
+    stage,
+    source: 'skills.policy',
+    bundle,
+    hash,
+    repoRoot,
+  });
   return {
     policy: resolvedPolicy,
     trace: {
       source: 'skills.policy',
-      bundle: `gate-policy.skills.policy.${stage}`,
-      hash: createPolicyTraceHash({
-        stage,
-        source: 'skills.policy',
-        blockOnOrAbove: resolvedPolicy.blockOnOrAbove,
-        warnOnOrAbove: resolvedPolicy.warnOnOrAbove,
-        sourcePolicyHash: createSkillsPolicyDeterministicHash(loadedPolicy),
-      }),
+      bundle,
+      hash,
+      version: policyAsCode.version,
+      signature: policyAsCode.signature,
+      policySource: policyAsCode.policySource,
+      validation: policyAsCode.validation,
     },
   };
 };

--- a/integrations/git/EvidenceService.ts
+++ b/integrations/git/EvidenceService.ts
@@ -103,6 +103,15 @@ export class EvidenceService implements IEvidenceService {
         platform: 'policy',
         bundle: params.policyTrace.bundle,
         hash: params.policyTrace.hash,
+        ...(params.policyTrace.version ? { version: params.policyTrace.version } : {}),
+        ...(params.policyTrace.signature ? { signature: params.policyTrace.signature } : {}),
+        ...(params.policyTrace.policySource ? { source: params.policyTrace.policySource } : {}),
+        ...(params.policyTrace.validation
+          ? {
+              validation_status: params.policyTrace.validation.status,
+              validation_code: params.policyTrace.validation.code,
+            }
+          : {}),
       });
     }
 

--- a/integrations/git/__tests__/EvidenceService.test.ts
+++ b/integrations/git/__tests__/EvidenceService.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import { EvidenceService } from '../EvidenceService';
+import { buildEvidenceChain } from '../../evidence/evidenceChain';
 
 const service = new EvidenceService();
 
@@ -45,7 +46,7 @@ test('loadPreviousEvidence returns undefined for wrong version', async () => {
 
 test('loadPreviousEvidence returns evidence for valid v2.1', async () => {
   await withTempDir((dir) => {
-    const evidence = {
+    const evidenceWithoutChain = {
       version: '2.1',
       timestamp: '2026-01-01T00:00:00Z',
       snapshot: { stage: 'PRE_COMMIT', outcome: 'PASS', findings: [] },
@@ -55,6 +56,12 @@ test('loadPreviousEvidence returns evidence for valid v2.1', async () => {
       human_intent: null,
       ai_gate: { status: 'ALLOWED', violations: [], human_intent: null },
       severity_metrics: { gate_status: 'ALLOWED', total_violations: 0, by_severity: {} },
+    };
+    const evidence = {
+      ...evidenceWithoutChain,
+      evidence_chain: buildEvidenceChain({
+        evidence: evidenceWithoutChain as Parameters<typeof buildEvidenceChain>[0]['evidence'],
+      }),
     };
     writeFileSync(join(dir, '.ai_evidence.json'), JSON.stringify(evidence), 'utf8');
     const result = service.loadPreviousEvidence(dir);

--- a/integrations/git/__tests__/hookGateSummary.test.ts
+++ b/integrations/git/__tests__/hookGateSummary.test.ts
@@ -32,6 +32,9 @@ test('runPreCommitStage emite resumen mínimo del gate en éxito', async () => {
         source: 'default',
         bundle: 'gate-policy.default.PRE_COMMIT',
         hash: POLICY_TRACE_HASH,
+        version: 'policy-as-code/default@1.0',
+        signature: 'a'.repeat(64),
+        policySource: 'computed-local',
       },
     }),
     runPlatformGate: async () => 0,
@@ -50,6 +53,9 @@ test('runPreCommitStage emite resumen mínimo del gate en éxito', async () => {
   assert.match(summaries[0] ?? '', /stage=PRE_COMMIT/);
   assert.match(summaries[0] ?? '', /decision=ALLOW/);
   assert.match(summaries[0] ?? '', /policy_hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/);
+  assert.match(summaries[0] ?? '', /policy_version=policy-as-code\/default@1.0/);
+  assert.match(summaries[0] ?? '', /policy_signature=a{64}/);
+  assert.match(summaries[0] ?? '', /policy_source=computed-local/);
   assert.match(summaries[0] ?? '', /evidence_kind=valid/);
   assert.match(summaries[0] ?? '', /evidence_age_seconds=30/);
 });
@@ -69,6 +75,9 @@ test('runPrePushStage respeta --quiet y suprime resumen mínimo en éxito', asyn
         source: 'default',
         bundle: 'gate-policy.default.PRE_PUSH',
         hash: POLICY_TRACE_HASH,
+        version: 'policy-as-code/default@1.0',
+        signature: 'b'.repeat(64),
+        policySource: 'computed-local',
       },
     }),
     runPlatformGate: async () => 0,

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -350,6 +350,75 @@ test('runPlatformGate devuelve 0 y no imprime findings cuando evaluateGate retor
   assert.equal(sddCheckCalled, true);
 });
 
+test('runPlatformGate bloquea en modo strict cuando policy-as-code es inválida', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'staged' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedFindings: ReadonlyArray<Finding> = [];
+
+  const result = await runPlatformGate({
+    policy,
+    policyTrace: {
+      source: 'default',
+      bundle: 'gate-policy.default.PRE_COMMIT',
+      hash: 'f'.repeat(64),
+      version: 'policy-as-code/default@1.0',
+      signature: 'a'.repeat(64),
+      policySource: 'file:.pumuki/policy-as-code.json',
+      validation: {
+        status: 'invalid',
+        code: 'POLICY_AS_CODE_SIGNATURE_MISMATCH',
+        message: 'mismatch',
+        strict: true,
+      },
+    },
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedFindings = paramsArg.findings;
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  const policyFinding = emittedFindings.find(
+    (finding) => finding.ruleId === 'governance.policy-as-code.invalid'
+  );
+  assert.ok(policyFinding);
+  assert.equal(policyFinding?.code, 'POLICY_AS_CODE_SIGNATURE_MISMATCH');
+  assert.equal(policyFinding?.source, 'policy-as-code');
+});
+
 test('runPlatformGate devuelve 1 cuando SDD bloquea PRE_COMMIT', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_COMMIT',

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -419,6 +419,75 @@ test('runPlatformGate bloquea en modo strict cuando policy-as-code es inválida'
   assert.equal(policyFinding?.source, 'policy-as-code');
 });
 
+test('runPlatformGate bloquea en modo strict cuando policy-as-code está expirada', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'range' as const, baseRef: 'origin/develop', headRef: 'HEAD' };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedFindings: ReadonlyArray<Finding> = [];
+
+  const result = await runPlatformGate({
+    policy,
+    policyTrace: {
+      source: 'default',
+      bundle: 'gate-policy.default.PRE_PUSH',
+      hash: 'f'.repeat(64),
+      version: 'policy-as-code/default@1.0',
+      signature: 'a'.repeat(64),
+      policySource: 'file:.pumuki/policy-as-code.json',
+      validation: {
+        status: 'expired',
+        code: 'POLICY_AS_CODE_CONTRACT_EXPIRED',
+        message: 'Policy-as-code contract expired at 2000-01-01T00:00:00.000Z.',
+        strict: true,
+      },
+    },
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedFindings = paramsArg.findings;
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  const policyFinding = emittedFindings.find(
+    (finding) => finding.ruleId === 'governance.policy-as-code.invalid'
+  );
+  assert.ok(policyFinding);
+  assert.equal(policyFinding?.code, 'POLICY_AS_CODE_CONTRACT_EXPIRED');
+  assert.equal(policyFinding?.source, 'policy-as-code');
+});
+
 test('runPlatformGate devuelve 1 cuando SDD bloquea PRE_COMMIT', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_COMMIT',

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -343,6 +343,29 @@ const toSkillsScopeComplianceBlockingFinding = (params: {
   };
 };
 
+const toPolicyAsCodeBlockingFinding = (params: {
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  policyTrace?: ResolvedStagePolicy['trace'];
+}): Finding | undefined => {
+  const validation = params.policyTrace?.validation;
+  if (!validation || validation.status === 'valid' || !validation.strict) {
+    return undefined;
+  }
+
+  return {
+    ruleId: 'governance.policy-as-code.invalid',
+    severity: 'ERROR',
+    code: validation.code,
+    message:
+      `Policy-as-code validation failed at ${params.stage}: ${validation.message} ` +
+      `policy_source=${params.policyTrace?.policySource ?? 'n/a'} ` +
+      `policy_version=${params.policyTrace?.version ?? 'n/a'}.`,
+    filePath: '.pumuki/policy-as-code.json',
+    matchedBy: 'PolicyAsCodeGuard',
+    source: 'policy-as-code',
+  };
+};
+
 const toGateWaiverAppliedFinding = (params: {
   stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
   waiver: Extract<GateWaiverResult, { kind: 'applied' }>['waiver'];
@@ -586,7 +609,16 @@ export async function runPlatformGate(params: {
           stage: params.policy.stage,
           facts,
           activeRuleIds: coverage?.activeRuleIds ?? [],
-          evaluatedRuleIds: coverage?.evaluatedRuleIds ?? [],
+        evaluatedRuleIds: coverage?.evaluatedRuleIds ?? [],
+      })
+      : undefined;
+  const policyAsCodeBlockingFinding =
+    params.policy.stage === 'PRE_COMMIT' ||
+    params.policy.stage === 'PRE_PUSH' ||
+    params.policy.stage === 'CI'
+      ? toPolicyAsCodeBlockingFinding({
+          stage: params.policy.stage,
+          policyTrace: params.policyTrace,
         })
       : undefined;
   const rulesCoverage = coverage
@@ -633,6 +665,7 @@ export async function runPlatformGate(params: {
   const effectiveFindings = sddBlockingFinding
     ? [
       sddBlockingFinding,
+      ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
       ...(unsupportedSkillsMappingFinding ? [unsupportedSkillsMappingFinding] : []),
       ...(platformSkillsCoverageFinding ? [platformSkillsCoverageFinding] : []),
       ...(skillsScopeComplianceFinding ? [skillsScopeComplianceFinding] : []),
@@ -644,8 +677,10 @@ export async function runPlatformGate(params: {
       || platformSkillsCoverageFinding
       || skillsScopeComplianceFinding
       || coverageBlockingFinding
+      || policyAsCodeBlockingFinding
       || tddBddEvaluation.findings.length > 0
       ? [
+        ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
         ...(unsupportedSkillsMappingFinding ? [unsupportedSkillsMappingFinding] : []),
         ...(platformSkillsCoverageFinding ? [platformSkillsCoverageFinding] : []),
         ...(skillsScopeComplianceFinding ? [skillsScopeComplianceFinding] : []),
@@ -657,6 +692,7 @@ export async function runPlatformGate(params: {
   const decision = dependencies.evaluateGate([...effectiveFindings], params.policy);
   const baseGateOutcome =
     sddBlockingFinding ||
+    policyAsCodeBlockingFinding ||
     unsupportedSkillsMappingFinding ||
     platformSkillsCoverageFinding ||
     skillsScopeComplianceFinding ||

--- a/integrations/git/stageRunners.ts
+++ b/integrations/git/stageRunners.ts
@@ -107,10 +107,7 @@ const toEvidenceAgeSeconds = (
 const emitSuccessfulHookGateSummary = (params: {
   dependencies: StageRunnerDependencies;
   stage: 'PRE_COMMIT' | 'PRE_PUSH';
-  policyTrace: {
-    bundle: string;
-    hash: string;
-  };
+  policyTrace: NonNullable<ReturnType<typeof resolvePolicyForStage>['trace']>;
   exitCode: number;
 }): void => {
   if (params.exitCode !== 0 || params.dependencies.isQuietMode()) {
@@ -124,7 +121,11 @@ const emitSuccessfulHookGateSummary = (params: {
       ? PRE_COMMIT_EVIDENCE_MAX_AGE_SECONDS
       : PRE_PUSH_EVIDENCE_MAX_AGE_SECONDS;
   params.dependencies.writeHookGateSummary(
-    `[pumuki][hook-gate] stage=${params.stage} policy_bundle=${params.policyTrace.bundle} policy_hash=${params.policyTrace.hash} decision=ALLOW evidence_kind=${evidence.kind} evidence_age_seconds=${evidenceAgeSeconds ?? 'n/a'} max_age_seconds=${maxAgeSeconds}`
+    `[pumuki][hook-gate] stage=${params.stage} policy_bundle=${params.policyTrace.bundle} policy_hash=${params.policyTrace.hash}` +
+      ` policy_version=${params.policyTrace.version ?? 'n/a'}` +
+      ` policy_signature=${params.policyTrace.signature ?? 'n/a'}` +
+      ` policy_source=${params.policyTrace.policySource ?? 'n/a'}` +
+      ` decision=ALLOW evidence_kind=${evidence.kind} evidence_age_seconds=${evidenceAgeSeconds ?? 'n/a'} max_age_seconds=${maxAgeSeconds}`
   );
 };
 
@@ -167,10 +168,7 @@ export async function runPreCommitStage(
   emitSuccessfulHookGateSummary({
     dependencies: activeDependencies,
     stage: 'PRE_COMMIT',
-    policyTrace: {
-      bundle: resolved.trace.bundle,
-      hash: resolved.trace.hash,
-    },
+    policyTrace: resolved.trace,
     exitCode,
   });
   notifyAuditSummaryForStage(activeDependencies, 'PRE_COMMIT');
@@ -198,10 +196,7 @@ export async function runPrePushStage(
       emitSuccessfulHookGateSummary({
         dependencies: activeDependencies,
         stage: 'PRE_PUSH',
-        policyTrace: {
-          bundle: resolved.trace.bundle,
-          hash: resolved.trace.hash,
-        },
+        policyTrace: resolved.trace,
         exitCode,
       });
       notifyAuditSummaryForStage(activeDependencies, 'PRE_PUSH');
@@ -225,10 +220,7 @@ export async function runPrePushStage(
   emitSuccessfulHookGateSummary({
     dependencies: activeDependencies,
     stage: 'PRE_PUSH',
-    policyTrace: {
-      bundle: resolved.trace.bundle,
-      hash: resolved.trace.hash,
-    },
+    policyTrace: resolved.trace,
     exitCode,
   });
   notifyAuditSummaryForStage(activeDependencies, 'PRE_PUSH');


### PR DESCRIPTION
## What
Implements the first production slice for issue #543 (policy-as-code versioned/signed hardening):
- extends policy trace metadata with `policy_version`, `policy_signature`, `policy_source` and validation status/code.
- adds runtime strict blocking guard (`governance.policy-as-code.invalid`) when policy-as-code validation is not valid under strict mode.
- propagates policy metadata into hook summaries and evidence ruleset state.

## Why
RuralGO validation reported policy-as-code as strategic gap for enterprise auditability. This PR provides machine-readable policy metadata plus strict enforcement hook for invalid contracts.

## RED -> GREEN evidence
- Added/updated tests for:
  - policy trace metadata resolution and unknown-source contract handling.
  - strict blocking in `runPlatformGate` for invalid policy-as-code validation.
  - hook summary output fields (`policy_version`, `policy_signature`, `policy_source`).
  - evidence loading fixture aligned with v2.1 evidence-chain validation.

## Commands run
- `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/EvidenceService.test.ts`
- `npm run -s typecheck`

## Scope notes
- Focused on policy trace contract + strict guard path.
- No behavioral change for non-strict mode except richer metadata emission.

Closes #543
