### PR TITLE
docs: publish 6.3.33 adoption notes and advance tracking

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,6 +3,22 @@
 This file tracks the active deterministic framework line used in this repository.
 Detailed commit history remains available through Git history (`git log` / `git show`).
 
+## 2026-03 (enterprise hardening updates)
+
+### 2026-03-04 (v6.3.33)
+
+- Runtime hardening shipped for enterprise diagnosis:
+  - `pumuki doctor --deep --json` now includes explicit compatibility contract payload under `deep.contract`.
+  - New deep check id `compatibility-contract` validates the active contract for `pumuki/openspec/hooks/adapter`.
+- Traceability:
+  - implementation PR: `#563`
+  - release PR: `#567`
+- Consumer quick verification:
+  - `npx --yes --package pumuki@latest pumuki doctor --deep --json`
+  - expected signal in JSON:
+    - `deep.checks` contains an item with `id=compatibility-contract`
+    - `deep.contract.overall` resolves to `compatible` or `incompatible` deterministically
+
 ## 2026-02 (enterprise-refactor updates)
 
 ### 2026-02-27 (v6.3.24)

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F2.T55` (publicar patch release del contrato de compatibilidad `doctor --deep`, issue `#565`).
+- Task activa (`🚧`): `P12.F2.T57` (export de telemetría de gates en JSONL determinista, issue `#569`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1780,11 +1780,35 @@ Criterio de salida F5:
     - `npm run -s validation:contract-suite:enterprise -- --json`
     - `npm run -s validation:tracking-single-active`
 
-- 🚧 `P12.F2.T55` Publicar patch release con el contrato de compatibilidad de `doctor --deep` ya mergeado en `#563`.
+- ✅ `P12.F2.T55` Publicar patch release con el contrato de compatibilidad de `doctor --deep` ya mergeado en `#563`.
+  - cierre ejecutado:
+    - issue creada y cerrada: `#565`.
+    - rama release creada y mergeada: `release/6.3.33` -> `#567` (`https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/567`).
+    - publicación npm completada: `pumuki@6.3.33`.
+    - commit de merge en `develop`: `6f36830`.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/doctor.test.ts integrations/lifecycle/__tests__/cli.test.ts`
+    - `npm run -s typecheck`
+    - `npm run -s validation:contract-suite:enterprise -- --json`
+    - `npm run -s validation:package-manifest`
+    - `npm publish --access public`
+    - `npm view pumuki version` => `6.3.33`
+
+- ✅ `P12.F2.T56` Publicar documentación de adopción de `6.3.33` (release notes + verificación operativa rápida).
+  - cierre ejecutado:
+    - issue documental creada: `#568`.
+    - release notes actualizadas con sección `2026-03-04 (v6.3.33)` y comandos de verificación para consumidores.
+    - documentación operativa alineada con el release publicado `6.3.33`.
+  - evidencia:
+    - `docs/RELEASE_NOTES.md` incluye delta funcional de `doctor --deep` para `compatibility-contract`.
+    - `npm view pumuki version` => `6.3.33`
+    - `npm run -s validation:tracking-single-active`
+
+- 🚧 `P12.F2.T57` Ejecutar siguiente mejora estratégica: export de telemetría de gates en JSONL determinista para auditoría enterprise.
   - salida esperada:
-    - issue de release creada con alcance/doD verificable (`#565`).
-    - versión npm nueva publicada con el fix de `#562`.
-    - trazabilidad cerrada en plan activo + registro maestro con evidencia de publicación.
+    - issue de implementación creada con alcance/doD verificable (`#569`).
+    - output JSONL estable para ingestión de auditoría (SIEM/OTel-ready) sin romper contrato actual.
+    - tests de esquema + no-regresión y documentación mínima de uso.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- adds release-note entry for `v6.3.33` with the `doctor --deep` compatibility-contract delta
- documents consumer quick verification commands for the new release
- closes tracking `T56` and activates `T57` as the only in-progress task (`#569`)

## Linked issue
- closes #568

## Validation
- `npm run -s validation:tracking-single-active`
