### PR TITLE
feat: expand enterprise contract suite with deterministic repeat profile

### DIFF
--- a/scripts/__tests__/enterprise-contract-suite-contract.test.ts
+++ b/scripts/__tests__/enterprise-contract-suite-contract.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveEnterpriseContractProfiles } from '../enterprise-contract-suite-contract';
+
+test('resolveEnterpriseContractProfiles returns deterministic profile order', () => {
+  const profiles = resolveEnterpriseContractProfiles();
+  assert.deepEqual(
+    profiles.map((profile) => profile.id),
+    ['minimal', 'block', 'minimal-repeat']
+  );
+});
+
+test('resolveEnterpriseContractProfiles keeps unique ids and expected exit codes', () => {
+  const profiles = resolveEnterpriseContractProfiles();
+  const ids = new Set<string>();
+
+  for (const profile of profiles) {
+    assert.equal(ids.has(profile.id), false);
+    ids.add(profile.id);
+    assert.match(profile.mode, /^(minimal|block)$/);
+    assert.match(`${profile.expectedExitCode}`, /^(0|1)$/);
+  }
+});

--- a/scripts/enterprise-contract-suite-contract.ts
+++ b/scripts/enterprise-contract-suite-contract.ts
@@ -1,4 +1,4 @@
-export type EnterpriseContractProfileId = 'minimal' | 'block';
+export type EnterpriseContractProfileId = 'minimal' | 'block' | 'minimal-repeat';
 
 export type EnterpriseContractProfileSpec = {
   id: EnterpriseContractProfileId;
@@ -29,3 +29,21 @@ export type EnterpriseContractSuiteOptions = {
   summaryPath: string;
   printJson: boolean;
 };
+
+export const resolveEnterpriseContractProfiles = (): ReadonlyArray<EnterpriseContractProfileSpec> => [
+  {
+    id: 'minimal',
+    mode: 'minimal',
+    expectedExitCode: 1,
+  },
+  {
+    id: 'block',
+    mode: 'block',
+    expectedExitCode: 0,
+  },
+  {
+    id: 'minimal-repeat',
+    mode: 'minimal',
+    expectedExitCode: 1,
+  },
+];

--- a/scripts/run-enterprise-contract-suite.ts
+++ b/scripts/run-enterprise-contract-suite.ts
@@ -8,26 +8,12 @@ import {
   renderEnterpriseContractSummary,
 } from './enterprise-contract-suite-report-lib';
 import type {
-  EnterpriseContractProfileResult,
   EnterpriseContractProfileSpec,
+  EnterpriseContractProfileResult,
 } from './enterprise-contract-suite-contract';
+import { resolveEnterpriseContractProfiles } from './enterprise-contract-suite-contract';
 import { ensureDirectory } from './package-install-smoke-file-lib';
 import { runCommand } from './package-install-smoke-command-lib';
-
-const PROFILE_SPECS: ReadonlyArray<EnterpriseContractProfileSpec> = [
-  {
-    id: 'minimal',
-    mode: 'minimal',
-    // The minimal fixture intentionally omits platform skill contracts to assert strict governance blocking.
-    expectedExitCode: 1,
-  },
-  {
-    id: 'block',
-    mode: 'block',
-    // The block fixture is expected to complete successfully as a deterministic BLOCK smoke scenario.
-    expectedExitCode: 0,
-  },
-];
 
 const runProfile = (
   repoRoot: string,
@@ -58,7 +44,9 @@ const writeTextFile = (repoRoot: string, relativePath: string, content: string):
 
 const main = (): number => {
   const options = parseEnterpriseContractSuiteArgs(process.argv.slice(2));
-  const results = PROFILE_SPECS.map((profile) => runProfile(options.repoRoot, profile));
+  const results = resolveEnterpriseContractProfiles().map((profile) =>
+    runProfile(options.repoRoot, profile)
+  );
 
   const report = buildEnterpriseContractReport({
     repoRoot: options.repoRoot,


### PR DESCRIPTION
## Summary
- add `resolveEnterpriseContractProfiles()` contract helper
- add third deterministic profile `minimal-repeat`
- wire runner to profile resolver
- add contract test for profile order and uniqueness

Closes #557

## Validation
- npx --yes tsx@4.21.0 --test scripts/__tests__/enterprise-contract-suite-contract.test.ts scripts/__tests__/enterprise-contract-suite-args-lib.test.ts scripts/__tests__/enterprise-contract-suite-report-lib.test.ts
- npm run -s typecheck
- npm run -s validation:contract-suite:enterprise -- --json
- npm run -s validation:tracking-single-active
