### PR TITLE
feat: add telemetry JSONL size rotation guard

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -104,6 +104,9 @@ Structured telemetry output is disabled by default and can be enabled with envir
 - `PUMUKI_TELEMETRY_JSONL_PATH`:
   - JSONL file path for `telemetry_event_v1` records.
   - Accepts absolute path or repo-relative path.
+- `PUMUKI_TELEMETRY_JSONL_MAX_BYTES`:
+  - Optional max size for JSONL file growth.
+  - When current file size plus next event exceeds this value, current file rotates to `<path>.1` before append.
 - `PUMUKI_TELEMETRY_OTEL_ENDPOINT`:
   - OTLP HTTP logs endpoint (`/v1/logs`).
 - `PUMUKI_TELEMETRY_OTEL_SERVICE_NAME`:
@@ -116,6 +119,7 @@ Notes:
 - You can enable JSONL only, OTel only, or both.
 - If unset, no telemetry export is attempted.
 - Gate execution remains deterministic even when OTel endpoint is unavailable (best-effort dispatch).
+- Rotation is opt-in; without `PUMUKI_TELEMETRY_JSONL_MAX_BYTES`, append behavior remains unchanged.
 
 Quick verification (JSONL):
 

--- a/integrations/telemetry/__tests__/gateTelemetry.test.ts
+++ b/integrations/telemetry/__tests__/gateTelemetry.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import test from 'node:test';
 import type { Finding } from '../../../core/gate/Finding';
 import type { RepoState } from '../../evidence/schema';
@@ -189,4 +189,44 @@ test('emitGateTelemetryEvent no emite nada si no hay outputs configurados', asyn
   assert.equal(result.skipped, true);
   assert.equal(result.otel_dispatched, false);
   assert.equal(result.event.schema, 'telemetry_event_v1');
+});
+
+test('emitGateTelemetryEvent rota JSONL cuando el tamaño máximo configurado se supera', async () => {
+  await withTempDir('pumuki-gate-telemetry-jsonl-rotate-', async (repoRoot) => {
+    const telemetryPath = join(repoRoot, '.pumuki/artifacts/gate-telemetry.jsonl');
+    mkdirSync(dirname(telemetryPath), { recursive: true });
+    writeFileSync(telemetryPath, '{"legacy":true}\n', 'utf8');
+
+    const result = await emitGateTelemetryEvent(
+      {
+        stage: 'PRE_COMMIT',
+        auditMode: 'gate',
+        gateOutcome: 'PASS',
+        filesScanned: 1,
+        findings: [],
+        repoRoot,
+        repoState: {
+          ...baseRepoState,
+          repo_root: repoRoot,
+        },
+      },
+      {
+        env: {
+          PUMUKI_TELEMETRY_JSONL_PATH: '.pumuki/artifacts/gate-telemetry.jsonl',
+          PUMUKI_TELEMETRY_JSONL_MAX_BYTES: '16',
+        } as NodeJS.ProcessEnv,
+        now: () => new Date('2026-03-04T00:00:00.000Z'),
+      }
+    );
+
+    assert.equal(result.skipped, false);
+    assert.equal(result.jsonl_path, telemetryPath);
+    assert.equal(existsSync(`${telemetryPath}.1`), true);
+    assert.equal(readFileSync(`${telemetryPath}.1`, 'utf8'), '{"legacy":true}\n');
+
+    const currentLine = readFileSync(telemetryPath, 'utf8').trim();
+    const currentEvent = JSON.parse(currentLine) as { schema?: string; stage?: string };
+    assert.equal(currentEvent.schema, 'telemetry_event_v1');
+    assert.equal(currentEvent.stage, 'PRE_COMMIT');
+  });
 });

--- a/integrations/telemetry/gateTelemetry.ts
+++ b/integrations/telemetry/gateTelemetry.ts
@@ -1,4 +1,11 @@
-import { appendFileSync, mkdirSync } from 'node:fs';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
 import { dirname, isAbsolute, join } from 'node:path';
 import type { Finding } from '../../core/gate/Finding';
 import type { GateOutcome } from '../../core/gate/GateOutcome';
@@ -76,6 +83,14 @@ const toOtelTimeoutMs = (value: string | undefined): number => {
   return parsed;
 };
 
+const toTelemetryJsonlMaxBytes = (value: string | undefined): number | null => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+};
+
 const resolveTargetPath = (repoRoot: string, targetPath: string): string => {
   if (isAbsolute(targetPath)) {
     return targetPath;
@@ -86,6 +101,31 @@ const resolveTargetPath = (repoRoot: string, targetPath: string): string => {
 const defaultAppendJsonlLine = (targetPath: string, line: string): void => {
   mkdirSync(dirname(targetPath), { recursive: true });
   appendFileSync(targetPath, line, 'utf8');
+};
+
+const rotateTelemetryJsonlIfNeeded = (params: {
+  targetPath: string;
+  line: string;
+  maxBytes: number;
+}): void => {
+  mkdirSync(dirname(params.targetPath), { recursive: true });
+
+  const lineBytes = Buffer.byteLength(params.line, 'utf8');
+  let currentSize = 0;
+  if (existsSync(params.targetPath)) {
+    currentSize = statSync(params.targetPath).size;
+  }
+  if (currentSize + lineBytes <= params.maxBytes) {
+    return;
+  }
+
+  const rotatedPath = `${params.targetPath}.1`;
+  if (existsSync(rotatedPath)) {
+    unlinkSync(rotatedPath);
+  }
+  if (existsSync(params.targetPath)) {
+    renameSync(params.targetPath, rotatedPath);
+  }
 };
 
 const defaultPostOtelPayload = async (params: {
@@ -325,6 +365,9 @@ export const emitGateTelemetryEvent = async (
   const otelTimeoutMs = toOtelTimeoutMs(
     activeDependencies.env.PUMUKI_TELEMETRY_OTEL_TIMEOUT_MS
   );
+  const telemetryJsonlMaxBytes = toTelemetryJsonlMaxBytes(
+    activeDependencies.env.PUMUKI_TELEMETRY_JSONL_MAX_BYTES
+  );
 
   const event = toTelemetryEvent({
     ...params,
@@ -342,7 +385,15 @@ export const emitGateTelemetryEvent = async (
   let jsonlPath: string | undefined;
   if (jsonlPathRaw.length > 0) {
     jsonlPath = resolveTargetPath(params.repoRoot, jsonlPathRaw);
-    activeDependencies.appendJsonlLine(jsonlPath, `${JSON.stringify(event)}\n`);
+    const line = `${JSON.stringify(event)}\n`;
+    if (typeof telemetryJsonlMaxBytes === 'number') {
+      rotateTelemetryJsonlIfNeeded({
+        targetPath: jsonlPath,
+        line,
+        maxBytes: telemetryJsonlMaxBytes,
+      });
+    }
+    activeDependencies.appendJsonlLine(jsonlPath, line);
   }
 
   let otelDispatched = false;


### PR DESCRIPTION
## Summary
- adds optional JSONL size guard via `PUMUKI_TELEMETRY_JSONL_MAX_BYTES`
- rotates telemetry file to `<path>.1` when current size + next event exceeds configured threshold
- keeps default behavior unchanged when max-bytes env var is absent
- documents the new env var in configuration docs

## Linked issue
- closes #572

## Validation
- `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:tracking-single-active`
