### PR TITLE
release: 6.3.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.33",
+  "version": "6.3.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.33",
+      "version": "6.3.34",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.33",
+  "version": "6.3.34",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bumps package version from `6.3.33` to `6.3.34`
- publishes telemetry hardening shipped in #574 and #577

## Linked issue
- closes #578

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/enterprise-contract-suite-contract.test.ts scripts/__tests__/enterprise-contract-suite-report-lib.test.ts scripts/__tests__/enterprise-contract-suite-args-lib.test.ts integrations/telemetry/__tests__/gateTelemetry.test.ts`
- `npm run -s typecheck`
- `npm run -s validation:contract-suite:enterprise -- --json`
- `npm run -s validation:package-manifest`
- `npm run -s validation:tracking-single-active`
