### PR TITLE
chore(release): publish 6.3.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.31",
+  "version": "6.3.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.31",
+      "version": "6.3.32",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.31",
+  "version": "6.3.32",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bump release version to 6.3.32
- include enterprise contract suite repeat-profile hardening from #558

## Validation
- npx --yes tsx@4.21.0 --test scripts/__tests__/enterprise-contract-suite-contract.test.ts scripts/__tests__/enterprise-contract-suite-args-lib.test.ts scripts/__tests__/enterprise-contract-suite-report-lib.test.ts
- npm run -s typecheck
- npm run -s validation:contract-suite:enterprise -- --json
- npm run -s validation:package-manifest
