### PR TITLE
docs: align T62 tracking with new issue #583

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,7 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F2.T62` (policy-as-code versionada y firmada para gates enterprise, issue `#543`).
+- Task activa (`🚧`): `P12.F2.T62` (modo degradado offline/air-gapped para gates enterprise, issue `#583`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1857,10 +1857,10 @@ Criterio de salida F5:
     - `npm run -s validation:tracking-single-active`
     - `gh issue close 581 --comment "Closed via release notes update for 6.3.34 and tracking sync."`
 
-- 🚧 `P12.F2.T62` Ejecutar la siguiente mejora estratégica pendiente: policy-as-code versionada y firmada para gates enterprise (`#543`).
+- 🚧 `P12.F2.T62` Ejecutar la siguiente mejora estratégica pendiente: modo degradado offline/air-gapped para gates enterprise (`#583`).
   - salida esperada:
-    - issue `#543` movida de `REPORTED` a `FIXED` con implementación verificable.
-    - contrato de policy firmado/versionado con validación estricta y trazabilidad en CLI.
+    - issue `#583` movida de `REPORTED` a `FIXED` con implementación verificable.
+    - contrato de `degraded_mode` por stage (`PRE_WRITE/PRE_COMMIT/PRE_PUSH/CI`) visible en CLI/JSON.
     - cobertura de tests RED/GREEN + release readiness documentada en plan activo.
 
 Criterio de salida F6:


### PR DESCRIPTION
## Summary
- fix tracking ambiguity: `T62` no longer points to closed issue `#543`
- create and link active issue `#583` for offline/air-gapped degraded mode
- keep single in-progress task policy in active tracking docs

## Validation
- npm run -s validation:tracking-single-active

Relates #583
