### PR TITLE
feat: structured gate telemetry export (JSONL + optional OTel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ Rule modes:
 9. Provider-agnostic adapter scaffolding (`codex`, `claude`, `cursor`, `windsurf`, `opencode`).
 10. Optional MCP servers for evidence and enterprise context.
 
+## Telemetry Export (Enterprise)
+
+Pumuki can export structured gate telemetry with a stable event schema (`telemetry_event_v1`) for SIEM/observability pipelines.
+
+Default behavior remains unchanged: telemetry export is disabled unless explicitly configured.
+
+Enable one or both outputs:
+
+- `PUMUKI_TELEMETRY_JSONL_PATH`: local JSONL target (absolute or repo-relative path)
+- `PUMUKI_TELEMETRY_OTEL_ENDPOINT`: OTLP HTTP logs endpoint (`/v1/logs`)
+- `PUMUKI_TELEMETRY_OTEL_SERVICE_NAME`: optional OTel service name (default: `pumuki`)
+- `PUMUKI_TELEMETRY_OTEL_TIMEOUT_MS`: optional OTel timeout in ms (default: `1500`)
+
+Example:
+
+```bash
+export PUMUKI_TELEMETRY_JSONL_PATH=".pumuki/artifacts/gate-telemetry.jsonl"
+export PUMUKI_TELEMETRY_OTEL_ENDPOINT="https://otel.example/v1/logs"
+export PUMUKI_TELEMETRY_OTEL_SERVICE_NAME="pumuki-enterprise"
+npx --yes pumuki-pre-commit
+```
+
+Each event captures deterministic stage/outcome/policy/repo context per gate execution.
+
 ## Framework Maintainer Flow (This Repo)
 
 Use this only when working in the Pumuki framework repository itself:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,6 +97,26 @@ Defined in `integrations/gate/stagePolicies.ts`:
 - `PRE_PUSH`: block `ERROR`, warn from `WARN`
 - `CI`: block `ERROR`, warn from `WARN`
 
+## Gate telemetry export (optional)
+
+Structured telemetry output is disabled by default and can be enabled with environment variables:
+
+- `PUMUKI_TELEMETRY_JSONL_PATH`:
+  - JSONL file path for `telemetry_event_v1` records.
+  - Accepts absolute path or repo-relative path.
+- `PUMUKI_TELEMETRY_OTEL_ENDPOINT`:
+  - OTLP HTTP logs endpoint (`/v1/logs`).
+- `PUMUKI_TELEMETRY_OTEL_SERVICE_NAME`:
+  - Optional service name for OTel payload (`default: pumuki`).
+- `PUMUKI_TELEMETRY_OTEL_TIMEOUT_MS`:
+  - Optional timeout for OTel dispatch in milliseconds (`default: 1500`).
+
+Notes:
+
+- You can enable JSONL only, OTel only, or both.
+- If unset, no telemetry export is attempted.
+- Gate execution remains deterministic even when OTel endpoint is unavailable (best-effort dispatch).
+
 ## Heuristic pilot flag
 
 Enable semantic heuristic rules:

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T38` (crear issue de policy-as-code versionada/firmada y trazarla en canónicos).
+- Task activa (`🚧`): `P12.F1.T43` (ejecutar implementación técnica de `#544` telemetría estructurada exportable JSONL/OTel).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F1.T43` (ejecutar implementación técnica de `#544` telemetría estructurada exportable JSONL/OTel).
+- Task activa (`🚧`): `P12.F1.T47` (consolidar monitoreo único de bloqueo remoto `#543/#544` y cerrar administrativamente al desbloquear checks).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1362,6 +1362,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996686860`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996696705`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996706258`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996716711`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1385,6 +1386,7 @@ Criterio de salida F5:
       - `gh run view 22665698270` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665753917` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665827489` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22665895124` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1422,6 +1424,8 @@ Criterio de salida F5:
       - `gh run view 22665753917 --log-failed` (`log not found: 65696940449` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65697083349` tras rerun más reciente).
       - `gh run view 22665827489 --log-failed` (`log not found: 65697186181` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65697321405` tras rerun más reciente).
+      - `gh run view 22665895124 --log-failed` (`log not found: 65697410820` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1398,6 +1398,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997225157`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997233928`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997241709`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997251884`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1550,6 +1551,8 @@ Criterio de salida F5:
       - `gh run view 22669216212 --log-failed` (`log not found: 65708668907` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65708782038` tras rerun más reciente).
       - `gh run view 22669274350 --log-failed` (`log not found: 65708866318` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65708968156` tras rerun más reciente).
+      - `gh run view 22669335641 --log-failed` (`log not found: 65709074333` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1570,6 +1573,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669150525).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669216212).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669274350).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669335641).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1387,6 +1387,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997054313`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997061285`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997069824`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997079882`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1516,6 +1517,8 @@ Criterio de salida F5:
       - `gh run view 22668157224 --log-failed` (`log not found: 65705054713` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65705138384` tras rerun más reciente).
       - `gh run view 22668204369 --log-failed` (`log not found: 65705213211` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65705296629` tras rerun más reciente).
+      - `gh run view 22668257758 --log-failed` (`log not found: 65705387100` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1525,6 +1528,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668110528).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668157224).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668204369).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668257758).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1388,6 +1388,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997061285`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997069824`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997079882`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997159959`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1519,6 +1520,9 @@ Criterio de salida F5:
       - `gh run view 22668204369 --log-failed` (`log not found: 65705213211` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65705296629` tras rerun más reciente).
       - `gh run view 22668257758 --log-failed` (`log not found: 65705387100` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`HTTP 502 transitorio; reintento exitoso en la misma iteración`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65705491494` tras rerun más reciente).
+      - `gh run view 22668319512 --log-failed` (`log not found: 65705589232` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1529,6 +1533,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668157224).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668204369).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668257758).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668319512).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1395,6 +1395,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997199504`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997207932`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997215929`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997225157`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1541,6 +1542,8 @@ Criterio de salida F5:
       - `gh run view 22669038265 --log-failed` (`log not found: 65708065044` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65708163851` tras rerun más reciente).
       - `gh run view 22669090011 --log-failed` (`log not found: 65708250845` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65708350882` tras rerun más reciente).
+      - `gh run view 22669150525 --log-failed` (`log not found: 65708457128` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1558,6 +1561,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668974897).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669038265).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669090011).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669150525).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1390,6 +1390,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997079882`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997159959`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997170015`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997180722`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1526,6 +1527,8 @@ Criterio de salida F5:
       - `gh run view 22668319512 --log-failed` (`log not found: 65705589232` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65707122133` tras rerun más reciente).
       - `gh run view 22668797947 --log-failed` (`log not found: 65707226855` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65707329503` tras rerun más reciente).
+      - `gh run view 22668854704 --log-failed` (`log not found: 65707429990` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1538,6 +1541,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668257758).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668319512).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668797947).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668854704).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1358,6 +1358,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994419936`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994427763`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994436145`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996676548`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1377,6 +1378,7 @@ Criterio de salida F5:
       - `gh run view 22649239593` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649281881` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649329429` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22649376065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1406,6 +1408,8 @@ Criterio de salida F5:
       - `gh run view 22649281881 --log-failed` (`log not found: 65644688865` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65644780562` tras rerun más reciente).
       - `gh run view 22649329429 --log-failed` (`log not found: 65644848629` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65644926526` tras rerun más reciente).
+      - `gh run view 22649376065 --log-failed` (`log not found: 65644998850` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1385,6 +1385,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997037581`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997047022`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997054313`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997061285`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1510,6 +1511,8 @@ Criterio de salida F5:
       - `gh run view 22668062038 --log-failed` (`log not found: 65704736981` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65704830813` tras rerun más reciente).
       - `gh run view 22668110528 --log-failed` (`log not found: 65704900259` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65704979829` tras rerun más reciente).
+      - `gh run view 22668157224 --log-failed` (`log not found: 65705054713` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1517,6 +1520,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668006686).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668062038).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668110528).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668157224).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1364,6 +1364,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996706258`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996716711`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996727981`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996740930`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1389,6 +1390,7 @@ Criterio de salida F5:
       - `gh run view 22665827489` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665895124` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665965221` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22666044652` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1430,6 +1432,8 @@ Criterio de salida F5:
       - `gh run view 22665895124 --log-failed` (`log not found: 65697410820` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65697543459` tras rerun más reciente).
       - `gh run view 22665965221 --log-failed` (`log not found: 65697646806` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65697807825` tras rerun más reciente).
+      - `gh run view 22666044652 --log-failed` (`log not found: 65697925535` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1365,6 +1365,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996716711`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996727981`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996740930`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996752091`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1391,6 +1392,7 @@ Criterio de salida F5:
       - `gh run view 22665895124` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665965221` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666044652` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22666126392` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1434,6 +1436,8 @@ Criterio de salida F5:
       - `gh run view 22665965221 --log-failed` (`log not found: 65697646806` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65697807825` tras rerun más reciente).
       - `gh run view 22666044652 --log-failed` (`log not found: 65697925535` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65698111394` tras rerun más reciente).
+      - `gh run view 22666126392 --log-failed` (`log not found: 65698204662` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1412,6 +1412,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997351225`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997358307`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997372963`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997392429`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1655,6 +1656,12 @@ Criterio de salida F5:
       - `gh run view 22670168836 --log-failed` (`log not found: 65711894522` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22670168836 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657122844*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; run principal `22670234492` con jobs serie `657122845*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65712284476` en iteración actual).
+      - `gh run view 22670234492 --log-failed` (`log not found: 65712284552` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22670234492 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1346,6 +1346,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994343825`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994350175`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994354919`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994362056`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1353,12 +1354,15 @@ Criterio de salida F5:
       - `gh run view 22648658046` (`billing lock` persistente en `PR #547`).
       - `gh run view 22648709712` (`billing lock` persistente en `PR #547` tras nueva iteración).
       - `gh run view 22648763409` (`billing lock` persistente en `PR #547` tras rerun adicional).
+      - `gh run view 22648802167` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
       - `gh run view 22648658046 --log-failed` (`log not found: 65642674072`).
       - `gh run view 22648709712 --log-failed` (`log not found: 65642843154`).
       - `gh run view 22648763409 --log-failed` (`log not found: 65643022620`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65643216310` tras rerun más reciente).
+      - `gh run view 22648802167 --log-failed` (`log not found: 65643143308`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1366,6 +1366,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996727981`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996740930`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996752091`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996764860`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1393,6 +1394,7 @@ Criterio de salida F5:
       - `gh run view 22665965221` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666044652` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666126392` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22666220507` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1438,6 +1440,8 @@ Criterio de salida F5:
       - `gh run view 22666044652 --log-failed` (`log not found: 65697925535` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65698111394` tras rerun más reciente).
       - `gh run view 22666126392 --log-failed` (`log not found: 65698204662` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65698367870` tras rerun más reciente).
+      - `gh run view 22666220507 --log-failed` (`log not found: 65698516866` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1361,6 +1361,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996676548`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996686860`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996696705`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996706258`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1383,6 +1384,7 @@ Criterio de salida F5:
       - `gh run view 22649376065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665698270` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665753917` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22665827489` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1418,6 +1420,8 @@ Criterio de salida F5:
       - `gh run view 22665698270 --log-failed` (`log not found: 65696755730` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65696859556` tras rerun más reciente).
       - `gh run view 22665753917 --log-failed` (`log not found: 65696940449` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65697083349` tras rerun más reciente).
+      - `gh run view 22665827489 --log-failed` (`log not found: 65697186181` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1377,6 +1377,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996956633`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996965410`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996973617`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996984742`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1415,6 +1416,7 @@ Criterio de salida F5:
       - `gh run view 22667485681` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667538321` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667596358` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667658920` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1482,6 +1484,8 @@ Criterio de salida F5:
       - `gh run view 22667538321 --log-failed` (`log not found: 65702989176` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65703090816` tras rerun más reciente).
       - `gh run view 22667596358 --log-failed` (`log not found: 65703178082` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65703278282` tras rerun más reciente).
+      - `gh run view 22667658920 --log-failed` (`log not found: 65703384656` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1391,6 +1391,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997159959`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997170015`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997180722`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997189427`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1529,6 +1530,8 @@ Criterio de salida F5:
       - `gh run view 22668797947 --log-failed` (`log not found: 65707226855` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65707329503` tras rerun más reciente).
       - `gh run view 22668854704 --log-failed` (`log not found: 65707429990` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65707555117` tras rerun más reciente).
+      - `gh run view 22668920998 --log-failed` (`log not found: 65707659830` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1542,6 +1545,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668319512).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668797947).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668854704).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668920998).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1386,6 +1386,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997047022`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997054313`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997061285`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997069824`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1513,6 +1514,8 @@ Criterio de salida F5:
       - `gh run view 22668110528 --log-failed` (`log not found: 65704900259` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65704979829` tras rerun más reciente).
       - `gh run view 22668157224 --log-failed` (`log not found: 65705054713` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65705138384` tras rerun más reciente).
+      - `gh run view 22668204369 --log-failed` (`log not found: 65705213211` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1521,6 +1524,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668062038).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668110528).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668157224).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668204369).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1360,6 +1360,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994436145`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996676548`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996686860`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996696705`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1381,6 +1382,7 @@ Criterio de salida F5:
       - `gh run view 22649329429` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649376065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665698270` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22665753917` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1414,6 +1416,8 @@ Criterio de salida F5:
       - `gh run view 22649376065 --log-failed` (`log not found: 65644998850` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65696640781` tras rerun más reciente).
       - `gh run view 22665698270 --log-failed` (`log not found: 65696755730` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65696859556` tras rerun más reciente).
+      - `gh run view 22665753917 --log-failed` (`log not found: 65696940449` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1376,6 +1376,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996944930`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996956633`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996965410`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996973617`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1413,6 +1414,7 @@ Criterio de salida F5:
       - `gh run view 22667425219` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667485681` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667538321` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667596358` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1478,6 +1480,8 @@ Criterio de salida F5:
       - `gh run view 22667485681 --log-failed` (`log not found: 65702813006` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65702908553` tras rerun más reciente).
       - `gh run view 22667538321 --log-failed` (`log not found: 65702989176` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65703090816` tras rerun más reciente).
+      - `gh run view 22667596358 --log-failed` (`log not found: 65703178082` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1389,6 +1389,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997069824`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997079882`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997159959`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997170015`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1523,6 +1524,8 @@ Criterio de salida F5:
       - `gh run view 22648216106 --log-failed` (`HTTP 502 transitorio; reintento exitoso en la misma iteración`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65705491494` tras rerun más reciente).
       - `gh run view 22668319512 --log-failed` (`log not found: 65705589232` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65707122133` tras rerun más reciente).
+      - `gh run view 22668797947 --log-failed` (`log not found: 65707226855` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1534,6 +1537,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668204369).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668257758).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668319512).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668797947).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1373,6 +1373,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996912834`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996922933`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996932570`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996944930`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1407,6 +1408,7 @@ Criterio de salida F5:
       - `gh run view 22667252651` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667314045` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667368669` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667425219` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1466,6 +1468,8 @@ Criterio de salida F5:
       - `gh run view 22667314045 --log-failed` (`log not found: 65702230857` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65702328886` tras rerun más reciente).
       - `gh run view 22667368669 --log-failed` (`log not found: 65702412996` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65702515281` tras rerun más reciente).
+      - `gh run view 22667425219 --log-failed` (`log not found: 65702607692` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1363,6 +1363,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996696705`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996706258`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996716711`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996727981`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1387,6 +1388,7 @@ Criterio de salida F5:
       - `gh run view 22665753917` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665827489` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22665895124` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22665965221` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1426,6 +1428,8 @@ Criterio de salida F5:
       - `gh run view 22665827489 --log-failed` (`log not found: 65697186181` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65697321405` tras rerun más reciente).
       - `gh run view 22665895124 --log-failed` (`log not found: 65697410820` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65697543459` tras rerun más reciente).
+      - `gh run view 22665965221 --log-failed` (`log not found: 65697646806` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1355,6 +1355,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994393393`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994398419`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994412271`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994419936`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1371,6 +1372,7 @@ Criterio de salida F5:
       - `gh run view 22649058314` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649100906` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649145066` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22649239593` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1395,6 +1397,7 @@ Criterio de salida F5:
       - `gh run view 22649100906 --log-failed` (`log not found: 65644109713`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65644443058` tras rerun más reciente).
       - `gh run view 22649145066 --log-failed` (`log not found: 65644443025` tras rerun más reciente).
+      - `gh run view 22649239593 --log-failed` (`log not found: 65644557592` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1408,6 +1408,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997316576`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997323683`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997332121`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997342051`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1627,6 +1628,12 @@ Criterio de salida F5:
       - `gh run view 22669900475 --log-failed` (`log not found: 65710983322` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669900475 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657110835*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669956352`, jobs serie `657111697*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65711083553` en iteración actual).
+      - `gh run view 22669956352 --log-failed` (`log not found: 65711169730` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669956352 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1378,6 +1378,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996965410`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996973617`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996984742`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996993890`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1417,6 +1418,7 @@ Criterio de salida F5:
       - `gh run view 22667538321` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667596358` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667658920` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667720182` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1486,6 +1488,8 @@ Criterio de salida F5:
       - `gh run view 22667596358 --log-failed` (`log not found: 65703178082` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65703278282` tras rerun más reciente).
       - `gh run view 22667658920 --log-failed` (`log not found: 65703384656` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65703501294` tras rerun más reciente).
+      - `gh run view 22667720182 --log-failed` (`log not found: 65703589832` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1409,6 +1409,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997323683`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997332121`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997342051`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997351225`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1634,6 +1635,12 @@ Criterio de salida F5:
       - `gh run view 22669956352 --log-failed` (`log not found: 65711169730` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669956352 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657113030*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22670030584`, jobs serie `657114211*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65711303075` en iteración actual).
+      - `gh run view 22670030584 --log-failed` (`log not found: 65711421164` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22670030584 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1397,6 +1397,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997215929`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997225157`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997233928`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997241709`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1547,6 +1548,8 @@ Criterio de salida F5:
       - `gh run view 22669150525 --log-failed` (`log not found: 65708457128` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65708568964` tras rerun más reciente).
       - `gh run view 22669216212 --log-failed` (`log not found: 65708668907` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65708782038` tras rerun más reciente).
+      - `gh run view 22669274350 --log-failed` (`log not found: 65708866318` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1566,6 +1569,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669090011).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669150525).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669216212).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669274350).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1345,17 +1345,20 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994336761`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994343825`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994350175`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994354919`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
       - `gh run view 22648216106` (`billing lock` persistente en `PR #545`).
       - `gh run view 22648658046` (`billing lock` persistente en `PR #547`).
       - `gh run view 22648709712` (`billing lock` persistente en `PR #547` tras nueva iteración).
+      - `gh run view 22648763409` (`billing lock` persistente en `PR #547` tras rerun adicional).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
       - `gh run view 22648658046 --log-failed` (`log not found: 65642674072`).
       - `gh run view 22648709712 --log-failed` (`log not found: 65642843154`).
+      - `gh run view 22648763409 --log-failed` (`log not found: 65643022620`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1411,6 +1411,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997342051`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997351225`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997358307`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997372963`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1648,6 +1649,12 @@ Criterio de salida F5:
       - `gh run view 22670080946 --log-failed` (`log not found: 65711595072` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22670080946 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657116861*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22670168836`, jobs serie `657118945*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65711686102` en iteración actual).
+      - `gh run view 22670168836 --log-failed` (`log not found: 65711894522` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22670168836 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1379,6 +1379,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996973617`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996984742`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996993890`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997005494`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1419,6 +1420,7 @@ Criterio de salida F5:
       - `gh run view 22667596358` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667658920` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667720182` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667790993` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1490,6 +1492,9 @@ Criterio de salida F5:
       - `gh run view 22667658920 --log-failed` (`log not found: 65703384656` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65703501294` tras rerun más reciente).
       - `gh run view 22667720182 --log-failed` (`log not found: 65703589832` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65703704301` tras rerun más reciente).
+      - `gh run view 22667790993 --log-failed` (`log not found: 65703832752` tras rerun más reciente).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1344,14 +1344,18 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994327893`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994336761`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994343825`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994350175`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
       - `gh run view 22648216106` (`billing lock` persistente en `PR #545`).
       - `gh run view 22648658046` (`billing lock` persistente en `PR #547`).
+      - `gh run view 22648709712` (`billing lock` persistente en `PR #547` tras nueva iteración).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
       - `gh run view 22648658046 --log-failed` (`log not found: 65642674072`).
+      - `gh run view 22648709712 --log-failed` (`log not found: 65642843154`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1394,6 +1394,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997189427`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997199504`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997207932`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997215929`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1538,6 +1539,8 @@ Criterio de salida F5:
       - `gh run view 22668974897 --log-failed` (`log not found: 65707843708` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65707967601` tras rerun más reciente).
       - `gh run view 22669038265 --log-failed` (`log not found: 65708065044` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65708163851` tras rerun más reciente).
+      - `gh run view 22669090011 --log-failed` (`log not found: 65708250845` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1554,6 +1557,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668920998).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668974897).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669038265).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669090011).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1213,7 +1213,101 @@ Criterio de salida F5:
     - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO push origin HEAD`
     - `npx --yes --package pumuki@latest pumuki-pre-commit` (hook gate `ALLOW/PASS` durante commit en `R_GO`)
     - `npx --yes --package pumuki@latest pumuki-pre-push` (hook gate `ALLOW/PASS` durante push en `R_GO`)
-- 🚧 `P12.F1.T38` Crear issue de mejora estratégica pendiente: policy-as-code versionada/firmada (backlog enterprise) y dejarla trazada en canónico + master plan.
+- ✅ `P12.F1.T38` Crear issue de mejora estratégica pendiente: policy-as-code versionada/firmada (backlog enterprise) y dejarla trazada en canónico + master plan.
+  - cierre ejecutado:
+    - issue creada en `ast-intelligence-hooks`: `#543` -> `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/543`.
+    - canónico RuralGO actualizado:
+      - `PUMUKI-INC-055` añadido como `REPORTED (#543)`.
+      - consolidación por causa raíz extendida con fila `policy-as-code`.
+      - trazabilidad de ejecución extendida con fila `REPORTED` para issue `#543`.
+    - master plan RuralGO actualizado:
+      - `ruralgo-master-plan.md` con `Issue #538` en `✅`.
+      - mejora estratégica `policy-as-code` promovida a `🚧` con referencia a `#543`.
+  - evidencia:
+    - `gh issue create --title "feature: policy-as-code versionada y firmada para gates enterprise" ...`
+    - edición de `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`
+    - edición de `R_GO/ruralgo-master-plan.md`
+    - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO commit -m "docs(validation): sync canonical feedback for issue 538"`
+    - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO push origin HEAD`
+- ✅ `P12.F1.T39` Ejecutar siguiente mejora estratégica: crear issue de telemetría estructurada exportable (JSONL/OTel) y trazarla en canónico + master plan.
+  - cierre ejecutado:
+    - issue creada en `ast-intelligence-hooks`: `#544` -> `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/544`.
+    - canónico RuralGO actualizado:
+      - `PUMUKI-INC-056` añadido como `⏳ REPORTED (#544)`.
+      - consolidación por causa raíz extendida con fila `telemetría estructurada exportable`.
+      - trazabilidad de ejecución extendida con fila `REPORTED` para issue `#544`.
+    - master plan RuralGO actualizado:
+      - `ruralgo-master-plan.md` mantiene `#543` como única `🚧`.
+      - mejora estratégica `telemetría` mantiene estado `⏳` y añade referencia a `Issue #544`.
+  - evidencia:
+    - `gh issue create --title "[P2][OPS] Telemetría estructurada exportable (JSONL/OTel) para auditoría enterprise" ...`
+    - edición de `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`
+    - edición de `R_GO/ruralgo-master-plan.md`
+- ⛔ `P12.F1.T40` Ejecutar implementación técnica de la mejora estratégica `#543` (policy-as-code versionada/firmada) en Pumuki con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
+  - avance en curso:
+    - rama de implementación: `feature/543-policy-as-code-signed`.
+    - commits técnicos:
+      - `a24bf6c` (`feat(gate): add policy-as-code trace metadata and strict validation guard`).
+      - `594a83c` (`feat(policy): add contract expiry validation and strict blocking coverage`).
+    - PR abierta: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/545`.
+    - tests/verificación ejecutados en verde:
+      - `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/git/__tests__/EvidenceService.test.ts`
+      - `npm run -s typecheck`
+    - alcance DoD cubierto en branch:
+      - contrato `policy-as-code` con validación runtime `valid/invalid/expired/unknown-source`.
+      - bloqueo strict (`PUMUKI_POLICY_STRICT=1`) con códigos explícitos de policy.
+      - documentación operativa mínima añadida en `README.md`.
+  - bloqueo actual:
+    - checks remotos de GitHub Actions en `#545` fallan de forma sistémica y sin logs recuperables (`log not found` en `gh run view --log`).
+    - `security/snyk` reporta límite de cuota privada (`You have used your limit of private tests`).
+    - pendiente decisión de merge cuando se desbloquee infraestructura/checks remotos.
+  - evidencia:
+    - `gh pr view 545 --json state,mergeStateStatus,statusCheckRollup,headRefOid,url`
+    - `gh pr checks 545 --json name,state,bucket,link,description`
+    - `gh run view 22647944444 --job 65640392393 --log`
+
+- ⛔ `P12.F1.T41` Desbloquear cierre administrativo de `#543` (merge PR `#545` + cierre issue `#543`) cuando los checks remotos vuelvan a estado operativo.
+  - issue operativa de soporte creada: `#546` (`ops: unblock remote PR checks (snyk quota + missing job logs)`).
+  - avance ejecutado:
+    - reintento de runs fallidos lanzado en lote (`gh run rerun <run_id> --failed`) para descartar flake.
+    - resultados tras rerun: `run_attempt=2` y estado `completed/failure` en todos los workflows afectados (sin recuperación automática).
+    - diagnóstico estructural confirmado en GitHub Actions:
+      - jobs de `CI` con `steps_count=0` en attempt 2.
+      - ZIP de logs del run disponible, pero solo contiene `system.txt` (sin logs de pasos de ejecución).
+    - issue `#543`, issue `#546` y PR `#545` actualizadas con comentario de progreso y bloqueo remoto.
+  - bloqueo reproducido (comando/error):
+    - comando: `gh run view 22648051050`
+    - error observado: `The job was not started because your account is locked due to a billing issue.` (anotación repetida en todos los jobs de `CI`).
+    - comando: `gh pr checks 545 --json name,state,bucket,link,description`
+    - error observado: `security/snyk (swiftenprofundidad) => ERROR: You have used your limit of private tests`.
+    - comando: `gh run view 22647944444 --job 65640392393 --log`
+    - error observado: `log not found: 65640392393`.
+  - corrección mínima propuesta:
+    - desbloquear billing de la cuenta/organización de GitHub Actions (el run no inicia jobs por lock de facturación).
+    - restaurar cuota/permisos de `Snyk` para checks de PR o desactivar temporalmente ese check como requerido.
+    - asegurar retención/publicación de logs de Actions para permitir diagnóstico de fallos reales.
+
+- 🚧 `P12.F1.T43` Ejecutar implementación técnica de `#544` (telemetría estructurada exportable JSONL/OTel) con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
+  - avance en curso:
+    - rama de implementación: `feature/544-telemetry-structured-export` (desde `develop`).
+    - implementación añadida:
+      - `integrations/telemetry/gateTelemetry.ts` (`telemetry_event_v1`, export JSONL y OTLP HTTP opcional).
+      - integración en runner de evidencia:
+        - `integrations/git/runPlatformGateEvidence.ts`.
+      - tests añadidos/actualizados:
+        - `integrations/telemetry/__tests__/gateTelemetry.test.ts`
+        - `integrations/git/__tests__/runPlatformGateEvidence.test.ts`
+      - documentación mínima:
+        - `README.md` (sección `Telemetry Export (Enterprise)`).
+        - `docs/CONFIGURATION.md` (env vars de export).
+    - verificación local en verde:
+      - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts integrations/git/__tests__/runPlatformGateEvidence.test.ts`
+      - `npm run -s typecheck`
+
+- ⏳ `P12.F1.T42` Sincronizar canónico RuralGO tras cierre de `#543` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
+  - salida esperada:
+    - `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` actualizado a `FIXED` para `PUMUKI-INC-055`.
+    - `R_GO/ruralgo-master-plan.md` con leyenda actualizada (solo 1 `🚧` activa) y referencia de issue/PR/commit.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1349,6 +1349,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994362056`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994367200`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994373091`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994378287`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1359,6 +1360,7 @@ Criterio de salida F5:
       - `gh run view 22648802167` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648857219` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648896311` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22648936952` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1371,6 +1373,8 @@ Criterio de salida F5:
       - `gh run view 22648857219 --log-failed` (`log not found: 65643317704`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65643485089` tras rerun más reciente).
       - `gh run view 22648896311 --log-failed` (`log not found: 65643440990`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65643613581` tras rerun más reciente).
+      - `gh run view 22648936952 --log-failed` (`log not found: 65643571905`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1402,6 +1402,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997262697`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997282872`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997283830`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997293723`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1586,6 +1587,11 @@ Criterio de salida F5:
       - `gh run rerun 22669476790 --failed` (rerun solicitado en iteración actual).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657099339*`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657099340*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669646243`, jobs serie `657101192*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65709933923` en iteración actual).
+      - `gh run view 22669646243 --log-failed` (`log not found: 65710119224` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669646243 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1381,6 +1381,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996993890`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997005494`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997016272`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997027105`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1498,9 +1499,12 @@ Criterio de salida F5:
       - `gh run view 22667790993 --log-failed` (`log not found: 65703832752` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65703972380` tras rerun más reciente).
       - `gh run view 22667861919 --log-failed` (`log not found: 65704071995` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65704197242` tras rerun más reciente).
+      - `gh run view 22667951577 --log-failed` (`log not found: 65704371271` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22667951577).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1351,6 +1351,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994373091`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994378287`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994383169`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994388105`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1363,6 +1364,7 @@ Criterio de salida F5:
       - `gh run view 22648896311` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648936952` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648976599` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22649016905` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1379,6 +1381,8 @@ Criterio de salida F5:
       - `gh run view 22648936952 --log-failed` (`log not found: 65643571905`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65643744852` tras rerun más reciente).
       - `gh run view 22648976599 --log-failed` (`log not found: 65643702306`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65643877247` tras rerun más reciente).
+      - `gh run view 22649016905 --log-failed` (`log not found: 65643835903`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1368,6 +1368,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996752091`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996764860`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996781223`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996790861`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1397,6 +1398,7 @@ Criterio de salida F5:
       - `gh run view 22666126392` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666220507` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666293279` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22666414388` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1446,6 +1448,8 @@ Criterio de salida F5:
       - `gh run view 22666220507 --log-failed` (`log not found: 65698516866` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65698649512` tras rerun más reciente).
       - `gh run view 22666293279 --log-failed` (`log not found: 65698759698` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65699043224` tras rerun más reciente).
+      - `gh run view 22666414388 --log-failed` (`log not found: 65699164373` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1375,6 +1375,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996932570`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996944930`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996956633`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996965410`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1411,6 +1412,7 @@ Criterio de salida F5:
       - `gh run view 22667368669` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667425219` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667485681` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667538321` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1474,6 +1476,8 @@ Criterio de salida F5:
       - `gh run view 22667425219 --log-failed` (`log not found: 65702607692` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65702709699` tras rerun más reciente).
       - `gh run view 22667485681 --log-failed` (`log not found: 65702813006` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65702908553` tras rerun más reciente).
+      - `gh run view 22667538321 --log-failed` (`log not found: 65702989176` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1359,6 +1359,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994427763`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994436145`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996676548`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996686860`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1379,6 +1380,7 @@ Criterio de salida F5:
       - `gh run view 22649281881` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649329429` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649376065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22665698270` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1410,6 +1412,8 @@ Criterio de salida F5:
       - `gh run view 22649329429 --log-failed` (`log not found: 65644848629` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65644926526` tras rerun más reciente).
       - `gh run view 22649376065 --log-failed` (`log not found: 65644998850` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65696640781` tras rerun más reciente).
+      - `gh run view 22665698270 --log-failed` (`log not found: 65696755730` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1356,6 +1356,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994398419`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994412271`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994419936`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994427763`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1373,6 +1374,7 @@ Criterio de salida F5:
       - `gh run view 22649100906` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649145066` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649239593` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22649281881` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1398,6 +1400,8 @@ Criterio de salida F5:
       - `gh run view 22648216106 --log-failed` (`log not found: 65644443058` tras rerun más reciente).
       - `gh run view 22649145066 --log-failed` (`log not found: 65644443025` tras rerun más reciente).
       - `gh run view 22649239593 --log-failed` (`log not found: 65644557592` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65644646291` tras rerun más reciente).
+      - `gh run view 22649281881 --log-failed` (`log not found: 65644688865` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1347,6 +1347,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994350175`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994354919`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994362056`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994367200`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1355,6 +1356,7 @@ Criterio de salida F5:
       - `gh run view 22648709712` (`billing lock` persistente en `PR #547` tras nueva iteración).
       - `gh run view 22648763409` (`billing lock` persistente en `PR #547` tras rerun adicional).
       - `gh run view 22648802167` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22648857219` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1363,6 +1365,8 @@ Criterio de salida F5:
       - `gh run view 22648763409 --log-failed` (`log not found: 65643022620`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65643216310` tras rerun más reciente).
       - `gh run view 22648802167 --log-failed` (`log not found: 65643143308`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65643360317` tras rerun más reciente).
+      - `gh run view 22648857219 --log-failed` (`log not found: 65643317704`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1382,6 +1382,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997005494`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997016272`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997027105`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997037581`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1501,10 +1502,13 @@ Criterio de salida F5:
       - `gh run view 22667861919 --log-failed` (`log not found: 65704071995` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65704197242` tras rerun más reciente).
       - `gh run view 22667951577 --log-failed` (`log not found: 65704371271` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65704419114` tras rerun más reciente).
+      - `gh run view 22668006686 --log-failed` (`log not found: 65704551026` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22667951577).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668006686).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1403,6 +1403,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997282872`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997283830`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997293723`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997300779`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1592,6 +1593,12 @@ Criterio de salida F5:
       - `gh run view 22669646243 --log-failed` (`log not found: 65710119224` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669646243 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657102064*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669693802`, jobs serie `657102782*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65710206405` en iteración actual).
+      - `gh run view 22669693802 --log-failed` (`log not found: 65710278243` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669693802 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1392,6 +1392,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997170015`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997180722`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997189427`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997199504`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1532,6 +1533,8 @@ Criterio de salida F5:
       - `gh run view 22668854704 --log-failed` (`log not found: 65707429990` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65707555117` tras rerun más reciente).
       - `gh run view 22668920998 --log-failed` (`log not found: 65707659830` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65707759607` tras rerun más reciente).
+      - `gh run view 22668974897 --log-failed` (`log not found: 65707843708` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1546,6 +1549,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668797947).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668854704).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668920998).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668974897).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1405,6 +1405,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997293723`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997300779`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997308456`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997316576`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1606,6 +1607,12 @@ Criterio de salida F5:
       - `gh run view 22669749649 --log-failed` (`log not found: 65710472753` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669749649 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657105379*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669801703`, jobs serie `657106489*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65710537976` en iteración actual).
+      - `gh run view 22669801703 --log-failed` (`log not found: 65710648961` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669801703 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1372,6 +1372,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996903908`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996912834`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996922933`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996932570`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1405,6 +1406,7 @@ Criterio de salida F5:
       - `gh run view 22666483065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667252651` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667314045` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667368669` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1462,6 +1464,8 @@ Criterio de salida F5:
       - `gh run view 22667252651 --log-failed` (`log not found: 65702026767` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65702137525` tras rerun más reciente).
       - `gh run view 22667314045 --log-failed` (`log not found: 65702230857` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65702328886` tras rerun más reciente).
+      - `gh run view 22667368669 --log-failed` (`log not found: 65702412996` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1400,6 +1400,8 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997241709`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997251884`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997262697`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997282872`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997283830`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1578,6 +1580,12 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669274350).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669335641).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669404203).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65709435542` en iteración actual).
+      - `gh run view 22669476790 --log-failed` (`log not found: 65709553382` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669476790 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657099339*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657099340*`).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1367,6 +1367,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996740930`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996752091`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996764860`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996781223`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1395,6 +1396,7 @@ Criterio de salida F5:
       - `gh run view 22666044652` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666126392` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666220507` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22666293279` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1442,6 +1444,8 @@ Criterio de salida F5:
       - `gh run view 22666126392 --log-failed` (`log not found: 65698204662` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65698367870` tras rerun más reciente).
       - `gh run view 22666220507 --log-failed` (`log not found: 65698516866` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65698649512` tras rerun más reciente).
+      - `gh run view 22666293279 --log-failed` (`log not found: 65698759698` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1343,11 +1343,17 @@ Criterio de salida F5:
     - issue operativa actualizada con seguimiento de `#547`:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994327893`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994336761`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994343825`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
+      - `gh run view 22648216106` (`billing lock` persistente en `PR #545`).
+      - `gh run view 22648658046` (`billing lock` persistente en `PR #547`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
+      - `gh run view 22648658046 --log-failed` (`log not found: 65642674072`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1352,6 +1352,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994378287`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994383169`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994388105`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994393393`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1365,6 +1366,7 @@ Criterio de salida F5:
       - `gh run view 22648936952` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648976599` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649016905` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22649058314` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1383,6 +1385,8 @@ Criterio de salida F5:
       - `gh run view 22648976599 --log-failed` (`log not found: 65643702306`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65643877247` tras rerun más reciente).
       - `gh run view 22649016905 --log-failed` (`log not found: 65643835903`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65644020384` tras rerun más reciente).
+      - `gh run view 22649058314 --log-failed` (`log not found: 65643972252`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1380,6 +1380,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996984742`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996993890`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997005494`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997016272`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1421,6 +1422,7 @@ Criterio de salida F5:
       - `gh run view 22667658920` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667720182` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667790993` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667861919` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1494,6 +1496,8 @@ Criterio de salida F5:
       - `gh run view 22667720182 --log-failed` (`log not found: 65703589832` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65703704301` tras rerun más reciente).
       - `gh run view 22667790993 --log-failed` (`log not found: 65703832752` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65703972380` tras rerun más reciente).
+      - `gh run view 22667861919 --log-failed` (`log not found: 65704071995` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1410,6 +1410,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997332121`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997342051`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997351225`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997358307`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1641,6 +1642,12 @@ Criterio de salida F5:
       - `gh run view 22670030584 --log-failed` (`log not found: 65711421164` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22670030584 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657115177*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22670080946`, jobs serie `657115950*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65711517708` en iteración actual).
+      - `gh run view 22670080946 --log-failed` (`log not found: 65711595072` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22670080946 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1407,6 +1407,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997308456`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997316576`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997323683`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997332121`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1620,6 +1621,12 @@ Criterio de salida F5:
       - `gh run view 22669852933 --log-failed` (`log not found: 65710820333` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669852933 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657109086*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669900475`, jobs serie `657109833*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65710908659` en iteración actual).
+      - `gh run view 22669900475 --log-failed` (`log not found: 65710983322` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669900475 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1404,6 +1404,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997283830`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997293723`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997300779`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997308456`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1599,6 +1600,12 @@ Criterio de salida F5:
       - `gh run view 22669693802 --log-failed` (`log not found: 65710278243` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669693802 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657103641*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669749649`, jobs serie `657104727*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65710364124` en iteración actual).
+      - `gh run view 22669749649 --log-failed` (`log not found: 65710472753` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669749649 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1384,6 +1384,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997027105`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997037581`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997047022`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997054313`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1507,12 +1508,15 @@ Criterio de salida F5:
       - `gh run view 22668006686 --log-failed` (`log not found: 65704551026` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65704663689` tras rerun más reciente).
       - `gh run view 22668062038 --log-failed` (`log not found: 65704736981` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65704830813` tras rerun más reciente).
+      - `gh run view 22668110528 --log-failed` (`log not found: 65704900259` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22667951577).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668006686).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668062038).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668110528).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1354,6 +1354,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994388105`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994393393`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994398419`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994412271`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1369,6 +1370,7 @@ Criterio de salida F5:
       - `gh run view 22649016905` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649058314` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649100906` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22649145066` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1391,6 +1393,8 @@ Criterio de salida F5:
       - `gh run view 22649058314 --log-failed` (`log not found: 65643972252`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65644159429` tras rerun más reciente).
       - `gh run view 22649100906 --log-failed` (`log not found: 65644109713`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65644443058` tras rerun más reciente).
+      - `gh run view 22649145066 --log-failed` (`log not found: 65644443025` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1370,6 +1370,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996781223`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996790861`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996903908`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996912834`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1401,6 +1402,7 @@ Criterio de salida F5:
       - `gh run view 22666293279` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666414388` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666483065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667252651` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1454,6 +1456,8 @@ Criterio de salida F5:
       - `gh run view 22666414388 --log-failed` (`log not found: 65699164373` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65699277824` tras rerun más reciente).
       - `gh run view 22666483065 --log-failed` (`log not found: 65699397098` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65701938535` tras rerun más reciente).
+      - `gh run view 22667252651 --log-failed` (`log not found: 65702026767` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1287,8 +1287,8 @@ Criterio de salida F5:
     - restaurar cuota/permisos de `Snyk` para checks de PR o desactivar temporalmente ese check como requerido.
     - asegurar retención/publicación de logs de Actions para permitir diagnóstico de fallos reales.
 
-- 🚧 `P12.F1.T43` Ejecutar implementación técnica de `#544` (telemetría estructurada exportable JSONL/OTel) con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
-  - avance en curso:
+- ✅ `P12.F1.T43` Ejecutar implementación técnica de `#544` (telemetría estructurada exportable JSONL/OTel) con ciclo RED -> GREEN -> REFACTOR y trazabilidad E2E.
+  - cierre ejecutado:
     - rama de implementación: `feature/544-telemetry-structured-export` (desde `develop`).
     - implementación añadida:
       - `integrations/telemetry/gateTelemetry.ts` (`telemetry_event_v1`, export JSONL y OTLP HTTP opcional).
@@ -1300,14 +1300,56 @@ Criterio de salida F5:
       - documentación mínima:
         - `README.md` (sección `Telemetry Export (Enterprise)`).
         - `docs/CONFIGURATION.md` (env vars de export).
-    - verificación local en verde:
-      - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts integrations/git/__tests__/runPlatformGateEvidence.test.ts`
-      - `npm run -s typecheck`
+    - commits técnicos en rama:
+      - `bc93dc1` (`feat(telemetry): add structured gate export to JSONL and optional OTel`).
+      - `abc0a7d` (`docs(tracking): rotate active task to T43 and sync blocker status`).
+    - PR abierta: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/547`.
+    - issue de trabajo: `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/544`.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts integrations/git/__tests__/runPlatformGateEvidence.test.ts`
+    - `npm run -s typecheck`
+    - `gh pr view 547 --json state,mergeStateStatus,statusCheckRollup,headRefOid,url`
+
+- ⛔ `P12.F1.T44` Desbloquear cierre administrativo de `#544` (merge PR `#547` + cierre issue `#544`) cuando los checks remotos vuelvan a estado operativo.
+  - bloqueo reproducido (comando/error):
+    - comando: `gh run view 22648407847`
+    - error observado: `The job was not started because your account is locked due to a billing issue.` (anotación repetida en jobs de `CI`).
+    - comando: `gh pr checks 547 --json name,state,bucket,link,description`
+    - error observado: `security/snyk (swiftenprofundidad) => ERROR: You have used your limit of private tests`.
+  - corrección mínima propuesta:
+    - desbloquear billing de la cuenta/organización de GitHub Actions.
+    - restaurar cuota/permisos de Snyk o ajustar temporalmente ese check requerido.
 
 - ⏳ `P12.F1.T42` Sincronizar canónico RuralGO tras cierre de `#543` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:
     - `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` actualizado a `FIXED` para `PUMUKI-INC-055`.
     - `R_GO/ruralgo-master-plan.md` con leyenda actualizada (solo 1 `🚧` activa) y referencia de issue/PR/commit.
+
+- ✅ `P12.F1.T46` Sincronizar canónico RuralGO en estado intermedio de `#544` (`REPORTED` con refs reales de issue/branch/PR/commit/evidencia) y alinear master plan con una única mejora `🚧`.
+  - cierre ejecutado:
+    - `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` actualizado con trazabilidad real de `#544/#547` (estado `🚧 REPORTED`).
+    - `R_GO/ruralgo-master-plan.md` actualizado con `#543 => ⛔` y `#544 => 🚧`.
+    - commit documental atómico en `R_GO`: `ed39a570b`.
+    - push remoto completado en `feature/rgo-1590-01-ios-physical-signoff`.
+  - evidencia:
+    - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO commit -m "docs(validation): sync issue 544 reported state and blocker visibility"`
+    - `git -C /Users/juancarlosmerlosalbarracin/Developer/Projects/R_GO push origin HEAD`
+    - `npx --yes --package pumuki@latest pumuki sdd session --refresh --json`
+    - `npx --yes --package pumuki@latest pumuki-pre-commit` (gate `ALLOW/PASS`)
+    - `npx --yes --package pumuki@latest pumuki-pre-push` (gate `ALLOW/PASS`)
+
+- 🚧 `P12.F1.T47` Consolidar monitoreo único del bloqueo remoto para `#543/#544` en issue operativa `#546` y ejecutar cierre administrativo automático en cuanto los checks remotos queden operativos.
+  - avance en curso:
+    - issue operativa actualizada con seguimiento de `#547`:
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994327893`
+    - evidencia de bloqueo vigente:
+      - `gh run view 22648407847` (`billing lock` en GitHub Actions).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
+
+- ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
+  - salida esperada:
+    - `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md` actualizado a `FIXED` para `PUMUKI-INC-056`.
+    - `R_GO/ruralgo-master-plan.md` con leyenda final actualizada y referencia de merge real.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1350,6 +1350,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994367200`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994373091`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994378287`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994383169`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1361,6 +1362,7 @@ Criterio de salida F5:
       - `gh run view 22648857219` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648896311` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648936952` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22648976599` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1375,6 +1377,8 @@ Criterio de salida F5:
       - `gh run view 22648896311 --log-failed` (`log not found: 65643440990`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65643613581` tras rerun más reciente).
       - `gh run view 22648936952 --log-failed` (`log not found: 65643571905`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65643744852` tras rerun más reciente).
+      - `gh run view 22648976599 --log-failed` (`log not found: 65643702306`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1374,6 +1374,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996922933`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996932570`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996944930`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996956633`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1409,6 +1410,7 @@ Criterio de salida F5:
       - `gh run view 22667314045` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667368669` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667425219` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667485681` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1470,6 +1472,8 @@ Criterio de salida F5:
       - `gh run view 22667368669 --log-failed` (`log not found: 65702412996` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65702515281` tras rerun más reciente).
       - `gh run view 22667425219 --log-failed` (`log not found: 65702607692` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65702709699` tras rerun más reciente).
+      - `gh run view 22667485681 --log-failed` (`log not found: 65702813006` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1371,6 +1371,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996790861`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996903908`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996912834`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996922933`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1403,6 +1404,7 @@ Criterio de salida F5:
       - `gh run view 22666414388` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666483065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22667252651` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22667314045` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1458,6 +1460,8 @@ Criterio de salida F5:
       - `gh run view 22666483065 --log-failed` (`log not found: 65699397098` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65701938535` tras rerun más reciente).
       - `gh run view 22667252651 --log-failed` (`log not found: 65702026767` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65702137525` tras rerun más reciente).
+      - `gh run view 22667314045 --log-failed` (`log not found: 65702230857` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1353,6 +1353,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994383169`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994388105`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994393393`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994398419`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1367,6 +1368,7 @@ Criterio de salida F5:
       - `gh run view 22648976599` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649016905` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22649058314` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22649100906` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1387,6 +1389,8 @@ Criterio de salida F5:
       - `gh run view 22649016905 --log-failed` (`log not found: 65643835903`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65644020384` tras rerun más reciente).
       - `gh run view 22649058314 --log-failed` (`log not found: 65643972252`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65644159429` tras rerun más reciente).
+      - `gh run view 22649100906 --log-failed` (`log not found: 65644109713`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1396,6 +1396,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997207932`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997215929`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997225157`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997233928`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1544,6 +1545,8 @@ Criterio de salida F5:
       - `gh run view 22669090011 --log-failed` (`log not found: 65708250845` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65708350882` tras rerun más reciente).
       - `gh run view 22669150525 --log-failed` (`log not found: 65708457128` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65708568964` tras rerun más reciente).
+      - `gh run view 22669216212 --log-failed` (`log not found: 65708668907` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1562,6 +1565,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669038265).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669090011).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669150525).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669216212).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1383,6 +1383,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997016272`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997027105`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997037581`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997047022`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1504,11 +1505,14 @@ Criterio de salida F5:
       - `gh run view 22667951577 --log-failed` (`log not found: 65704371271` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65704419114` tras rerun más reciente).
       - `gh run view 22668006686 --log-failed` (`log not found: 65704551026` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65704663689` tras rerun más reciente).
+      - `gh run view 22668062038 --log-failed` (`log not found: 65704736981` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22667951577).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668006686).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668062038).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1406,6 +1406,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997300779`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997308456`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997316576`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997323683`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1613,6 +1614,12 @@ Criterio de salida F5:
       - `gh run view 22669801703 --log-failed` (`log not found: 65710648961` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22669801703 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota; jobs actualizados a serie `657107362*`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run `22669852933`, jobs serie `657108203*`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65710736293` en iteración actual).
+      - `gh run view 22669852933 --log-failed` (`log not found: 65710820333` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22669852933 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1399,6 +1399,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997233928`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997241709`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997251884`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997262697`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1553,6 +1554,8 @@ Criterio de salida F5:
       - `gh run view 22669274350 --log-failed` (`log not found: 65708866318` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65708968156` tras rerun más reciente).
       - `gh run view 22669335641 --log-failed` (`log not found: 65709074333` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65709189549` tras rerun más reciente).
+      - `gh run view 22669404203 --log-failed` (`log not found: 65709306026` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1574,6 +1577,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669216212).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669274350).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669335641).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669404203).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1369,6 +1369,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996764860`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996781223`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996790861`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3996903908`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1399,6 +1400,7 @@ Criterio de salida F5:
       - `gh run view 22666220507` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666293279` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22666414388` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22666483065` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1450,6 +1452,8 @@ Criterio de salida F5:
       - `gh run view 22666293279 --log-failed` (`log not found: 65698759698` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65699043224` tras rerun más reciente).
       - `gh run view 22666414388 --log-failed` (`log not found: 65699164373` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65699277824` tras rerun más reciente).
+      - `gh run view 22666483065 --log-failed` (`log not found: 65699397098` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1348,6 +1348,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994354919`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994362056`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994367200`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994373091`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1357,6 +1358,7 @@ Criterio de salida F5:
       - `gh run view 22648763409` (`billing lock` persistente en `PR #547` tras rerun adicional).
       - `gh run view 22648802167` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648857219` (`billing lock` persistente en `PR #547` tras heartbeat actual).
+      - `gh run view 22648896311` (`billing lock` persistente en `PR #547` tras heartbeat actual).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1367,6 +1369,8 @@ Criterio de salida F5:
       - `gh run view 22648802167 --log-failed` (`log not found: 65643143308`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65643360317` tras rerun más reciente).
       - `gh run view 22648857219 --log-failed` (`log not found: 65643317704`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65643485089` tras rerun más reciente).
+      - `gh run view 22648896311 --log-failed` (`log not found: 65643440990`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1393,6 +1393,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997180722`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997189427`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997199504`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997207932`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1535,6 +1536,8 @@ Criterio de salida F5:
       - `gh run view 22668920998 --log-failed` (`log not found: 65707659830` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65707759607` tras rerun más reciente).
       - `gh run view 22668974897 --log-failed` (`log not found: 65707843708` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65707967601` tras rerun más reciente).
+      - `gh run view 22669038265 --log-failed` (`log not found: 65708065044` tras rerun más reciente).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`HTTP 502 transitorio en esta iteración; reintento exitoso`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
@@ -1550,6 +1553,7 @@ Criterio de salida F5:
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668854704).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668920998).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22668974897).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota; nuevo run 22669038265).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1357,6 +1357,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994412271`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994419936`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994427763`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994436145`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1375,6 +1376,7 @@ Criterio de salida F5:
       - `gh run view 22649145066` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649239593` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22649281881` (`billing lock` persistente en `PR #547` tras nuevo rerun).
+      - `gh run view 22649329429` (`billing lock` persistente en `PR #547` tras nuevo rerun).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642755577`).
       - `gh run view 22648216106 --log-failed` (`log not found: 65642904197` tras nueva iteración).
       - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
@@ -1402,6 +1404,8 @@ Criterio de salida F5:
       - `gh run view 22649239593 --log-failed` (`log not found: 65644557592` tras rerun más reciente).
       - `gh run view 22648216106 --log-failed` (`log not found: 65644646291` tras rerun más reciente).
       - `gh run view 22649281881 --log-failed` (`log not found: 65644688865` tras rerun más reciente).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65644780562` tras rerun más reciente).
+      - `gh run view 22649329429 --log-failed` (`log not found: 65644848629` tras rerun más reciente).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
       - `gh pr checks 545 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1413,6 +1413,7 @@ Criterio de salida F5:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997358307`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997372963`
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997392429`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3997407417`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
       - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
@@ -1662,6 +1663,12 @@ Criterio de salida F5:
       - `gh run view 22670234492 --log-failed` (`log not found: 65712284552` en iteración actual).
       - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
       - `gh run rerun 22670234492 --failed` (rerun solicitado en iteración actual).
+      - `gh pr checks 545 --json name,state,bucket,link,description` (run principal `22648216106`; jobs actualizados a serie `65712790*` con mezcla `QUEUED/FAILURE`).
+      - `gh pr checks 547 --json name,state,bucket,link,description` (run principal `22670371464`; jobs actualizados a serie `65712790*` con mezcla `QUEUED/FAILURE`).
+      - `gh run view 22648216106 --log-failed` (`log not found: 65712482761` en iteración actual).
+      - `gh run view 22670371464 --log-failed` (`log not found: 65712590007` en iteración actual).
+      - `gh run rerun 22648216106 --failed` (rerun solicitado en iteración actual).
+      - `gh run rerun 22670371464 --failed` (rerun solicitado en iteración actual).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).
   - salida esperada:

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1342,8 +1342,11 @@ Criterio de salida F5:
   - avance en curso:
     - issue operativa actualizada con seguimiento de `#547`:
       - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994327893`
+      - `https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/issues/546#issuecomment-3994336761`
     - evidencia de bloqueo vigente:
       - `gh run view 22648407847` (`billing lock` en GitHub Actions).
+      - `gh run view 22648597740` (`billing lock` persistente tras rerun/retrigger).
+      - `gh run view 22648597740 --log-failed` (`log not found: 65642481475`).
       - `gh pr checks 547 --json name,state,bucket,link,description` (`security/snyk` sin cuota).
 
 - ⏳ `P12.F1.T45` Sincronizar canónico RuralGO tras cierre de `#544` (`REPORTED -> FIXED` en feedback + master plan con refs reales).

--- a/integrations/git/__tests__/runPlatformGateEvidence.test.ts
+++ b/integrations/git/__tests__/runPlatformGateEvidence.test.ts
@@ -312,3 +312,102 @@ test('emitPlatformGateEvidence inyecta evaluationMetrics vacio cuando no se info
     coverage_ratio: 1,
   });
 });
+
+test('emitPlatformGateEvidence delega telemetría estructurada con stage/outcome/policy', async () => {
+  const findings: ReadonlyArray<Finding> = [
+    {
+      ruleId: 'governance.policy-as-code.invalid',
+      severity: 'ERROR',
+      code: 'POLICY_AS_CODE_SIGNATURE_MISMATCH',
+      message: 'mismatch',
+      filePath: '.pumuki/policy-as-code.json',
+    },
+  ];
+  const detectedPlatforms: DetectedPlatforms = {
+    backend: { detected: true, confidence: 'HIGH' },
+  };
+  const skillsRuleSet: SkillsRuleSetLoadResult = {
+    rules: [],
+    activeBundles: [],
+    mappedHeuristicRuleIds: new Set<string>(),
+    requiresHeuristicFacts: false,
+  };
+  const evidenceService: IEvidenceService = {
+    loadPreviousEvidence: () => undefined,
+    toDetectedPlatformsRecord: () => ({ backend: { detected: true, confidence: 'HIGH' } }),
+    buildRulesetState: () => [],
+  };
+  const policyTrace: ResolvedStagePolicy['trace'] = {
+    source: 'default',
+    bundle: 'gate-policy.default.PRE_PUSH',
+    hash: 'abc123',
+    version: 'policy-as-code/default@1.0',
+    signature: 'f'.repeat(64),
+    policySource: 'computed-local',
+    validation: {
+      status: 'valid',
+      code: 'POLICY_AS_CODE_VALID',
+      message: 'ok',
+      strict: false,
+    },
+  };
+
+  let telemetryCaptured:
+    | {
+      stage: string;
+      gateOutcome: string;
+      filesScanned: number;
+      findingsCount: number;
+      policyBundle: string | undefined;
+      repoBranch: string | null;
+    }
+    | undefined;
+
+  emitPlatformGateEvidence(
+    {
+      stage: 'PRE_PUSH',
+      findings,
+      gateOutcome: 'BLOCK',
+      filesScanned: 5,
+      repoRoot: '/repo/root',
+      detectedPlatforms,
+      skillsRuleSet,
+      projectRules: [],
+      heuristicRules: [],
+      evidenceService,
+      policyTrace,
+    },
+    {
+      generateEvidence: () => ({
+        evidence: { version: '2.1' },
+        write: { ok: true, path: '/tmp/.ai_evidence.json' },
+      }),
+      emitGateTelemetryEvent: async (params) => {
+        telemetryCaptured = {
+          stage: params.stage,
+          gateOutcome: params.gateOutcome,
+          filesScanned: params.filesScanned,
+          findingsCount: params.findings.length,
+          policyBundle: params.policyTrace?.bundle,
+          repoBranch: params.repoState.git.branch,
+        };
+        return {
+          skipped: true,
+          otel_dispatched: false,
+          event: {} as never,
+        };
+      },
+    }
+  );
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(telemetryCaptured, {
+    stage: 'PRE_PUSH',
+    gateOutcome: 'BLOCK',
+    filesScanned: 5,
+    findingsCount: 1,
+    policyBundle: 'gate-policy.default.PRE_PUSH',
+    repoBranch: null,
+  });
+});

--- a/integrations/git/runPlatformGateEvidence.ts
+++ b/integrations/git/runPlatformGateEvidence.ts
@@ -15,13 +15,16 @@ import type { SnapshotEvaluationMetrics, SnapshotRulesCoverage } from '../eviden
 import { normalizeSnapshotEvaluationMetrics } from '../evidence/evaluationMetrics';
 import { normalizeSnapshotRulesCoverage } from '../evidence/rulesCoverage';
 import type { TddBddSnapshot } from '../tdd/types';
+import { emitGateTelemetryEvent } from '../telemetry/gateTelemetry';
 
 export type PlatformGateEvidenceDependencies = {
   generateEvidence: typeof generateEvidence;
+  emitGateTelemetryEvent: typeof emitGateTelemetryEvent;
 };
 
 const defaultDependencies: PlatformGateEvidenceDependencies = {
   generateEvidence,
+  emitGateTelemetryEvent,
 };
 
 export const emitPlatformGateEvidence = (params: {
@@ -54,6 +57,7 @@ export const emitPlatformGateEvidence = (params: {
   };
   const evaluationMetrics = normalizeSnapshotEvaluationMetrics(params.evaluationMetrics);
   const rulesCoverage = normalizeSnapshotRulesCoverage(params.stage, params.rulesCoverage);
+  const repoState = captureRepoState(params.repoRoot);
 
   activeDependencies.generateEvidence({
     stage: params.stage,
@@ -77,7 +81,7 @@ export const emitPlatformGateEvidence = (params: {
       policyTrace: params.policyTrace,
       stage: params.stage,
     }),
-    repoState: captureRepoState(params.repoRoot),
+    repoState,
     sddMetrics: params.sddDecision
       ? {
         enforced: true,
@@ -89,5 +93,17 @@ export const emitPlatformGateEvidence = (params: {
         },
       }
       : undefined,
+  });
+
+  void activeDependencies.emitGateTelemetryEvent({
+    stage: params.stage,
+    auditMode: params.auditMode ?? 'gate',
+    gateOutcome: params.gateOutcome,
+    filesScanned: params.filesScanned,
+    findings: params.findings,
+    repoRoot: params.repoRoot,
+    repoState,
+    policyTrace: params.policyTrace,
+    sddDecision: params.sddDecision,
   });
 };

--- a/integrations/telemetry/__tests__/gateTelemetry.test.ts
+++ b/integrations/telemetry/__tests__/gateTelemetry.test.ts
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import type { Finding } from '../../../core/gate/Finding';
+import type { RepoState } from '../../evidence/schema';
+import { withTempDir } from '../../__tests__/helpers/tempDir';
+import { emitGateTelemetryEvent } from '../gateTelemetry';
+
+const baseRepoState: RepoState = {
+  repo_root: '/repo/root',
+  git: {
+    available: true,
+    branch: 'feature/example',
+    upstream: 'origin/feature/example',
+    ahead: 1,
+    behind: 0,
+    dirty: true,
+    staged: 2,
+    unstaged: 1,
+  },
+  lifecycle: {
+    installed: true,
+    package_version: '6.3.26',
+    lifecycle_version: '6.3.26',
+    hooks: {
+      pre_commit: 'managed',
+      pre_push: 'managed',
+    },
+  },
+};
+
+const findings: ReadonlyArray<Finding> = [
+  {
+    ruleId: 'governance.policy-as-code.invalid',
+    severity: 'ERROR',
+    code: 'POLICY_AS_CODE_SIGNATURE_MISMATCH',
+    message: 'mismatch',
+    filePath: '.pumuki/policy-as-code.json',
+  },
+];
+
+test('emitGateTelemetryEvent escribe JSONL determinista cuando está configurado', async () => {
+  await withTempDir('pumuki-gate-telemetry-jsonl-', async (repoRoot) => {
+    const result = await emitGateTelemetryEvent(
+      {
+        stage: 'PRE_PUSH',
+        auditMode: 'gate',
+        gateOutcome: 'BLOCK',
+        filesScanned: 7,
+        findings,
+        repoRoot,
+        repoState: {
+          ...baseRepoState,
+          repo_root: repoRoot,
+        },
+        policyTrace: {
+          source: 'default',
+          bundle: 'gate-policy.default.PRE_PUSH',
+          hash: 'abc123',
+          version: 'policy-as-code/default@1.0',
+          signature: 'f'.repeat(64),
+          policySource: 'computed-local',
+          validation: {
+            status: 'valid',
+            code: 'POLICY_AS_CODE_VALID',
+            message: 'ok',
+            strict: false,
+          },
+        },
+      },
+      {
+        env: {
+          PUMUKI_TELEMETRY_JSONL_PATH: '.pumuki/artifacts/gate-telemetry.jsonl',
+        } as NodeJS.ProcessEnv,
+        now: () => new Date('2026-03-04T00:00:00.000Z'),
+      }
+    );
+
+    assert.equal(result.skipped, false);
+    assert.equal(result.otel_dispatched, false);
+    assert.ok(result.jsonl_path);
+    assert.equal(
+      result.jsonl_path,
+      join(repoRoot, '.pumuki/artifacts/gate-telemetry.jsonl')
+    );
+
+    const line = readFileSync(result.jsonl_path, 'utf8').trim();
+    const parsed = JSON.parse(line) as {
+      schema: string;
+      stage: string;
+      gate_outcome: string;
+      findings_total: number;
+      policy?: { bundle?: string };
+    };
+    assert.equal(parsed.schema, 'telemetry_event_v1');
+    assert.equal(parsed.stage, 'PRE_PUSH');
+    assert.equal(parsed.gate_outcome, 'BLOCK');
+    assert.equal(parsed.findings_total, 1);
+    assert.equal(parsed.policy?.bundle, 'gate-policy.default.PRE_PUSH');
+  });
+});
+
+test('emitGateTelemetryEvent envía payload OTel opcional cuando endpoint está configurado', async () => {
+  let captured:
+    | {
+      endpoint: string;
+      timeoutMs: number;
+      payload: unknown;
+    }
+    | undefined;
+
+  const result = await emitGateTelemetryEvent(
+    {
+      stage: 'PRE_COMMIT',
+      auditMode: 'gate',
+      gateOutcome: 'PASS',
+      filesScanned: 0,
+      findings: [],
+      repoRoot: '/repo/root',
+      repoState: baseRepoState,
+    },
+    {
+      env: {
+        PUMUKI_TELEMETRY_OTEL_ENDPOINT: 'https://otel.example/v1/logs',
+        PUMUKI_TELEMETRY_OTEL_SERVICE_NAME: 'pumuki-enterprise',
+        PUMUKI_TELEMETRY_OTEL_TIMEOUT_MS: '2500',
+      } as NodeJS.ProcessEnv,
+      now: () => new Date('2026-03-04T00:00:00.000Z'),
+      postOtelPayload: async (params) => {
+        captured = {
+          endpoint: params.endpoint,
+          timeoutMs: params.timeoutMs,
+          payload: params.payload,
+        };
+      },
+    }
+  );
+
+  assert.equal(result.skipped, false);
+  assert.equal(result.otel_dispatched, true);
+  assert.ok(captured);
+  assert.equal(captured?.endpoint, 'https://otel.example/v1/logs');
+  assert.equal(captured?.timeoutMs, 2500);
+});
+
+test('emitGateTelemetryEvent no emite nada si no hay outputs configurados', async () => {
+  const result = await emitGateTelemetryEvent(
+    {
+      stage: 'CI',
+      auditMode: 'engine',
+      gateOutcome: 'WARN',
+      filesScanned: 3,
+      findings: [],
+      repoRoot: '/repo/root',
+      repoState: baseRepoState,
+    },
+    {
+      env: {} as NodeJS.ProcessEnv,
+      now: () => new Date('2026-03-04T00:00:00.000Z'),
+    }
+  );
+
+  assert.equal(result.skipped, true);
+  assert.equal(result.otel_dispatched, false);
+  assert.equal(result.event.schema, 'telemetry_event_v1');
+});

--- a/integrations/telemetry/gateTelemetry.ts
+++ b/integrations/telemetry/gateTelemetry.ts
@@ -1,0 +1,372 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
+import type { Finding } from '../../core/gate/Finding';
+import type { GateOutcome } from '../../core/gate/GateOutcome';
+import type { GateStage } from '../../core/gate/GateStage';
+import type { Severity } from '../../core/rules/Severity';
+import type { RepoState } from '../evidence/schema';
+import type { ResolvedStagePolicy } from '../gate/stagePolicies';
+import type { SddDecision } from '../sdd';
+
+const TELEMETRY_EVENT_SCHEMA = 'telemetry_event_v1';
+const TELEMETRY_EVENT_SCHEMA_VERSION = '1.0';
+const DEFAULT_OTEL_SERVICE_NAME = 'pumuki';
+const DEFAULT_OTEL_TIMEOUT_MS = 1500;
+
+type PolicyTrace = ResolvedStagePolicy['trace'] & {
+  version?: string;
+  signature?: string;
+  policySource?: string;
+  validation?: {
+    status: 'valid' | 'invalid' | 'expired' | 'unknown-source';
+    code: string;
+  };
+};
+
+const toSeverityCounts = (
+  findings: ReadonlyArray<Finding>
+): Record<Severity, number> => {
+  const counts: Record<Severity, number> = {
+    CRITICAL: 0,
+    ERROR: 0,
+    WARN: 0,
+    INFO: 0,
+  };
+  for (const finding of findings) {
+    counts[finding.severity] += 1;
+  }
+  return counts;
+};
+
+const toBlockingFindingsCount = (findings: ReadonlyArray<Finding>): number => {
+  let count = 0;
+  for (const finding of findings) {
+    if (finding.severity === 'CRITICAL' || finding.severity === 'ERROR') {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+const toGateSeverityText = (outcome: GateOutcome): string => {
+  if (outcome === 'BLOCK') {
+    return 'ERROR';
+  }
+  if (outcome === 'WARN') {
+    return 'WARN';
+  }
+  return 'INFO';
+};
+
+const toGateSeverityNumber = (outcome: GateOutcome): number => {
+  if (outcome === 'BLOCK') {
+    return 17;
+  }
+  if (outcome === 'WARN') {
+    return 13;
+  }
+  return 9;
+};
+
+const toOtelTimeoutMs = (value: string | undefined): number => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_OTEL_TIMEOUT_MS;
+  }
+  return parsed;
+};
+
+const resolveTargetPath = (repoRoot: string, targetPath: string): string => {
+  if (isAbsolute(targetPath)) {
+    return targetPath;
+  }
+  return join(repoRoot, targetPath);
+};
+
+const defaultAppendJsonlLine = (targetPath: string, line: string): void => {
+  mkdirSync(dirname(targetPath), { recursive: true });
+  appendFileSync(targetPath, line, 'utf8');
+};
+
+const defaultPostOtelPayload = async (params: {
+  endpoint: string;
+  payload: unknown;
+  timeoutMs: number;
+}): Promise<void> => {
+  if (typeof fetch !== 'function') {
+    return;
+  }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, params.timeoutMs);
+  try {
+    await fetch(params.endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(params.payload),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+export type GateTelemetryEventV1 = {
+  schema: typeof TELEMETRY_EVENT_SCHEMA;
+  schema_version: typeof TELEMETRY_EVENT_SCHEMA_VERSION;
+  emitted_at: string;
+  stage: GateStage;
+  audit_mode: 'gate' | 'engine';
+  gate_outcome: GateOutcome;
+  files_scanned: number;
+  findings_total: number;
+  blocking_findings: number;
+  severity_counts: Record<Severity, number>;
+  repo: {
+    root: string;
+    branch: string | null;
+    upstream: string | null;
+    dirty: boolean;
+    staged: number;
+    unstaged: number;
+    ahead: number;
+    behind: number;
+  };
+  policy?: {
+    source: PolicyTrace['source'];
+    bundle: string;
+    hash: string;
+    version?: string;
+    signature?: string;
+    policy_source?: string;
+    validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source';
+    validation_code?: string;
+  };
+  sdd?: {
+    allowed: boolean;
+    code: string;
+    message: string;
+  };
+};
+
+export type EmitGateTelemetryResult = {
+  skipped: boolean;
+  jsonl_path?: string;
+  otel_dispatched: boolean;
+  event: GateTelemetryEventV1;
+};
+
+export type EmitGateTelemetryDependencies = {
+  env: NodeJS.ProcessEnv;
+  now: () => Date;
+  appendJsonlLine: (targetPath: string, line: string) => void;
+  postOtelPayload: (params: {
+    endpoint: string;
+    payload: unknown;
+    timeoutMs: number;
+  }) => Promise<void>;
+};
+
+const defaultDependencies: EmitGateTelemetryDependencies = {
+  env: process.env,
+  now: () => new Date(),
+  appendJsonlLine: defaultAppendJsonlLine,
+  postOtelPayload: defaultPostOtelPayload,
+};
+
+const toTelemetryEvent = (params: {
+  stage: GateStage;
+  auditMode: 'gate' | 'engine';
+  gateOutcome: GateOutcome;
+  filesScanned: number;
+  findings: ReadonlyArray<Finding>;
+  repoRoot: string;
+  repoState: RepoState;
+  policyTrace?: PolicyTrace;
+  sddDecision?: Pick<SddDecision, 'allowed' | 'code' | 'message'>;
+  emittedAt: Date;
+}): GateTelemetryEventV1 => {
+  return {
+    schema: TELEMETRY_EVENT_SCHEMA,
+    schema_version: TELEMETRY_EVENT_SCHEMA_VERSION,
+    emitted_at: params.emittedAt.toISOString(),
+    stage: params.stage,
+    audit_mode: params.auditMode,
+    gate_outcome: params.gateOutcome,
+    files_scanned: params.filesScanned,
+    findings_total: params.findings.length,
+    blocking_findings: toBlockingFindingsCount(params.findings),
+    severity_counts: toSeverityCounts(params.findings),
+    repo: {
+      root: params.repoRoot,
+      branch: params.repoState.git.branch,
+      upstream: params.repoState.git.upstream,
+      dirty: params.repoState.git.dirty,
+      staged: params.repoState.git.staged,
+      unstaged: params.repoState.git.unstaged,
+      ahead: params.repoState.git.ahead,
+      behind: params.repoState.git.behind,
+    },
+    ...(params.policyTrace
+      ? {
+        policy: {
+          source: params.policyTrace.source,
+          bundle: params.policyTrace.bundle,
+          hash: params.policyTrace.hash,
+          ...(params.policyTrace.version ? { version: params.policyTrace.version } : {}),
+          ...(params.policyTrace.signature ? { signature: params.policyTrace.signature } : {}),
+          ...(params.policyTrace.policySource
+            ? { policy_source: params.policyTrace.policySource }
+            : {}),
+          ...(params.policyTrace.validation
+            ? {
+              validation_status: params.policyTrace.validation.status,
+              validation_code: params.policyTrace.validation.code,
+            }
+            : {}),
+        },
+      }
+      : {}),
+    ...(params.sddDecision
+      ? {
+        sdd: {
+          allowed: params.sddDecision.allowed,
+          code: params.sddDecision.code,
+          message: params.sddDecision.message,
+        },
+      }
+      : {}),
+  };
+};
+
+const toOtelPayload = (params: {
+  event: GateTelemetryEventV1;
+  serviceName: string;
+}): unknown => {
+  const eventBody = JSON.stringify(params.event);
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            {
+              key: 'service.name',
+              value: { stringValue: params.serviceName },
+            },
+            {
+              key: 'pumuki.telemetry.schema',
+              value: { stringValue: params.event.schema },
+            },
+          ],
+        },
+        scopeLogs: [
+          {
+            scope: {
+              name: 'pumuki.telemetry',
+              version: params.event.schema_version,
+            },
+            logRecords: [
+              {
+                timeUnixNano: `${Date.parse(params.event.emitted_at) * 1000000}`,
+                severityNumber: toGateSeverityNumber(params.event.gate_outcome),
+                severityText: toGateSeverityText(params.event.gate_outcome),
+                body: { stringValue: eventBody },
+                attributes: [
+                  {
+                    key: 'pumuki.stage',
+                    value: { stringValue: params.event.stage },
+                  },
+                  {
+                    key: 'pumuki.gate_outcome',
+                    value: { stringValue: params.event.gate_outcome },
+                  },
+                  {
+                    key: 'pumuki.policy_hash',
+                    value: {
+                      stringValue: params.event.policy?.hash ?? '',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+};
+
+export const emitGateTelemetryEvent = async (
+  params: {
+    stage: GateStage;
+    auditMode: 'gate' | 'engine';
+    gateOutcome: GateOutcome;
+    filesScanned: number;
+    findings: ReadonlyArray<Finding>;
+    repoRoot: string;
+    repoState: RepoState;
+    policyTrace?: PolicyTrace;
+    sddDecision?: Pick<SddDecision, 'allowed' | 'code' | 'message'>;
+  },
+  dependencies: Partial<EmitGateTelemetryDependencies> = {}
+): Promise<EmitGateTelemetryResult> => {
+  const activeDependencies: EmitGateTelemetryDependencies = {
+    ...defaultDependencies,
+    ...dependencies,
+  };
+  const jsonlPathRaw = activeDependencies.env.PUMUKI_TELEMETRY_JSONL_PATH?.trim() ?? '';
+  const otelEndpoint = activeDependencies.env.PUMUKI_TELEMETRY_OTEL_ENDPOINT?.trim() ?? '';
+  const otelServiceName =
+    activeDependencies.env.PUMUKI_TELEMETRY_OTEL_SERVICE_NAME?.trim() ||
+    DEFAULT_OTEL_SERVICE_NAME;
+  const otelTimeoutMs = toOtelTimeoutMs(
+    activeDependencies.env.PUMUKI_TELEMETRY_OTEL_TIMEOUT_MS
+  );
+
+  const event = toTelemetryEvent({
+    ...params,
+    emittedAt: activeDependencies.now(),
+  });
+
+  if (jsonlPathRaw.length === 0 && otelEndpoint.length === 0) {
+    return {
+      skipped: true,
+      otel_dispatched: false,
+      event,
+    };
+  }
+
+  let jsonlPath: string | undefined;
+  if (jsonlPathRaw.length > 0) {
+    jsonlPath = resolveTargetPath(params.repoRoot, jsonlPathRaw);
+    activeDependencies.appendJsonlLine(jsonlPath, `${JSON.stringify(event)}\n`);
+  }
+
+  let otelDispatched = false;
+  if (otelEndpoint.length > 0) {
+    const payload = toOtelPayload({
+      event,
+      serviceName: otelServiceName,
+    });
+    try {
+      await activeDependencies.postOtelPayload({
+        endpoint: otelEndpoint,
+        payload,
+        timeoutMs: otelTimeoutMs,
+      });
+      otelDispatched = true;
+    } catch {
+      otelDispatched = false;
+    }
+  }
+
+  return {
+    skipped: false,
+    ...(jsonlPath ? { jsonl_path: jsonlPath } : {}),
+    otel_dispatched: otelDispatched,
+    event,
+  };
+};


### PR DESCRIPTION
## Summary
Implements issue #544 by adding structured gate telemetry export with a stable `telemetry_event_v1` contract.

### What is included
- New telemetry module:
  - `integrations/telemetry/gateTelemetry.ts`
- Automatic telemetry emission on each gate evidence write:
  - `integrations/git/runPlatformGateEvidence.ts`
- Outputs (opt-in, non-intrusive by default):
  - JSONL via `PUMUKI_TELEMETRY_JSONL_PATH`
  - OTel (OTLP HTTP) via `PUMUKI_TELEMETRY_OTEL_ENDPOINT`
- Minimal docs:
  - `README.md`
  - `docs/CONFIGURATION.md`
- Contract and integration tests:
  - `integrations/telemetry/__tests__/gateTelemetry.test.ts`
  - `integrations/git/__tests__/runPlatformGateEvidence.test.ts`

## Backward compatibility
- No behavior change unless telemetry env vars are set.
- Existing `--json` flows remain unchanged.

## Verification
- `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts integrations/git/__tests__/runPlatformGateEvidence.test.ts`
- `npm run -s typecheck`

Closes #544
