### PR TITLE
test/docs: harden JSONL telemetry audit contract

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,6 +117,20 @@ Notes:
 - If unset, no telemetry export is attempted.
 - Gate execution remains deterministic even when OTel endpoint is unavailable (best-effort dispatch).
 
+Quick verification (JSONL):
+
+```bash
+PUMUKI_TELEMETRY_JSONL_PATH=.pumuki/artifacts/gate-telemetry.jsonl \
+  npx --yes --package pumuki@latest pumuki-pre-commit
+```
+
+Expected JSONL keys for enterprise audit ingestion:
+
+- `schema=telemetry_event_v1` with `schema_version=1.0`
+- `stage`, `gate_outcome`, `severity_counts`
+- `policy.bundle`, `policy.hash`, `policy.version`, `policy.signature`, `policy.policy_source`
+- `policy.validation_status`, `policy.validation_code` (when policy-as-code validation is available)
+
 ## Heuristic pilot flag
 
 Enable semantic heuristic rules:

--- a/integrations/telemetry/__tests__/gateTelemetry.test.ts
+++ b/integrations/telemetry/__tests__/gateTelemetry.test.ts
@@ -68,6 +68,11 @@ test('emitGateTelemetryEvent escribe JSONL determinista cuando está configurado
             strict: false,
           },
         },
+        sddDecision: {
+          allowed: false,
+          code: 'SDD_CHANGE_INCOMPLETE',
+          message: 'missing scenario.feature',
+        },
       },
       {
         env: {
@@ -88,16 +93,36 @@ test('emitGateTelemetryEvent escribe JSONL determinista cuando está configurado
     const line = readFileSync(result.jsonl_path, 'utf8').trim();
     const parsed = JSON.parse(line) as {
       schema: string;
+      schema_version: string;
       stage: string;
       gate_outcome: string;
       findings_total: number;
-      policy?: { bundle?: string };
+      policy?: {
+        bundle?: string;
+        version?: string;
+        signature?: string;
+        policy_source?: string;
+        validation_status?: string;
+        validation_code?: string;
+      };
+      sdd?: {
+        allowed?: boolean;
+        code?: string;
+      };
     };
     assert.equal(parsed.schema, 'telemetry_event_v1');
+    assert.equal(parsed.schema_version, '1.0');
     assert.equal(parsed.stage, 'PRE_PUSH');
     assert.equal(parsed.gate_outcome, 'BLOCK');
     assert.equal(parsed.findings_total, 1);
     assert.equal(parsed.policy?.bundle, 'gate-policy.default.PRE_PUSH');
+    assert.equal(parsed.policy?.version, 'policy-as-code/default@1.0');
+    assert.equal(parsed.policy?.signature, 'f'.repeat(64));
+    assert.equal(parsed.policy?.policy_source, 'computed-local');
+    assert.equal(parsed.policy?.validation_status, 'valid');
+    assert.equal(parsed.policy?.validation_code, 'POLICY_AS_CODE_VALID');
+    assert.equal(parsed.sdd?.allowed, false);
+    assert.equal(parsed.sdd?.code, 'SDD_CHANGE_INCOMPLETE');
   });
 });
 


### PR DESCRIPTION
## Summary
- hardens JSONL telemetry contract assertions for enterprise audit ingestion
- verifies policy metadata (`version/signature/source/validation`) and SDD metadata are present in deterministic JSONL output
- documents a concrete JSONL verification snippet in configuration docs

## Linked issue
- closes #569

## Validation
- `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:tracking-single-active`
