### PR TITLE
feat: explicit compatibility contract in doctor --deep

### DIFF
--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../saasIngestionContract';
 import { resolveHotspotsSaasIngestionMetricsPath } from '../saasIngestionMetrics';
 import { parseLifecycleCliArgs, runLifecycleCli } from '../cli';
+import { computeEvidencePayloadHash } from '../../evidence/evidenceChain';
 import { openSddSession } from '../../sdd/sessionStore';
 import { resolveMcpAiGateReceiptPath, writeMcpAiGateReceipt } from '../../mcp/aiGateReceipt';
 
@@ -41,76 +42,85 @@ const createGitRepo = (trackedNodeModules = false): string => {
 };
 
 const writePreWriteEvidence = (repoRoot: string, branch: string): void => {
-  writeFileSync(
-    join(repoRoot, '.ai_evidence.json'),
-    JSON.stringify(
-      {
-        version: '2.1',
-        timestamp: new Date().toISOString(),
-        snapshot: {
-          stage: 'PRE_COMMIT',
-          outcome: 'PASS',
-          rules_coverage: {
-            stage: 'PRE_COMMIT',
-            active_rule_ids: ['skills.backend.no-empty-catch'],
-            evaluated_rule_ids: ['skills.backend.no-empty-catch'],
-            matched_rule_ids: [],
-            unevaluated_rule_ids: [],
-            counts: {
-              active: 1,
-              evaluated: 1,
-              matched: 0,
-              unevaluated: 0,
-            },
-            coverage_ratio: 1,
-          },
-          findings: [],
+  const evidence = {
+    version: '2.1' as const,
+    timestamp: new Date().toISOString(),
+    snapshot: {
+      stage: 'PRE_COMMIT' as const,
+      outcome: 'PASS' as const,
+      rules_coverage: {
+        stage: 'PRE_COMMIT' as const,
+        active_rule_ids: ['skills.backend.no-empty-catch'],
+        evaluated_rule_ids: ['skills.backend.no-empty-catch'],
+        matched_rule_ids: [],
+        unevaluated_rule_ids: [],
+        counts: {
+          active: 1,
+          evaluated: 1,
+          matched: 0,
+          unevaluated: 0,
         },
-        ledger: [],
-        platforms: {},
-        rulesets: [],
-        human_intent: null,
-        ai_gate: {
-          status: 'ALLOWED',
-          violations: [],
-          human_intent: null,
-        },
-        severity_metrics: {
-          gate_status: 'ALLOWED',
-          total_violations: 0,
-          by_severity: {
-            CRITICAL: 0,
-            ERROR: 0,
-            WARN: 0,
-            INFO: 0,
-          },
-        },
-        repo_state: {
-          repo_root: repoRoot,
-          git: {
-            available: true,
-            branch,
-            upstream: null,
-            ahead: 0,
-            behind: 0,
-            dirty: false,
-            staged: 0,
-            unstaged: 0,
-          },
-          lifecycle: {
-            installed: true,
-            package_version: '6.3.26',
-            lifecycle_version: '6.3.26',
-            hooks: {
-              pre_commit: 'managed',
-              pre_push: 'managed',
-            },
-          },
+        coverage_ratio: 1,
+      },
+      findings: [],
+    },
+    ledger: [],
+    platforms: {},
+    rulesets: [],
+    human_intent: null,
+    ai_gate: {
+      status: 'ALLOWED' as const,
+      violations: [],
+      human_intent: null,
+    },
+    severity_metrics: {
+      gate_status: 'ALLOWED' as const,
+      total_violations: 0,
+      by_severity: {
+        CRITICAL: 0,
+        ERROR: 0,
+        WARN: 0,
+        INFO: 0,
+      },
+    },
+    repo_state: {
+      repo_root: repoRoot,
+      git: {
+        available: true,
+        branch,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        dirty: false,
+        staged: 0,
+        unstaged: 0,
+      },
+      lifecycle: {
+        installed: true,
+        package_version: '6.3.26',
+        lifecycle_version: '6.3.26',
+        hooks: {
+          pre_commit: 'managed' as const,
+          pre_push: 'managed' as const,
         },
       },
-      null,
-      2
-    ),
+    },
+  };
+
+  const payloadHash = computeEvidencePayloadHash(evidence);
+  const withChain = {
+    ...evidence,
+    evidence_chain: {
+      algorithm: 'sha256' as const,
+      previous_payload_hash: null,
+      payload_hash: payloadHash,
+      sequence: 1,
+    },
+  };
+
+  writeFileSync(
+    join(repoRoot, '.ai_evidence.json'),
+    JSON.stringify(withChain, null, 2),
     'utf8'
   );
 };
@@ -591,6 +601,9 @@ test('runLifecycleCli doctor --deep --json expone checks enterprise determinista
       deep?: {
         enabled?: boolean;
         checks?: Array<{ id?: string }>;
+        contract?: {
+          overall?: string;
+        };
       };
     };
     assert.equal(payload.deep?.enabled, true);
@@ -598,6 +611,12 @@ test('runLifecycleCli doctor --deep --json expone checks enterprise determinista
     assert.equal(payload.deep?.checks?.some((check) => check.id === 'adapter-wiring'), true);
     assert.equal(payload.deep?.checks?.some((check) => check.id === 'policy-drift'), true);
     assert.equal(payload.deep?.checks?.some((check) => check.id === 'evidence-source-drift'), true);
+    assert.equal(payload.deep?.checks?.some((check) => check.id === 'compatibility-contract'), true);
+    assert.equal(
+      payload.deep?.contract?.overall === 'compatible' ||
+      payload.deep?.contract?.overall === 'incompatible',
+      true
+    );
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/__tests__/doctor.test.ts
+++ b/integrations/lifecycle/__tests__/doctor.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import type { AiEvidenceV2_1 } from '../../evidence/schema';
+import { computeEvidencePayloadHash } from '../../evidence/evidenceChain';
 import { withTempDir } from '../../__tests__/helpers/tempDir';
 import { PUMUKI_CONFIG_KEYS } from '../constants';
 import type { ILifecycleGitService } from '../gitService';
@@ -70,56 +71,68 @@ const sampleEvidence = (params: {
   branch: string;
   upstream: string | null;
   timestamp?: string;
-}): AiEvidenceV2_1 => ({
-  version: '2.1',
-  timestamp: params.timestamp ?? new Date().toISOString(),
-  snapshot: {
-    stage: 'PRE_COMMIT',
-    outcome: 'PASS',
-    findings: [],
-  },
-  ledger: [],
-  platforms: {},
-  rulesets: [],
-  human_intent: null,
-  ai_gate: {
-    status: 'ALLOWED',
-    violations: [],
+}): AiEvidenceV2_1 => {
+  const evidence: AiEvidenceV2_1 = {
+    version: '2.1',
+    timestamp: params.timestamp ?? new Date().toISOString(),
+    snapshot: {
+      stage: 'PRE_COMMIT',
+      outcome: 'PASS',
+      findings: [],
+    },
+    ledger: [],
+    platforms: {},
+    rulesets: [],
     human_intent: null,
-  },
-  severity_metrics: {
-    gate_status: 'ALLOWED',
-    total_violations: 0,
-    by_severity: {
-      CRITICAL: 0,
-      ERROR: 0,
-      WARN: 0,
-      INFO: 0,
+    ai_gate: {
+      status: 'ALLOWED',
+      violations: [],
+      human_intent: null,
     },
-  },
-  repo_state: {
-    repo_root: params.repoRoot,
-    git: {
-      available: true,
-      branch: params.branch,
-      upstream: params.upstream,
-      ahead: 0,
-      behind: 0,
-      dirty: false,
-      staged: 0,
-      unstaged: 0,
-    },
-    lifecycle: {
-      installed: true,
-      package_version: '6.3.26',
-      lifecycle_version: '6.3.26',
-      hooks: {
-        pre_commit: 'managed',
-        pre_push: 'managed',
+    severity_metrics: {
+      gate_status: 'ALLOWED',
+      total_violations: 0,
+      by_severity: {
+        CRITICAL: 0,
+        ERROR: 0,
+        WARN: 0,
+        INFO: 0,
       },
     },
-  },
-});
+    repo_state: {
+      repo_root: params.repoRoot,
+      git: {
+        available: true,
+        branch: params.branch,
+        upstream: params.upstream,
+        ahead: 0,
+        behind: 0,
+        dirty: false,
+        staged: 0,
+        unstaged: 0,
+      },
+      lifecycle: {
+        installed: true,
+        package_version: '6.3.26',
+        lifecycle_version: '6.3.26',
+        hooks: {
+          pre_commit: 'managed',
+          pre_push: 'managed',
+        },
+      },
+    },
+  };
+
+  const payloadHash = computeEvidencePayloadHash(evidence);
+  evidence.evidence_chain = {
+    algorithm: 'sha256',
+    previous_payload_hash: null,
+    payload_hash: payloadHash,
+    sequence: 1,
+  };
+
+  return evidence;
+};
 
 test('runLifecycleDoctor marca issue bloqueante cuando hay rutas trackeadas en node_modules', async () => {
   await withTempDir('pumuki-doctor-tracked-', async (repoRoot) => {
@@ -362,7 +375,104 @@ test('runLifecycleDoctor --deep queda en PASS cuando upstream/adapter/policy/evi
 
     assert.equal(report.deep?.enabled, true);
     assert.equal(report.deep?.checks.every((check) => check.status === 'pass'), true);
+    assert.equal(report.deep?.contract.overall, 'compatible');
     assert.equal(report.deep?.blocking, false);
     assert.equal(doctorHasBlockingIssues(report), false);
+  });
+});
+
+test('runLifecycleDoctor --deep marca incompatibilidad cuando OpenSpec es requerido y no está instalado', async () => {
+  await withTempDir('pumuki-doctor-deep-compat-openspec-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.git', 'hooks'), { recursive: true });
+    mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+    mkdirSync(join(repoRoot, 'openspec', 'changes'), { recursive: true });
+    installPumukiHooks(repoRoot);
+
+    writeFileSync(
+      join(repoRoot, '.pumuki', 'adapter.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            pre_write: { command: 'npx --yes pumuki-pre-write' },
+            pre_commit: { command: 'npx --yes pumuki-pre-commit' },
+            pre_push: { command: 'npx --yes pumuki-pre-push' },
+            ci: { command: 'npx --yes pumuki-ci' },
+          },
+          mcp: {
+            enterprise: { command: 'npx --yes --package pumuki@latest pumuki-mcp-enterprise-stdio' },
+            evidence: { command: 'npx --yes --package pumuki@latest pumuki-mcp-evidence-stdio' },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    writeFileSync(
+      join(repoRoot, 'skills.policy.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          defaultBundleEnabled: true,
+          stages: {
+            PRE_COMMIT: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
+            PRE_PUSH: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
+            CI: { blockOnOrAbove: 'ERROR', warnOnOrAbove: 'WARN' },
+          },
+          bundles: {},
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const branch = 'feature/doctor-deep-compat';
+    const upstream = 'origin/feature/doctor-deep-compat';
+    writeFileSync(
+      join(repoRoot, '.ai_evidence.json'),
+      JSON.stringify(
+        sampleEvidence({
+          repoRoot,
+          branch,
+          upstream,
+        }),
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const git = new FakeLifecycleGitService(
+      repoRoot,
+      [],
+      {
+        [PUMUKI_CONFIG_KEYS.installed]: 'true',
+        [PUMUKI_CONFIG_KEYS.version]: getCurrentPumukiVersion(),
+        [PUMUKI_CONFIG_KEYS.hooks]: 'pre-commit,pre-push',
+      },
+      {
+        'rev-parse --abbrev-ref --symbolic-full-name @{u}': upstream,
+        'rev-parse --abbrev-ref HEAD': branch,
+      }
+    );
+
+    const report = runLifecycleDoctor({
+      cwd: repoRoot,
+      git,
+      deep: true,
+    });
+
+    const compatibilityCheck = report.deep?.checks.find(
+      (check) => check.id === 'compatibility-contract'
+    );
+
+    assert.equal(report.deep?.contract.overall, 'incompatible');
+    assert.equal(report.deep?.contract.openspec.required, true);
+    assert.equal(report.deep?.contract.openspec.installed, false);
+    assert.equal(compatibilityCheck?.status, 'fail');
+    assert.equal(compatibilityCheck?.severity, 'warning');
+    assert.equal(report.deep?.blocking, false);
   });
 });

--- a/integrations/lifecycle/doctor.ts
+++ b/integrations/lifecycle/doctor.ts
@@ -6,6 +6,11 @@ import { getPumukiHooksStatus } from './hookManager';
 import { LifecycleGitService, type ILifecycleGitService } from './gitService';
 import { getCurrentPumukiVersion } from './packageInfo';
 import { readLifecycleState, type LifecycleState } from './state';
+import {
+  detectOpenSpecInstallation,
+  evaluateOpenSpecCompatibility,
+  isOpenSpecProjectInitialized,
+} from '../sdd/openSpecCli';
 
 export type DoctorIssueSeverity = 'warning' | 'error';
 
@@ -18,7 +23,8 @@ export type DoctorDeepCheckId =
   | 'upstream-readiness'
   | 'adapter-wiring'
   | 'policy-drift'
-  | 'evidence-source-drift';
+  | 'evidence-source-drift'
+  | 'compatibility-contract';
 
 export type DoctorDeepCheck = {
   id: DoctorDeepCheckId;
@@ -33,6 +39,30 @@ export type DoctorDeepReport = {
   enabled: true;
   checks: ReadonlyArray<DoctorDeepCheck>;
   blocking: boolean;
+  contract: DoctorCompatibilityContract;
+};
+
+export type DoctorCompatibilityContract = {
+  overall: 'compatible' | 'incompatible';
+  pumuki: {
+    installed: boolean;
+    version: string;
+  };
+  openspec: {
+    required: boolean;
+    installed: boolean;
+    version: string | null;
+    minimumVersion: string;
+    compatible: boolean;
+  };
+  hooks: {
+    managed: boolean;
+    managedCount: number;
+    totalCount: number;
+  };
+  adapter: {
+    valid: boolean;
+  };
 };
 
 export type LifecycleDoctorReport = {
@@ -457,21 +487,128 @@ const evaluateEvidenceSourceDriftCheck = (params: {
   });
 };
 
+const buildCompatibilityContract = (params: {
+  repoRoot: string;
+  lifecycleState: LifecycleState;
+  hookStatus: ReturnType<typeof getPumukiHooksStatus>;
+  adapterCheck: DoctorDeepCheck;
+}): DoctorCompatibilityContract => {
+  const hooks = Object.values(params.hookStatus);
+  const managedCount = hooks.filter((entry) => entry.managedBlockPresent).length;
+  const totalCount = hooks.length;
+  const hooksManaged = totalCount > 0 && managedCount === totalCount;
+
+  const openSpecRequired = isOpenSpecProjectInitialized(params.repoRoot);
+  const openSpecInstalled = detectOpenSpecInstallation(params.repoRoot);
+  const openSpecCompatibility = evaluateOpenSpecCompatibility(openSpecInstalled);
+  const openSpecCompatible = openSpecRequired ? openSpecCompatibility.compatible : true;
+
+  const adapterValid = params.adapterCheck.status === 'pass';
+  const pumukiInstalled = params.lifecycleState.installed === 'true';
+  const overallCompatible =
+    pumukiInstalled && hooksManaged && adapterValid && openSpecCompatible;
+
+  return {
+    overall: overallCompatible ? 'compatible' : 'incompatible',
+    pumuki: {
+      installed: pumukiInstalled,
+      version: getCurrentPumukiVersion(),
+    },
+    openspec: {
+      required: openSpecRequired,
+      installed: openSpecInstalled.installed,
+      version: openSpecInstalled.version ?? null,
+      minimumVersion: openSpecCompatibility.minimumVersion,
+      compatible: openSpecCompatible,
+    },
+    hooks: {
+      managed: hooksManaged,
+      managedCount,
+      totalCount,
+    },
+    adapter: {
+      valid: adapterValid,
+    },
+  };
+};
+
+const evaluateCompatibilityContractCheck = (
+  contract: DoctorCompatibilityContract
+): DoctorDeepCheck => {
+  if (contract.overall === 'compatible') {
+    return buildDeepCheck({
+      id: 'compatibility-contract',
+      status: 'pass',
+      severity: 'info',
+      message: 'Compatibility contract is satisfied for pumuki/openspec/hooks/adapter.',
+      metadata: {
+        pumuki_installed: contract.pumuki.installed,
+        openspec_required: contract.openspec.required,
+        openspec_compatible: contract.openspec.compatible,
+        hooks_managed: contract.hooks.managed,
+        adapter_valid: contract.adapter.valid,
+      },
+    });
+  }
+
+  const remediation: string[] = [];
+  if (!contract.pumuki.installed) {
+    remediation.push('Run "pumuki install" to restore lifecycle state.');
+  }
+  if (!contract.hooks.managed) {
+    remediation.push('Regenerate managed hooks with "pumuki install".');
+  }
+  if (!contract.adapter.valid) {
+    remediation.push('Repair adapter wiring with "pumuki adapter install --agent=codex".');
+  }
+  if (contract.openspec.required && !contract.openspec.compatible) {
+    remediation.push(
+      `Install or upgrade OpenSpec to >= ${contract.openspec.minimumVersion} before enterprise validation.`
+    );
+  }
+
+  return buildDeepCheck({
+    id: 'compatibility-contract',
+    status: 'fail',
+    severity: 'warning',
+    message: 'Compatibility contract is not satisfied for one or more required components.',
+    remediation: remediation.join(' '),
+    metadata: {
+      pumuki_installed: contract.pumuki.installed,
+      openspec_required: contract.openspec.required,
+      openspec_compatible: contract.openspec.compatible,
+      hooks_managed: contract.hooks.managed,
+      adapter_valid: contract.adapter.valid,
+    },
+  });
+};
+
 const buildDoctorDeepReport = (params: {
   git: ILifecycleGitService;
   repoRoot: string;
+  lifecycleState: LifecycleState;
+  hookStatus: ReturnType<typeof getPumukiHooksStatus>;
 }): DoctorDeepReport => {
+  const adapterCheck = evaluateAdapterWiringCheck(params.repoRoot);
+  const compatibilityContract = buildCompatibilityContract({
+    repoRoot: params.repoRoot,
+    lifecycleState: params.lifecycleState,
+    hookStatus: params.hookStatus,
+    adapterCheck,
+  });
+
   const checks: DoctorDeepCheck[] = [
     evaluateUpstreamReadinessCheck({
       git: params.git,
       repoRoot: params.repoRoot,
     }),
-    evaluateAdapterWiringCheck(params.repoRoot),
+    adapterCheck,
     evaluatePolicyDriftCheck(params.repoRoot),
     evaluateEvidenceSourceDriftCheck({
       git: params.git,
       repoRoot: params.repoRoot,
     }),
+    evaluateCompatibilityContractCheck(compatibilityContract),
   ];
 
   return {
@@ -480,6 +617,7 @@ const buildDoctorDeepReport = (params: {
     blocking: checks.some(
       (check) => check.status === 'fail' && check.severity === 'error'
     ),
+    contract: compatibilityContract,
   };
 };
 
@@ -504,6 +642,8 @@ export const runLifecycleDoctor = (params?: {
     ? buildDoctorDeepReport({
       git,
       repoRoot,
+      lifecycleState,
+      hookStatus,
     })
     : undefined;
 


### PR DESCRIPTION
## Summary
- adds an explicit compatibility contract payload under `doctor --deep` for pumuki/openspec/hooks/adapter
- adds deep check `compatibility-contract` with deterministic pass/fail metadata and remediation
- extends lifecycle tests to verify the new contract in doctor + CLI JSON output

## Linked issue
- closes #562

## Validation
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/doctor.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:contract-suite:enterprise -- --json`
- `npm run -s validation:tracking-single-active`
