### PR TITLE
feature: degraded mode offline/air-gapped for enterprise gates (#583)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,6 +97,61 @@ Defined in `integrations/gate/stagePolicies.ts`:
 - `PRE_PUSH`: block `ERROR`, warn from `WARN`
 - `CI`: block `ERROR`, warn from `WARN`
 
+## Degraded mode (offline / air-gapped)
+
+Pumuki supports a deterministic degraded contract by stage:
+
+- `PRE_WRITE`
+- `PRE_COMMIT`
+- `PRE_PUSH`
+- `CI`
+
+Resolution precedence:
+
+1. Environment variables (`PUMUKI_DEGRADED_MODE=1`)
+2. File contract (`.pumuki/degraded-mode.json`)
+
+Environment variables:
+
+- `PUMUKI_DEGRADED_MODE`: enable/disable (`1|0`, `true|false`, `yes|no`)
+- `PUMUKI_DEGRADED_REASON`: operator-visible reason
+- `PUMUKI_DEGRADED_ACTION`: global default action (`allow|block`)
+- `PUMUKI_DEGRADED_ACTION_PRE_WRITE`: per-stage override
+- `PUMUKI_DEGRADED_ACTION_PRE_COMMIT`: per-stage override
+- `PUMUKI_DEGRADED_ACTION_PRE_PUSH`: per-stage override
+- `PUMUKI_DEGRADED_ACTION_CI`: per-stage override
+
+File contract (`.pumuki/degraded-mode.json`):
+
+```json
+{
+  "version": "1.0",
+  "enabled": true,
+  "reason": "offline-airgapped",
+  "stages": {
+    "PRE_WRITE": "block",
+    "PRE_COMMIT": "allow",
+    "PRE_PUSH": "block",
+    "CI": "block"
+  }
+}
+```
+
+Runtime behavior:
+
+- `action=block`:
+  - gate adds finding `governance.degraded-mode.blocked`
+  - SDD returns `SDD_DEGRADED_MODE_BLOCKED`
+- `action=allow`:
+  - gate adds informational finding `governance.degraded-mode.active`
+  - SDD returns `ALLOWED` with degraded metadata in `decision.details`
+
+Traceability:
+
+- `policyTrace.degraded` is emitted for gate stages.
+- hook summaries include `degraded_mode`, `degraded_action`, and `degraded_reason` when active.
+- evidence/telemetry include degraded metadata in policy trace when available.
+
 ## Gate telemetry export (optional)
 
 Structured telemetry output is disabled by default and can be enabled with environment variables:

--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,7 +7,8 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Task activa (`🚧`): `P12.F2.T62` (modo degradado offline/air-gapped para gates enterprise, issue `#583`).
+- Última task cerrada (`✅`): `P12.F2.T62` (modo degradado offline/air-gapped para gates enterprise, issue `#583`).
+- Task activa (`🚧`): `P12.F2.T63` (extender `pumuki sdd sync-docs` con `--change --stage --task`, issue `#585`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1857,11 +1857,28 @@ Criterio de salida F5:
     - `npm run -s validation:tracking-single-active`
     - `gh issue close 581 --comment "Closed via release notes update for 6.3.34 and tracking sync."`
 
-- 🚧 `P12.F2.T62` Ejecutar la siguiente mejora estratégica pendiente: modo degradado offline/air-gapped para gates enterprise (`#583`).
+- ✅ `P12.F2.T62` Ejecutar la siguiente mejora estratégica pendiente: modo degradado offline/air-gapped para gates enterprise (`#583`).
+  - cierre ejecutado:
+    - contrato reutilizable implementado en `integrations/gate/degradedMode.ts` con precedencia `env -> .pumuki/degraded-mode.json`.
+    - `resolvePolicyForStage` expone `trace.degraded` por stage.
+    - `runPlatformGate` aplica enforcement:
+      - `action=block` -> finding `governance.degraded-mode.blocked` + gate `BLOCK`.
+      - `action=allow` -> finding `governance.degraded-mode.active` + gate permite continuar.
+    - hooks exitosos publican resumen degradado (`degraded_mode`, `degraded_action`, `degraded_reason`).
+    - SDD integra el contrato:
+      - `action=block` -> `SDD_DEGRADED_MODE_BLOCKED`.
+      - `action=allow` -> `ALLOWED` con metadata degradada en `decision.details`.
+    - documentación operativa actualizada en `docs/CONFIGURATION.md`.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/sdd/__tests__/policy.test.ts` => `58 passed, 0 failed`.
+    - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts` => `4 passed`.
+    - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/EvidenceService.test.ts` => `15 passed`.
+
+- 🚧 `P12.F2.T63` Iniciar SDD pendiente enterprise: extender `pumuki sdd sync-docs` con contexto explícito (`--change`, `--stage`, `--task`) y trazabilidad canónica (`#585`).
   - salida esperada:
-    - issue `#583` movida de `REPORTED` a `FIXED` con implementación verificable.
-    - contrato de `degraded_mode` por stage (`PRE_WRITE/PRE_COMMIT/PRE_PUSH/CI`) visible en CLI/JSON.
-    - cobertura de tests RED/GREEN + release readiness documentada en plan activo.
+    - issue de implementación creada y enlazada desde plan activo.
+    - contrato CLI para `sync-docs` ampliado con flags explícitas y validación determinista.
+    - tests de contrato (`dry-run`, `json`, validación de argumentos) en verde.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/integrations/evidence/schema.ts
+++ b/integrations/evidence/schema.ts
@@ -91,6 +91,11 @@ export type RulesetState = {
   source?: string;
   validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source';
   validation_code?: string;
+  degraded_mode_enabled?: boolean;
+  degraded_mode_action?: 'allow' | 'block';
+  degraded_mode_reason?: string;
+  degraded_mode_source?: 'env' | 'file:.pumuki/degraded-mode.json';
+  degraded_mode_code?: 'DEGRADED_MODE_ALLOWED' | 'DEGRADED_MODE_BLOCKED';
 };
 
 export type HumanIntentConfidence = 'high' | 'medium' | 'low' | 'unset';

--- a/integrations/gate/__tests__/stagePolicies.test.ts
+++ b/integrations/gate/__tests__/stagePolicies.test.ts
@@ -333,6 +333,73 @@ test('resolvePolicyForStage aplica perfil all-severities y bloquea INFO', async 
   });
 });
 
+test('resolvePolicyForStage expone contrato degraded mode desde entorno con acción block por stage', async () => {
+  await withTempDir('pumuki-stage-policy-degraded-env-', async (repoRoot) => {
+    const previousEnabled = process.env.PUMUKI_DEGRADED_MODE;
+    const previousReason = process.env.PUMUKI_DEGRADED_REASON;
+    const previousPrePush = process.env.PUMUKI_DEGRADED_ACTION_PRE_PUSH;
+    process.env.PUMUKI_DEGRADED_MODE = '1';
+    process.env.PUMUKI_DEGRADED_REASON = 'offline-airgapped';
+    process.env.PUMUKI_DEGRADED_ACTION_PRE_PUSH = 'block';
+    try {
+      const resolved = resolvePolicyForStage('PRE_PUSH', repoRoot);
+      assert.equal(resolved.trace.degraded?.enabled, true);
+      assert.equal(resolved.trace.degraded?.action, 'block');
+      assert.equal(resolved.trace.degraded?.reason, 'offline-airgapped');
+      assert.equal(resolved.trace.degraded?.source, 'env');
+      assert.equal(resolved.trace.degraded?.code, 'DEGRADED_MODE_BLOCKED');
+    } finally {
+      if (typeof previousEnabled === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_MODE;
+      } else {
+        process.env.PUMUKI_DEGRADED_MODE = previousEnabled;
+      }
+      if (typeof previousReason === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_REASON;
+      } else {
+        process.env.PUMUKI_DEGRADED_REASON = previousReason;
+      }
+      if (typeof previousPrePush === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_ACTION_PRE_PUSH;
+      } else {
+        process.env.PUMUKI_DEGRADED_ACTION_PRE_PUSH = previousPrePush;
+      }
+    }
+  });
+});
+
+test('resolvePolicyForStage expone contrato degraded mode desde archivo con acción allow por stage', async () => {
+  await withTempDir('pumuki-stage-policy-degraded-file-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.pumuki'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.pumuki', 'degraded-mode.json'),
+      JSON.stringify(
+        {
+          version: '1.0',
+          enabled: true,
+          reason: 'airgapped-enterprise',
+          stages: {
+            PRE_WRITE: 'allow',
+            PRE_COMMIT: 'allow',
+            PRE_PUSH: 'block',
+            CI: 'block',
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const resolved = resolvePolicyForStage('PRE_COMMIT', repoRoot);
+    assert.equal(resolved.trace.degraded?.enabled, true);
+    assert.equal(resolved.trace.degraded?.action, 'allow');
+    assert.equal(resolved.trace.degraded?.reason, 'airgapped-enterprise');
+    assert.equal(resolved.trace.degraded?.source, 'file:.pumuki/degraded-mode.json');
+    assert.equal(resolved.trace.degraded?.code, 'DEGRADED_MODE_ALLOWED');
+  });
+});
+
 test('mapEnterpriseSeverityToGateSeverity convierte severidades enterprise a severidades de gate', () => {
   assert.equal(mapEnterpriseSeverityToGateSeverity('CRITICAL'), 'CRITICAL');
   assert.equal(mapEnterpriseSeverityToGateSeverity('HIGH'), 'ERROR');

--- a/integrations/gate/degradedMode.ts
+++ b/integrations/gate/degradedMode.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type DegradedStage = 'PRE_WRITE' | 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+export type DegradedAction = 'allow' | 'block';
+export type DegradedCode = 'DEGRADED_MODE_ALLOWED' | 'DEGRADED_MODE_BLOCKED';
+
+export type DegradedResolution = {
+  enabled: true;
+  action: DegradedAction;
+  reason: string;
+  source: 'env' | 'file:.pumuki/degraded-mode.json';
+  code: DegradedCode;
+};
+
+const DEGRADED_MODE_FILE_PATH = '.pumuki/degraded-mode.json';
+
+const toBooleanFlag = (value: string | undefined): boolean | null => {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on') {
+    return true;
+  }
+  if (normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off') {
+    return false;
+  }
+  return null;
+};
+
+const toAction = (value: unknown): DegradedAction | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'allow') {
+    return 'allow';
+  }
+  if (normalized === 'block') {
+    return 'block';
+  }
+  return null;
+};
+
+const toCode = (action: DegradedAction): DegradedCode => {
+  return action === 'block' ? 'DEGRADED_MODE_BLOCKED' : 'DEGRADED_MODE_ALLOWED';
+};
+
+const resolveActionFromEnv = (stage: DegradedStage): DegradedAction => {
+  const stageKey = `PUMUKI_DEGRADED_ACTION_${stage}`;
+  const byStage = toAction(process.env[stageKey]);
+  if (byStage) {
+    return byStage;
+  }
+  const globalAction = toAction(process.env.PUMUKI_DEGRADED_ACTION);
+  if (globalAction) {
+    return globalAction;
+  }
+  return 'allow';
+};
+
+type DegradedModeFile = {
+  version?: unknown;
+  enabled?: unknown;
+  reason?: unknown;
+  action?: unknown;
+  stages?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const resolveFromFile = (
+  repoRoot: string,
+  stage: DegradedStage
+): DegradedResolution | undefined => {
+  const configPath = join(repoRoot, DEGRADED_MODE_FILE_PATH);
+  if (!existsSync(configPath)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as DegradedModeFile;
+    if (parsed.enabled !== true) {
+      return undefined;
+    }
+    const stageActions = isRecord(parsed.stages) ? parsed.stages : undefined;
+    const stageAction = stageActions ? toAction(stageActions[stage]) : null;
+    const globalAction = toAction(parsed.action);
+    const action = stageAction ?? globalAction ?? 'allow';
+    const reason =
+      typeof parsed.reason === 'string' && parsed.reason.trim().length > 0
+        ? parsed.reason.trim()
+        : 'degraded-mode';
+    return {
+      enabled: true,
+      action,
+      reason,
+      source: 'file:.pumuki/degraded-mode.json',
+      code: toCode(action),
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+export const resolveDegradedMode = (
+  stage: DegradedStage,
+  repoRoot: string = process.cwd()
+): DegradedResolution | undefined => {
+  const enabledFromEnv = toBooleanFlag(process.env.PUMUKI_DEGRADED_MODE);
+  if (enabledFromEnv === true) {
+    const action = resolveActionFromEnv(stage);
+    const reason =
+      process.env.PUMUKI_DEGRADED_REASON?.trim().length
+        ? process.env.PUMUKI_DEGRADED_REASON.trim()
+        : 'degraded-mode';
+    return {
+      enabled: true,
+      action,
+      reason,
+      source: 'env',
+      code: toCode(action),
+    };
+  }
+  if (enabledFromEnv === false) {
+    return undefined;
+  }
+  return resolveFromFile(repoRoot, stage);
+};

--- a/integrations/gate/stagePolicies.ts
+++ b/integrations/gate/stagePolicies.ts
@@ -10,6 +10,7 @@ import {
   loadSkillsPolicy,
 } from '../config/skillsPolicy';
 import type { SkillsStage } from '../config/skillsLock';
+import { resolveDegradedMode } from './degradedMode';
 
 const heuristicsPromotionStageAllowList = new Set<GateStage>([
   'PRE_COMMIT',
@@ -57,6 +58,13 @@ export type ResolvedStagePolicy = {
         | 'POLICY_AS_CODE_UNKNOWN_SOURCE';
       message: string;
       strict: boolean;
+    };
+    degraded?: {
+      enabled: true;
+      action: 'allow' | 'block';
+      reason: string;
+      source: 'env' | 'file:.pumuki/degraded-mode.json';
+      code: 'DEGRADED_MODE_ALLOWED' | 'DEGRADED_MODE_BLOCKED';
     };
   };
 };
@@ -519,6 +527,7 @@ export const resolvePolicyForStage = (
   stage: SkillsStage,
   repoRoot: string = process.cwd()
 ): ResolvedStagePolicy => {
+  const degraded = resolveDegradedMode(stage, repoRoot);
   const hardModeState = resolveHardModeState(repoRoot);
   if (hardModeState.enabled) {
     const profileName = hardModeState.profileName;
@@ -553,6 +562,7 @@ export const resolvePolicyForStage = (
         signature: policyAsCode.signature,
         policySource: policyAsCode.policySource,
         validation: policyAsCode.validation,
+        ...(degraded ? { degraded } : {}),
       },
     };
   }
@@ -586,6 +596,7 @@ export const resolvePolicyForStage = (
         signature: policyAsCode.signature,
         policySource: policyAsCode.policySource,
         validation: policyAsCode.validation,
+        ...(degraded ? { degraded } : {}),
       },
     };
   }
@@ -621,6 +632,7 @@ export const resolvePolicyForStage = (
       signature: policyAsCode.signature,
       policySource: policyAsCode.policySource,
       validation: policyAsCode.validation,
+      ...(degraded ? { degraded } : {}),
     },
   };
 };

--- a/integrations/git/EvidenceService.ts
+++ b/integrations/git/EvidenceService.ts
@@ -112,6 +112,15 @@ export class EvidenceService implements IEvidenceService {
               validation_code: params.policyTrace.validation.code,
             }
           : {}),
+        ...(params.policyTrace.degraded
+          ? {
+              degraded_mode_enabled: params.policyTrace.degraded.enabled,
+              degraded_mode_action: params.policyTrace.degraded.action,
+              degraded_mode_reason: params.policyTrace.degraded.reason,
+              degraded_mode_source: params.policyTrace.degraded.source,
+              degraded_mode_code: params.policyTrace.degraded.code,
+            }
+          : {}),
       });
     }
 

--- a/integrations/git/__tests__/hookGateSummary.test.ts
+++ b/integrations/git/__tests__/hookGateSummary.test.ts
@@ -35,6 +35,13 @@ test('runPreCommitStage emite resumen mínimo del gate en éxito', async () => {
         version: 'policy-as-code/default@1.0',
         signature: 'a'.repeat(64),
         policySource: 'computed-local',
+        degraded: {
+          enabled: true,
+          action: 'allow',
+          reason: 'offline-airgapped',
+          source: 'env',
+          code: 'DEGRADED_MODE_ALLOWED',
+        },
       },
     }),
     runPlatformGate: async () => 0,
@@ -56,6 +63,9 @@ test('runPreCommitStage emite resumen mínimo del gate en éxito', async () => {
   assert.match(summaries[0] ?? '', /policy_version=policy-as-code\/default@1.0/);
   assert.match(summaries[0] ?? '', /policy_signature=a{64}/);
   assert.match(summaries[0] ?? '', /policy_source=computed-local/);
+  assert.match(summaries[0] ?? '', /degraded_mode=enabled/);
+  assert.match(summaries[0] ?? '', /degraded_action=allow/);
+  assert.match(summaries[0] ?? '', /degraded_reason=offline-airgapped/);
   assert.match(summaries[0] ?? '', /evidence_kind=valid/);
   assert.match(summaries[0] ?? '', /evidence_age_seconds=30/);
 });

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -488,6 +488,158 @@ test('runPlatformGate bloquea en modo strict cuando policy-as-code está expirad
   assert.equal(policyFinding?.source, 'policy-as-code');
 });
 
+test('runPlatformGate bloquea cuando degraded mode está activo en fail-closed para el stage', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_PUSH',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'range' as const, baseRef: 'origin/develop', headRef: 'HEAD' };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedFindings: ReadonlyArray<Finding> = [];
+
+  const result = await runPlatformGate({
+    policy,
+    policyTrace: {
+      source: 'default',
+      bundle: 'gate-policy.default.PRE_PUSH',
+      hash: 'f'.repeat(64),
+      version: 'policy-as-code/default@1.0',
+      signature: 'a'.repeat(64),
+      policySource: 'computed-local',
+      degraded: {
+        enabled: true,
+        action: 'block',
+        reason: 'offline-airgapped',
+        source: 'env',
+        code: 'DEGRADED_MODE_BLOCKED',
+      },
+      validation: {
+        status: 'valid',
+        code: 'POLICY_AS_CODE_VALID',
+        message: 'Policy-as-code contract verified successfully.',
+        strict: false,
+      },
+    },
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedFindings = paramsArg.findings;
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  const degradedFinding = emittedFindings.find(
+    (finding) => finding.ruleId === 'governance.degraded-mode.blocked'
+  );
+  assert.ok(degradedFinding);
+  assert.equal(degradedFinding?.code, 'DEGRADED_MODE_BLOCKED');
+  assert.equal(degradedFinding?.source, 'degraded-mode');
+});
+
+test('runPlatformGate mantiene allow cuando degraded mode está activo en fail-open para el stage', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'staged' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedFindings: ReadonlyArray<Finding> = [];
+
+  const result = await runPlatformGate({
+    policy,
+    policyTrace: {
+      source: 'default',
+      bundle: 'gate-policy.default.PRE_COMMIT',
+      hash: 'f'.repeat(64),
+      version: 'policy-as-code/default@1.0',
+      signature: 'a'.repeat(64),
+      policySource: 'computed-local',
+      degraded: {
+        enabled: true,
+        action: 'allow',
+        reason: 'offline-airgapped',
+        source: 'env',
+        code: 'DEGRADED_MODE_ALLOWED',
+      },
+      validation: {
+        status: 'valid',
+        code: 'POLICY_AS_CODE_VALID',
+        message: 'Policy-as-code contract verified successfully.',
+        strict: false,
+      },
+    },
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedFindings = paramsArg.findings;
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  const degradedFinding = emittedFindings.find(
+    (finding) => finding.ruleId === 'governance.degraded-mode.active'
+  );
+  assert.ok(degradedFinding);
+  assert.equal(degradedFinding?.code, 'DEGRADED_MODE_ALLOWED');
+  assert.equal(degradedFinding?.severity, 'INFO');
+});
+
 test('runPlatformGate devuelve 1 cuando SDD bloquea PRE_COMMIT', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_COMMIT',

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -366,6 +366,40 @@ const toPolicyAsCodeBlockingFinding = (params: {
   };
 };
 
+const toDegradedModeFinding = (params: {
+  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  policyTrace?: ResolvedStagePolicy['trace'];
+}): Finding | undefined => {
+  const degraded = params.policyTrace?.degraded;
+  if (!degraded?.enabled) {
+    return undefined;
+  }
+  if (degraded.action === 'block') {
+    return {
+      ruleId: 'governance.degraded-mode.blocked',
+      severity: 'ERROR',
+      code: degraded.code,
+      message:
+        `Degraded mode is active at ${params.stage} with fail-closed action=block. ` +
+        `reason=${degraded.reason} source=${degraded.source}.`,
+      filePath: '.pumuki/degraded-mode.json',
+      matchedBy: 'DegradedModeGuard',
+      source: 'degraded-mode',
+    };
+  }
+  return {
+    ruleId: 'governance.degraded-mode.active',
+    severity: 'INFO',
+    code: degraded.code,
+    message:
+      `Degraded mode is active at ${params.stage} with fail-open action=allow. ` +
+      `reason=${degraded.reason} source=${degraded.source}.`,
+    filePath: '.pumuki/degraded-mode.json',
+    matchedBy: 'DegradedModeGuard',
+    source: 'degraded-mode',
+  };
+};
+
 const toGateWaiverAppliedFinding = (params: {
   stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
   waiver: Extract<GateWaiverResult, { kind: 'applied' }>['waiver'];
@@ -621,6 +655,16 @@ export async function runPlatformGate(params: {
           policyTrace: params.policyTrace,
         })
       : undefined;
+  const degradedModeFinding =
+    params.policy.stage === 'PRE_COMMIT' ||
+    params.policy.stage === 'PRE_PUSH' ||
+    params.policy.stage === 'CI'
+      ? toDegradedModeFinding({
+          stage: params.policy.stage,
+          policyTrace: params.policyTrace,
+        })
+      : undefined;
+  const degradedModeBlocks = params.policyTrace?.degraded?.action === 'block';
   const rulesCoverage = coverage
     ? {
       stage: params.policy.stage,
@@ -665,6 +709,7 @@ export async function runPlatformGate(params: {
   const effectiveFindings = sddBlockingFinding
     ? [
       sddBlockingFinding,
+      ...(degradedModeFinding ? [degradedModeFinding] : []),
       ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
       ...(unsupportedSkillsMappingFinding ? [unsupportedSkillsMappingFinding] : []),
       ...(platformSkillsCoverageFinding ? [platformSkillsCoverageFinding] : []),
@@ -678,8 +723,10 @@ export async function runPlatformGate(params: {
       || skillsScopeComplianceFinding
       || coverageBlockingFinding
       || policyAsCodeBlockingFinding
+      || degradedModeFinding
       || tddBddEvaluation.findings.length > 0
       ? [
+        ...(degradedModeFinding ? [degradedModeFinding] : []),
         ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
         ...(unsupportedSkillsMappingFinding ? [unsupportedSkillsMappingFinding] : []),
         ...(platformSkillsCoverageFinding ? [platformSkillsCoverageFinding] : []),
@@ -692,6 +739,7 @@ export async function runPlatformGate(params: {
   const decision = dependencies.evaluateGate([...effectiveFindings], params.policy);
   const baseGateOutcome =
     sddBlockingFinding ||
+    degradedModeBlocks ||
     policyAsCodeBlockingFinding ||
     unsupportedSkillsMappingFinding ||
     platformSkillsCoverageFinding ||

--- a/integrations/git/stageRunners.ts
+++ b/integrations/git/stageRunners.ts
@@ -120,11 +120,17 @@ const emitSuccessfulHookGateSummary = (params: {
     params.stage === 'PRE_COMMIT'
       ? PRE_COMMIT_EVIDENCE_MAX_AGE_SECONDS
       : PRE_PUSH_EVIDENCE_MAX_AGE_SECONDS;
+  const degradedSummary =
+    params.policyTrace.degraded?.enabled
+      ? ` degraded_mode=enabled degraded_action=${params.policyTrace.degraded.action}` +
+        ` degraded_reason=${params.policyTrace.degraded.reason}`
+      : '';
   params.dependencies.writeHookGateSummary(
     `[pumuki][hook-gate] stage=${params.stage} policy_bundle=${params.policyTrace.bundle} policy_hash=${params.policyTrace.hash}` +
       ` policy_version=${params.policyTrace.version ?? 'n/a'}` +
       ` policy_signature=${params.policyTrace.signature ?? 'n/a'}` +
       ` policy_source=${params.policyTrace.policySource ?? 'n/a'}` +
+      `${degradedSummary}` +
       ` decision=ALLOW evidence_kind=${evidence.kind} evidence_age_seconds=${evidenceAgeSeconds ?? 'n/a'} max_age_seconds=${maxAgeSeconds}`
   );
 };

--- a/integrations/sdd/__tests__/policy.test.ts
+++ b/integrations/sdd/__tests__/policy.test.ts
@@ -242,6 +242,76 @@ test('evaluateSddPolicy permite PRE_WRITE con sesión válida sin ejecutar valid
   });
 });
 
+test('evaluateSddPolicy bloquea PRE_WRITE cuando degraded mode fail-closed está activo', () => {
+  return withFixtureRepo('pumuki-sdd-prewrite-degraded-block-', (repoRoot) => {
+    const previousEnabled = process.env.PUMUKI_DEGRADED_MODE;
+    const previousReason = process.env.PUMUKI_DEGRADED_REASON;
+    const previousAction = process.env.PUMUKI_DEGRADED_ACTION_PRE_WRITE;
+    process.env.PUMUKI_DEGRADED_MODE = '1';
+    process.env.PUMUKI_DEGRADED_REASON = 'offline-airgapped';
+    process.env.PUMUKI_DEGRADED_ACTION_PRE_WRITE = 'block';
+    try {
+      const result = evaluateSddPolicy({ stage: 'PRE_WRITE', repoRoot });
+      assert.equal(result.decision.allowed, false);
+      assert.equal(result.decision.code, 'SDD_DEGRADED_MODE_BLOCKED');
+      assert.equal(result.decision.details?.degraded_mode, true);
+      assert.equal(result.decision.details?.degraded_action, 'block');
+      assert.equal(result.decision.details?.degraded_reason, 'offline-airgapped');
+    } finally {
+      if (typeof previousEnabled === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_MODE;
+      } else {
+        process.env.PUMUKI_DEGRADED_MODE = previousEnabled;
+      }
+      if (typeof previousReason === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_REASON;
+      } else {
+        process.env.PUMUKI_DEGRADED_REASON = previousReason;
+      }
+      if (typeof previousAction === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_ACTION_PRE_WRITE;
+      } else {
+        process.env.PUMUKI_DEGRADED_ACTION_PRE_WRITE = previousAction;
+      }
+    }
+  });
+});
+
+test('evaluateSddPolicy permite PRE_COMMIT cuando degraded mode fail-open está activo', () => {
+  return withFixtureRepo('pumuki-sdd-precommit-degraded-allow-', (repoRoot) => {
+    const previousEnabled = process.env.PUMUKI_DEGRADED_MODE;
+    const previousReason = process.env.PUMUKI_DEGRADED_REASON;
+    const previousAction = process.env.PUMUKI_DEGRADED_ACTION_PRE_COMMIT;
+    process.env.PUMUKI_DEGRADED_MODE = '1';
+    process.env.PUMUKI_DEGRADED_REASON = 'offline-airgapped';
+    process.env.PUMUKI_DEGRADED_ACTION_PRE_COMMIT = 'allow';
+    try {
+      const result = evaluateSddPolicy({ stage: 'PRE_COMMIT', repoRoot });
+      assert.equal(result.decision.allowed, true);
+      assert.equal(result.decision.code, 'ALLOWED');
+      assert.equal(result.decision.details?.degraded_mode, true);
+      assert.equal(result.decision.details?.degraded_action, 'allow');
+      assert.equal(result.decision.details?.degraded_reason, 'offline-airgapped');
+    } finally {
+      if (typeof previousEnabled === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_MODE;
+      } else {
+        process.env.PUMUKI_DEGRADED_MODE = previousEnabled;
+      }
+      if (typeof previousReason === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_REASON;
+      } else {
+        process.env.PUMUKI_DEGRADED_REASON = previousReason;
+      }
+      if (typeof previousAction === 'undefined') {
+        delete process.env.PUMUKI_DEGRADED_ACTION_PRE_COMMIT;
+      } else {
+        process.env.PUMUKI_DEGRADED_ACTION_PRE_COMMIT = previousAction;
+      }
+    }
+  });
+});
+
 test('evaluateSddPolicy bloquea con SDD_CHANGE_INCOMPLETE en PRE_PUSH cuando falta contrato mínimo del change', () => {
   return withFixtureRepo('pumuki-sdd-change-incomplete-', (repoRoot) => {
     writeOpenSpecBinary(repoRoot, {

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -8,6 +8,7 @@ import {
   validateOpenSpecChanges,
 } from './openSpecCli';
 import { readSddSession, refreshSddSession } from './sessionStore';
+import { resolveDegradedMode } from '../gate/degradedMode';
 import type {
   SddDecision,
   SddEvaluateResult,
@@ -203,6 +204,42 @@ export const evaluateSddPolicy = (params: {
         {
           bypass: true,
           env: 'PUMUKI_SDD_BYPASS',
+        }
+      ),
+    };
+  }
+
+  const degradedMode = resolveDegradedMode(params.stage, repoRoot);
+  if (degradedMode?.action === 'block') {
+    return {
+      stage: params.stage,
+      status,
+      decision: blocked(
+        'SDD_DEGRADED_MODE_BLOCKED',
+        `SDD blocked by degraded mode (action=block). reason=${degradedMode.reason} source=${degradedMode.source}.`,
+        {
+          degraded_mode: true,
+          degraded_action: degradedMode.action,
+          degraded_reason: degradedMode.reason,
+          degraded_source: degradedMode.source,
+          degraded_code: degradedMode.code,
+        }
+      ),
+    };
+  }
+
+  if (degradedMode?.action === 'allow') {
+    return {
+      stage: params.stage,
+      status,
+      decision: allowed(
+        `SDD allowed in degraded mode (action=allow). reason=${degradedMode.reason} source=${degradedMode.source}.`,
+        {
+          degraded_mode: true,
+          degraded_action: degradedMode.action,
+          degraded_reason: degradedMode.reason,
+          degraded_source: degradedMode.source,
+          degraded_code: degradedMode.code,
         }
       ),
     };

--- a/integrations/sdd/types.ts
+++ b/integrations/sdd/types.ts
@@ -12,6 +12,7 @@ export type SddDecisionCode =
   | 'SDD_VALIDATION_FAILED'
   | 'SDD_VALIDATION_ERROR'
   | 'SDD_VALIDATION_EMPTY_SCOPE'
+  | 'SDD_DEGRADED_MODE_BLOCKED'
   | 'SDD_CHANGE_INCOMPLETE';
 
 export type SddDecision = {

--- a/integrations/telemetry/gateTelemetry.ts
+++ b/integrations/telemetry/gateTelemetry.ts
@@ -28,6 +28,13 @@ type PolicyTrace = ResolvedStagePolicy['trace'] & {
     status: 'valid' | 'invalid' | 'expired' | 'unknown-source';
     code: string;
   };
+  degraded?: {
+    enabled: true;
+    action: 'allow' | 'block';
+    reason: string;
+    source: 'env' | 'file:.pumuki/degraded-mode.json';
+    code: 'DEGRADED_MODE_ALLOWED' | 'DEGRADED_MODE_BLOCKED';
+  };
 };
 
 const toSeverityCounts = (
@@ -184,6 +191,11 @@ export type GateTelemetryEventV1 = {
     policy_source?: string;
     validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source';
     validation_code?: string;
+    degraded_mode_enabled?: boolean;
+    degraded_mode_action?: 'allow' | 'block';
+    degraded_mode_reason?: string;
+    degraded_mode_source?: 'env' | 'file:.pumuki/degraded-mode.json';
+    degraded_mode_code?: 'DEGRADED_MODE_ALLOWED' | 'DEGRADED_MODE_BLOCKED';
   };
   sdd?: {
     allowed: boolean;
@@ -265,6 +277,15 @@ const toTelemetryEvent = (params: {
             ? {
               validation_status: params.policyTrace.validation.status,
               validation_code: params.policyTrace.validation.code,
+            }
+            : {}),
+          ...(params.policyTrace.degraded
+            ? {
+              degraded_mode_enabled: params.policyTrace.degraded.enabled,
+              degraded_mode_action: params.policyTrace.degraded.action,
+              degraded_mode_reason: params.policyTrace.degraded.reason,
+              degraded_mode_source: params.policyTrace.degraded.source,
+              degraded_mode_code: params.policyTrace.degraded.code,
             }
             : {}),
         },


### PR DESCRIPTION
## Summary
Implements enterprise degraded-mode behavior by stage (`PRE_WRITE/PRE_COMMIT/PRE_PUSH/CI`) and wires it through policy trace, gate enforcement, hook summaries, and SDD policy decisions.

## What changed
- Added reusable degraded resolver: `integrations/gate/degradedMode.ts`.
- Extended `resolvePolicyForStage` trace with `degraded` metadata.
- Enforced degraded behavior in gate:
  - `action=block` => `governance.degraded-mode.blocked` + gate block.
  - `action=allow` => `governance.degraded-mode.active` (info).
- Extended hook success summary with degraded fields.
- Added SDD decision for fail-closed degraded mode:
  - `SDD_DEGRADED_MODE_BLOCKED`.
- Propagated degraded metadata to evidence/telemetry policy traces.
- Updated `docs/CONFIGURATION.md` with degraded-mode contract and examples.
- Updated tracking docs: `T62` closed, `T63` activated.

## Tests (GREEN)
- `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/hookGateSummary.test.ts integrations/sdd/__tests__/policy.test.ts integrations/telemetry/__tests__/gateTelemetry.test.ts integrations/git/__tests__/EvidenceService.test.ts`

All selected suites pass.

## Traceability
- Fix issue: #583
- Next SDD task opened: #585
