### PR TITLE
release: 6.3.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.32",
+  "version": "6.3.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.32",
+      "version": "6.3.33",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.32",
+  "version": "6.3.33",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bumps package version from `6.3.32` to `6.3.33`
- publishes the release containing PR #563 (`doctor --deep` compatibility contract)

## Linked issue
- closes #565

## Validation
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/doctor.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:contract-suite:enterprise -- --json`
- `npm run -s validation:package-manifest`
