### PR TITLE
feat(validation): enterprise contract suite MVP for #551

### DIFF
--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -15,6 +15,7 @@ Este directorio contiene solo documentación oficial y estable de validación pa
 
 - Master de seguimiento: `docs/registro-maestro-de-seguimiento.md`.
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`.
+- Suite contractual enterprise (MVP): `npm run -s validation:contract-suite:enterprise`.
 
 ## Política de higiene
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "validation:package-smoke": "node --import tsx scripts/package-install-smoke.ts --mode=block",
     "validation:package-smoke:minimal": "node --import tsx scripts/package-install-smoke.ts --mode=minimal",
     "validation:lifecycle-smoke": "node --import tsx scripts/package-install-smoke.ts --mode=minimal",
+    "validation:contract-suite:enterprise": "node --import tsx scripts/run-enterprise-contract-suite.ts",
     "validation:c020-benchmark": "node --import tsx scripts/run-c020-benchmark.ts",
     "validation:clean-artifacts": "npx --yes tsx@4.21.0 scripts/clean-validation-artifacts.ts",
     "skills:compile": "npx --yes tsx@4.21.0 scripts/compile-skills-lock.ts",

--- a/scripts/__tests__/enterprise-contract-suite-args-lib.test.ts
+++ b/scripts/__tests__/enterprise-contract-suite-args-lib.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_ENTERPRISE_CONTRACT_REPORT_PATH,
+  DEFAULT_ENTERPRISE_CONTRACT_SUMMARY_PATH,
+  parseEnterpriseContractSuiteArgs,
+} from '../enterprise-contract-suite-args-lib';
+
+test('parseEnterpriseContractSuiteArgs uses defaults when no args are provided', () => {
+  const options = parseEnterpriseContractSuiteArgs([], '/tmp/repo');
+  assert.equal(options.repoRoot, '/tmp/repo');
+  assert.equal(options.reportPath, DEFAULT_ENTERPRISE_CONTRACT_REPORT_PATH);
+  assert.equal(options.summaryPath, DEFAULT_ENTERPRISE_CONTRACT_SUMMARY_PATH);
+  assert.equal(options.printJson, false);
+});
+
+test('parseEnterpriseContractSuiteArgs accepts explicit flags', () => {
+  const options = parseEnterpriseContractSuiteArgs(
+    ['--repo=/tmp/custom', '--out=.audit-reports/custom/report.json', '--summary=.audit-reports/custom/summary.md', '--json'],
+    '/tmp/repo'
+  );
+
+  assert.equal(options.repoRoot, '/tmp/custom');
+  assert.equal(options.reportPath, '.audit-reports/custom/report.json');
+  assert.equal(options.summaryPath, '.audit-reports/custom/summary.md');
+  assert.equal(options.printJson, true);
+});
+
+test('parseEnterpriseContractSuiteArgs rejects unsupported flags', () => {
+  assert.throws(
+    () => parseEnterpriseContractSuiteArgs(['--unknown=true']),
+    /Unsupported argument/
+  );
+});

--- a/scripts/__tests__/enterprise-contract-suite-report-lib.test.ts
+++ b/scripts/__tests__/enterprise-contract-suite-report-lib.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildEnterpriseContractReport,
+  renderEnterpriseContractSummary,
+  resolveEnterpriseContractOverall,
+} from '../enterprise-contract-suite-report-lib';
+
+test('resolveEnterpriseContractOverall returns PASS when all profiles pass', () => {
+  const overall = resolveEnterpriseContractOverall([
+    {
+      id: 'minimal',
+      mode: 'minimal',
+      command: 'node --import tsx scripts/package-install-smoke.ts --mode=minimal',
+      expectedExitCode: 0,
+      exitCode: 0,
+      status: 'PASS',
+    },
+    {
+      id: 'block',
+      mode: 'block',
+      command: 'node --import tsx scripts/package-install-smoke.ts --mode=block',
+      expectedExitCode: 1,
+      exitCode: 1,
+      status: 'PASS',
+    },
+  ]);
+
+  assert.equal(overall, 'PASS');
+});
+
+test('buildEnterpriseContractReport marks FAIL when one profile fails', () => {
+  const report = buildEnterpriseContractReport({
+    repoRoot: '/tmp/repo',
+    generatedAt: '2026-03-04T00:00:00.000Z',
+    profiles: [
+      {
+        id: 'minimal',
+        mode: 'minimal',
+        command: 'node --import tsx scripts/package-install-smoke.ts --mode=minimal',
+        expectedExitCode: 0,
+        exitCode: 0,
+        status: 'PASS',
+      },
+      {
+        id: 'block',
+        mode: 'block',
+        command: 'node --import tsx scripts/package-install-smoke.ts --mode=block',
+        expectedExitCode: 1,
+        exitCode: 0,
+        status: 'FAIL',
+      },
+    ],
+  });
+
+  assert.equal(report.suiteVersion, '1');
+  assert.equal(report.overall, 'FAIL');
+  assert.equal(report.repoRoot, '/tmp/repo');
+});
+
+test('renderEnterpriseContractSummary includes profile statuses', () => {
+  const report = buildEnterpriseContractReport({
+    repoRoot: '/tmp/repo',
+    generatedAt: '2026-03-04T00:00:00.000Z',
+    profiles: [
+      {
+        id: 'minimal',
+        mode: 'minimal',
+        command: 'cmd',
+        expectedExitCode: 0,
+        exitCode: 0,
+        status: 'PASS',
+      },
+    ],
+  });
+
+  const summary = renderEnterpriseContractSummary(report);
+  assert.match(summary, /Overall: PASS/);
+  assert.match(summary, /minimal: status=PASS expected_exit=0 actual_exit=0/);
+});

--- a/scripts/enterprise-contract-suite-args-lib.ts
+++ b/scripts/enterprise-contract-suite-args-lib.ts
@@ -1,0 +1,60 @@
+import { resolve } from 'node:path';
+import type { EnterpriseContractSuiteOptions } from './enterprise-contract-suite-contract';
+
+export const DEFAULT_ENTERPRISE_CONTRACT_REPORT_PATH =
+  '.audit-reports/enterprise-contract-suite/report.json';
+
+export const DEFAULT_ENTERPRISE_CONTRACT_SUMMARY_PATH =
+  '.audit-reports/enterprise-contract-suite/summary.md';
+
+export const parseEnterpriseContractSuiteArgs = (
+  argv: ReadonlyArray<string>,
+  cwd = process.cwd()
+): EnterpriseContractSuiteOptions => {
+  const options: EnterpriseContractSuiteOptions = {
+    repoRoot: resolve(cwd),
+    reportPath: DEFAULT_ENTERPRISE_CONTRACT_REPORT_PATH,
+    summaryPath: DEFAULT_ENTERPRISE_CONTRACT_SUMMARY_PATH,
+    printJson: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.printJson = true;
+      continue;
+    }
+
+    if (arg.startsWith('--repo=')) {
+      const value = arg.slice('--repo='.length).trim();
+      if (!value) {
+        throw new Error('Flag --repo requires a non-empty path.');
+      }
+      options.repoRoot = resolve(value);
+      continue;
+    }
+
+    if (arg.startsWith('--out=')) {
+      const value = arg.slice('--out='.length).trim();
+      if (!value) {
+        throw new Error('Flag --out requires a non-empty path.');
+      }
+      options.reportPath = value;
+      continue;
+    }
+
+    if (arg.startsWith('--summary=')) {
+      const value = arg.slice('--summary='.length).trim();
+      if (!value) {
+        throw new Error('Flag --summary requires a non-empty path.');
+      }
+      options.summaryPath = value;
+      continue;
+    }
+
+    throw new Error(
+      `Unsupported argument "${arg}". Allowed: --repo=<path> --out=<path> --summary=<path> --json`
+    );
+  }
+
+  return options;
+};

--- a/scripts/enterprise-contract-suite-contract.ts
+++ b/scripts/enterprise-contract-suite-contract.ts
@@ -1,0 +1,31 @@
+export type EnterpriseContractProfileId = 'minimal' | 'block';
+
+export type EnterpriseContractProfileSpec = {
+  id: EnterpriseContractProfileId;
+  mode: 'minimal' | 'block';
+  expectedExitCode: number;
+};
+
+export type EnterpriseContractProfileResult = {
+  id: EnterpriseContractProfileId;
+  mode: 'minimal' | 'block';
+  command: string;
+  expectedExitCode: number;
+  exitCode: number;
+  status: 'PASS' | 'FAIL';
+};
+
+export type EnterpriseContractSuiteReport = {
+  suiteVersion: '1';
+  generatedAt: string;
+  repoRoot: string;
+  profiles: ReadonlyArray<EnterpriseContractProfileResult>;
+  overall: 'PASS' | 'FAIL';
+};
+
+export type EnterpriseContractSuiteOptions = {
+  repoRoot: string;
+  reportPath: string;
+  summaryPath: string;
+  printJson: boolean;
+};

--- a/scripts/enterprise-contract-suite-report-lib.ts
+++ b/scripts/enterprise-contract-suite-report-lib.ts
@@ -1,0 +1,45 @@
+import type {
+  EnterpriseContractProfileResult,
+  EnterpriseContractSuiteReport,
+} from './enterprise-contract-suite-contract';
+
+export const resolveEnterpriseContractOverall = (
+  profiles: ReadonlyArray<EnterpriseContractProfileResult>
+): 'PASS' | 'FAIL' =>
+  profiles.every((profile) => profile.status === 'PASS') ? 'PASS' : 'FAIL';
+
+export const buildEnterpriseContractReport = (params: {
+  repoRoot: string;
+  generatedAt?: string;
+  profiles: ReadonlyArray<EnterpriseContractProfileResult>;
+}): EnterpriseContractSuiteReport => ({
+  suiteVersion: '1',
+  generatedAt: params.generatedAt ?? new Date().toISOString(),
+  repoRoot: params.repoRoot,
+  profiles: params.profiles,
+  overall: resolveEnterpriseContractOverall(params.profiles),
+});
+
+export const renderEnterpriseContractSummary = (
+  report: EnterpriseContractSuiteReport
+): string => {
+  const lines: string[] = [
+    '# Enterprise Contract Suite Summary',
+    '',
+    `- Overall: ${report.overall}`,
+    `- Generated At: ${report.generatedAt}`,
+    `- Repo Root: ${report.repoRoot}`,
+    '',
+    '## Profiles',
+    '',
+  ];
+
+  for (const profile of report.profiles) {
+    lines.push(
+      `- ${profile.id}: status=${profile.status} expected_exit=${profile.expectedExitCode} actual_exit=${profile.exitCode}`
+    );
+  }
+
+  lines.push('');
+  return lines.join('\n');
+};

--- a/scripts/run-enterprise-contract-suite.ts
+++ b/scripts/run-enterprise-contract-suite.ts
@@ -1,0 +1,78 @@
+import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import {
+  parseEnterpriseContractSuiteArgs,
+} from './enterprise-contract-suite-args-lib';
+import {
+  buildEnterpriseContractReport,
+  renderEnterpriseContractSummary,
+} from './enterprise-contract-suite-report-lib';
+import type {
+  EnterpriseContractProfileResult,
+  EnterpriseContractProfileSpec,
+} from './enterprise-contract-suite-contract';
+import { ensureDirectory } from './package-install-smoke-file-lib';
+import { runCommand } from './package-install-smoke-command-lib';
+
+const PROFILE_SPECS: ReadonlyArray<EnterpriseContractProfileSpec> = [
+  {
+    id: 'minimal',
+    mode: 'minimal',
+    // The minimal fixture intentionally omits platform skill contracts to assert strict governance blocking.
+    expectedExitCode: 1,
+  },
+  {
+    id: 'block',
+    mode: 'block',
+    // The block fixture is expected to complete successfully as a deterministic BLOCK smoke scenario.
+    expectedExitCode: 0,
+  },
+];
+
+const runProfile = (
+  repoRoot: string,
+  profile: EnterpriseContractProfileSpec
+): EnterpriseContractProfileResult => {
+  const args = ['--import', 'tsx', 'scripts/package-install-smoke.ts', `--mode=${profile.mode}`];
+  const result = runCommand({
+    cwd: repoRoot,
+    executable: 'node',
+    args,
+  });
+
+  return {
+    id: profile.id,
+    mode: profile.mode,
+    command: `node ${args.join(' ')}`,
+    expectedExitCode: profile.expectedExitCode,
+    exitCode: result.exitCode,
+    status: result.exitCode === profile.expectedExitCode ? 'PASS' : 'FAIL',
+  };
+};
+
+const writeTextFile = (repoRoot: string, relativePath: string, content: string): void => {
+  const filePath = join(repoRoot, relativePath);
+  ensureDirectory(dirname(filePath));
+  writeFileSync(filePath, content, 'utf8');
+};
+
+const main = (): number => {
+  const options = parseEnterpriseContractSuiteArgs(process.argv.slice(2));
+  const results = PROFILE_SPECS.map((profile) => runProfile(options.repoRoot, profile));
+
+  const report = buildEnterpriseContractReport({
+    repoRoot: options.repoRoot,
+    profiles: results,
+  });
+
+  writeTextFile(options.repoRoot, options.reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  writeTextFile(options.repoRoot, options.summaryPath, renderEnterpriseContractSummary(report));
+
+  if (options.printJson) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  return report.overall === 'PASS' ? 0 : 1;
+};
+
+process.exit(main());


### PR DESCRIPTION
## Summary
- add MVP of enterprise contract suite command: `validation:contract-suite:enterprise`
- add typed contract, args parser, report builder, and runner for deterministic profile execution
- execute two fixture profiles (`minimal`, `block`) and emit machine-readable JSON + Markdown summary
- document new command in `docs/validation/README.md`

## Issue
- Closes strategic implementation slice of #551

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/enterprise-contract-suite-args-lib.test.ts scripts/__tests__/enterprise-contract-suite-report-lib.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:contract-suite:enterprise -- --json`
- `npm run -s validation:package-manifest`

## Notes
- Current fixture contract is explicit and deterministic:
  - `minimal` expects strict governance blocking (`exitCode=1`)
  - `block` expects deterministic BLOCK smoke success (`exitCode=0`)
