### PR TITLE
docs: close T58 and activate T59

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F2.T58` (rotación/guard de tamaño para telemetría JSONL, issue `#572`).
+- Task activa (`🚧`): `P12.F2.T59` (cobertura contractual enterprise de rotación JSONL, issue `#575`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1815,11 +1815,22 @@ Criterio de salida F5:
     - `npm run -s validation:tracking-single-active`
     - `docs/CONFIGURATION.md` actualizado con verificación operativa JSONL y claves esperadas.
 
-- 🚧 `P12.F2.T58` Ejecutar siguiente mejora estratégica: rotación/guard de tamaño para telemetría JSONL en repos enterprise de larga duración.
+- ✅ `P12.F2.T58` Ejecutar siguiente mejora estratégica: rotación/guard de tamaño para telemetría JSONL en repos enterprise de larga duración.
+  - cierre ejecutado:
+    - issue creada y cerrada: `#572`.
+    - rama técnica creada y mergeada: `feature/572-telemetry-jsonl-rotation-guard` -> `#574` (`https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/574`).
+    - commit de merge en `develop`: `b3a5b27`.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts`
+    - `npm run -s typecheck`
+    - `npm run -s validation:tracking-single-active`
+    - `docs/CONFIGURATION.md` actualizado con `PUMUKI_TELEMETRY_JSONL_MAX_BYTES`.
+
+- 🚧 `P12.F2.T59` Ejecutar siguiente mejora estratégica: cubrir la rotación JSONL en la suite contractual enterprise.
   - salida esperada:
-    - issue de implementación creada con alcance/doD verificable (`#572`).
-    - soporte opcional de rotación por tamaño en `PUMUKI_TELEMETRY_JSONL_PATH`.
-    - tests de no-regresión y contrato determinista de archivo.
+    - issue de implementación creada con alcance/doD verificable (`#575`).
+    - profile/escenario contractual que valide artefactos `gate-telemetry.jsonl` + `gate-telemetry.jsonl.1`.
+    - resultado visible en `validation:contract-suite:enterprise -- --json`.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- closes tracking task `T58` with real refs (`#572` / `#574`)
- activates `T59` as the only in-progress task mapped to issue `#575`
- keeps master tracker pointer aligned

## Validation
- `npm run -s validation:tracking-single-active`
