### PR TITLE
docs: retarget active T55 to release issue #565

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F2.T55` (ejecutar policy-as-code versionada y firmada para gates enterprise, issue `#543`).
+- Task activa (`🚧`): `P12.F2.T55` (publicar patch release del contrato de compatibilidad `doctor --deep`, issue `#565`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1780,11 +1780,11 @@ Criterio de salida F5:
     - `npm run -s validation:contract-suite:enterprise -- --json`
     - `npm run -s validation:tracking-single-active`
 
-- 🚧 `P12.F2.T55` Ejecutar siguiente mejora estratégica pendiente: policy-as-code versionada y firmada para gates enterprise (`#543`).
+- 🚧 `P12.F2.T55` Publicar patch release con el contrato de compatibilidad de `doctor --deep` ya mergeado en `#563`.
   - salida esperada:
-    - definición contractual machine-readable de policy con validación en runtime.
-    - tests RED/GREEN de firma/validez y bloqueo en modo estricto.
-    - PR mergeada + release y trazabilidad cerrada en canónico/master.
+    - issue de release creada con alcance/doD verificable (`#565`).
+    - versión npm nueva publicada con el fix de `#562`.
+    - trazabilidad cerrada en plan activo + registro maestro con evidencia de publicación.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- keeps tracking consistent after closing #562/#563
- retargets active `T55` to the real next task: release publication for the merged compatibility-contract fix
- points active task to issue #565 in both active plan and master tracker

## Validation
- `npm run -s validation:tracking-single-active`
