### PR TITLE
docs: close T57 and activate T58 in tracking

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F2.T57` (export de telemetría de gates en JSONL determinista, issue `#569`).
+- Task activa (`🚧`): `P12.F2.T58` (rotación/guard de tamaño para telemetría JSONL, issue `#572`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1804,11 +1804,22 @@ Criterio de salida F5:
     - `npm view pumuki version` => `6.3.33`
     - `npm run -s validation:tracking-single-active`
 
-- 🚧 `P12.F2.T57` Ejecutar siguiente mejora estratégica: export de telemetría de gates en JSONL determinista para auditoría enterprise.
+- ✅ `P12.F2.T57` Ejecutar siguiente mejora estratégica: export de telemetría de gates en JSONL determinista para auditoría enterprise.
+  - cierre ejecutado:
+    - issue creada y cerrada: `#569`.
+    - rama técnica creada y mergeada: `feature/569-telemetry-jsonl-audit-hardening` -> `#571` (`https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/571`).
+    - commit de merge en `develop`: `b98ef25`.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts`
+    - `npm run -s typecheck`
+    - `npm run -s validation:tracking-single-active`
+    - `docs/CONFIGURATION.md` actualizado con verificación operativa JSONL y claves esperadas.
+
+- 🚧 `P12.F2.T58` Ejecutar siguiente mejora estratégica: rotación/guard de tamaño para telemetría JSONL en repos enterprise de larga duración.
   - salida esperada:
-    - issue de implementación creada con alcance/doD verificable (`#569`).
-    - output JSONL estable para ingestión de auditoría (SIEM/OTel-ready) sin romper contrato actual.
-    - tests de esquema + no-regresión y documentación mínima de uso.
+    - issue de implementación creada con alcance/doD verificable (`#572`).
+    - soporte opcional de rotación por tamaño en `PUMUKI_TELEMETRY_JSONL_PATH`.
+    - tests de no-regresión y contrato determinista de archivo.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- closes tracking task `T57` with real refs (`#569` / `#571`)
- activates `T58` as the only in-progress task, mapped to issue `#572`
- keeps master tracker pointer aligned with active plan

## Validation
- `npm run -s validation:tracking-single-active`
