### PR TITLE
feat: add telemetry-rotation profile to enterprise contract suite

### DIFF
--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -16,6 +16,11 @@ Este directorio contiene solo documentación oficial y estable de validación pa
 - Master de seguimiento: `docs/registro-maestro-de-seguimiento.md`.
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`.
 - Suite contractual enterprise (MVP): `npm run -s validation:contract-suite:enterprise`.
+  - Perfiles activos del reporte JSON:
+    - `minimal`
+    - `block`
+    - `minimal-repeat`
+    - `telemetry-rotation`
 
 ## Política de higiene
 

--- a/scripts/__tests__/enterprise-contract-suite-contract.test.ts
+++ b/scripts/__tests__/enterprise-contract-suite-contract.test.ts
@@ -6,7 +6,7 @@ test('resolveEnterpriseContractProfiles returns deterministic profile order', ()
   const profiles = resolveEnterpriseContractProfiles();
   assert.deepEqual(
     profiles.map((profile) => profile.id),
-    ['minimal', 'block', 'minimal-repeat']
+    ['minimal', 'block', 'minimal-repeat', 'telemetry-rotation']
   );
 });
 

--- a/scripts/enterprise-contract-suite-contract.ts
+++ b/scripts/enterprise-contract-suite-contract.ts
@@ -1,4 +1,8 @@
-export type EnterpriseContractProfileId = 'minimal' | 'block' | 'minimal-repeat';
+export type EnterpriseContractProfileId =
+  | 'minimal'
+  | 'block'
+  | 'minimal-repeat'
+  | 'telemetry-rotation';
 
 export type EnterpriseContractProfileSpec = {
   id: EnterpriseContractProfileId;
@@ -45,5 +49,10 @@ export const resolveEnterpriseContractProfiles = (): ReadonlyArray<EnterpriseCon
     id: 'minimal-repeat',
     mode: 'minimal',
     expectedExitCode: 1,
+  },
+  {
+    id: 'telemetry-rotation',
+    mode: 'minimal',
+    expectedExitCode: 0,
   },
 ];

--- a/scripts/enterprise-contract-telemetry-rotation.ts
+++ b/scripts/enterprise-contract-telemetry-rotation.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { RepoState } from '../integrations/evidence/schema';
+import { emitGateTelemetryEvent } from '../integrations/telemetry/gateTelemetry';
+
+const buildRepoState = (repoRoot: string): RepoState => ({
+  repo_root: repoRoot,
+  git: {
+    available: true,
+    branch: 'feature/contract-suite-telemetry-rotation',
+    upstream: 'origin/feature/contract-suite-telemetry-rotation',
+    ahead: 0,
+    behind: 0,
+    dirty: false,
+    staged: 0,
+    unstaged: 0,
+  },
+  lifecycle: {
+    installed: true,
+    package_version: '6.3.33',
+    lifecycle_version: '6.3.33',
+    hooks: {
+      pre_commit: 'managed',
+      pre_push: 'managed',
+    },
+  },
+});
+
+const main = async (): Promise<void> => {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'pumuki-contract-telemetry-rotation-'));
+  const jsonlRelativePath = '.pumuki/artifacts/gate-telemetry.jsonl';
+  const repoState = buildRepoState(workspaceRoot);
+
+  try {
+    await emitGateTelemetryEvent(
+      {
+        stage: 'PRE_COMMIT',
+        auditMode: 'gate',
+        gateOutcome: 'PASS',
+        filesScanned: 1,
+        findings: [],
+        repoRoot: workspaceRoot,
+        repoState,
+      },
+      {
+        env: {
+          PUMUKI_TELEMETRY_JSONL_PATH: jsonlRelativePath,
+          PUMUKI_TELEMETRY_JSONL_MAX_BYTES: '1',
+        } as NodeJS.ProcessEnv,
+        now: () => new Date('2026-03-04T00:00:00.000Z'),
+      }
+    );
+
+    const secondEvent = await emitGateTelemetryEvent(
+      {
+        stage: 'PRE_PUSH',
+        auditMode: 'gate',
+        gateOutcome: 'BLOCK',
+        filesScanned: 2,
+        findings: [],
+        repoRoot: workspaceRoot,
+        repoState,
+      },
+      {
+        env: {
+          PUMUKI_TELEMETRY_JSONL_PATH: jsonlRelativePath,
+          PUMUKI_TELEMETRY_JSONL_MAX_BYTES: '1',
+        } as NodeJS.ProcessEnv,
+        now: () => new Date('2026-03-04T00:00:01.000Z'),
+      }
+    );
+
+    assert.ok(secondEvent.jsonl_path);
+    const currentPath = secondEvent.jsonl_path;
+    const rotatedPath = `${currentPath}.1`;
+    assert.equal(existsSync(currentPath), true);
+    assert.equal(existsSync(rotatedPath), true);
+
+    const currentPayload = JSON.parse(readFileSync(currentPath, 'utf8').trim()) as {
+      schema?: string;
+      stage?: string;
+    };
+    const rotatedPayload = JSON.parse(readFileSync(rotatedPath, 'utf8').trim()) as {
+      schema?: string;
+      stage?: string;
+    };
+
+    assert.equal(currentPayload.schema, 'telemetry_event_v1');
+    assert.equal(currentPayload.stage, 'PRE_PUSH');
+    assert.equal(rotatedPayload.schema, 'telemetry_event_v1');
+    assert.equal(rotatedPayload.stage, 'PRE_COMMIT');
+  } finally {
+    rmSync(workspaceRoot, {
+      recursive: true,
+      force: true,
+    });
+  }
+};
+
+void main();

--- a/scripts/run-enterprise-contract-suite.ts
+++ b/scripts/run-enterprise-contract-suite.ts
@@ -19,7 +19,10 @@ const runProfile = (
   repoRoot: string,
   profile: EnterpriseContractProfileSpec
 ): EnterpriseContractProfileResult => {
-  const args = ['--import', 'tsx', 'scripts/package-install-smoke.ts', `--mode=${profile.mode}`];
+  const args =
+    profile.id === 'telemetry-rotation'
+      ? ['--import', 'tsx', 'scripts/enterprise-contract-telemetry-rotation.ts']
+      : ['--import', 'tsx', 'scripts/package-install-smoke.ts', `--mode=${profile.mode}`];
   const result = runCommand({
     cwd: repoRoot,
     executable: 'node',


### PR DESCRIPTION
## Summary
- adds new enterprise contract profile `telemetry-rotation`
- executes dedicated scenario script `scripts/enterprise-contract-telemetry-rotation.ts`
- validates expected telemetry artifacts (`gate-telemetry.jsonl` + `.1`) under rotation conditions
- updates validation docs with the new profile list

## Linked issue
- closes #575

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/enterprise-contract-suite-contract.test.ts scripts/__tests__/enterprise-contract-suite-report-lib.test.ts scripts/__tests__/enterprise-contract-suite-args-lib.test.ts integrations/telemetry/__tests__/gateTelemetry.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:contract-suite:enterprise -- --json`
- `npm run -s validation:tracking-single-active`
