### PR TITLE
fix: include telemetry module in published npm package (issue #548)

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "integrations/mcp/*.ts",
     "integrations/notifications/*.ts",
     "integrations/platform/*.ts",
+    "integrations/telemetry/*.ts",
     "scripts/*.ts",
     "scripts/adapters/*.ts",
     "scripts/adapters/*.md",

--- a/scripts/package-manifest-lib.ts
+++ b/scripts/package-manifest-lib.ts
@@ -10,6 +10,7 @@ export const REQUIRED_PACKAGE_PATHS = [
   'core/rules/presets/heuristics/typescript.ts',
   'scripts/package-install-smoke.ts',
   'integrations/git/runPlatformGate.ts',
+  'integrations/telemetry/gateTelemetry.ts',
   'integrations/lifecycle/cli.ts',
   'integrations/notifications/emitAuditSummaryNotification.ts',
   'integrations/evidence/buildEvidence.ts',


### PR DESCRIPTION
## Summary
Fixes consumer runtime crash introduced in `pumuki@6.3.29` where `integrations/telemetry/gateTelemetry.ts` was not included in the npm tarball.

## Root cause
`package.json` `files` whitelist did not include `integrations/telemetry/*.ts`.

## Changes
- Add `integrations/telemetry/*.ts` to publish `files` list.
- Add manifest guard requirement for `integrations/telemetry/gateTelemetry.ts` in `scripts/package-manifest-lib.ts`.

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/package-manifest-lib.test.ts scripts/__tests__/check-package-manifest.test.ts`
- `npm run -s validation:package-manifest`
- `npm pack --json --dry-run | rg "integrations/telemetry/gateTelemetry.ts"`
- `npx --yes tsx@4.21.0 --test integrations/git/__tests__/runPlatformGateEvidence.test.ts integrations/telemetry/__tests__/gateTelemetry.test.ts`
- `npm run -s typecheck`

Closes #548.
