### PR TITLE
feature: extend sdd sync-docs context contract (#585)

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,8 +7,8 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Última task cerrada (`✅`): `P12.F2.T62` (modo degradado offline/air-gapped para gates enterprise, issue `#583`).
-- Task activa (`🚧`): `P12.F2.T63` (extender `pumuki sdd sync-docs` con `--change --stage --task`, issue `#585`).
+- Última task cerrada (`✅`): `P12.F2.T63` (extender `pumuki sdd sync-docs` con `--change --stage --task`, issue `#585`).
+- Task activa (`🚧`): `P12.F2.T64` (ampliar `sync-docs` a múltiples documentos/secciones gestionadas, issue `#587`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1874,11 +1874,21 @@ Criterio de salida F5:
     - `npx --yes tsx@4.21.0 --test integrations/telemetry/__tests__/gateTelemetry.test.ts` => `4 passed`.
     - `npx --yes tsx@4.21.0 --test integrations/git/__tests__/EvidenceService.test.ts` => `15 passed`.
 
-- 🚧 `P12.F2.T63` Iniciar SDD pendiente enterprise: extender `pumuki sdd sync-docs` con contexto explícito (`--change`, `--stage`, `--task`) y trazabilidad canónica (`#585`).
+- ✅ `P12.F2.T63` Iniciar SDD pendiente enterprise: extender `pumuki sdd sync-docs` con contexto explícito (`--change`, `--stage`, `--task`) y trazabilidad canónica (`#585`).
+  - cierre ejecutado:
+    - `runSddSyncDocs` amplía contrato con contexto explícito (`change`, `stage`, `task`) en salida canónica.
+    - `parseLifecycleCliArgs` soporta:
+      - `pumuki sdd sync-docs --change=<id> --stage=<stage> --task=<task-id> [--dry-run] [--json]`.
+    - `runLifecycleCli` propaga contexto al runtime y lo imprime en salida texto/json.
+    - cobertura de tests ampliada para parsing + ejecución `dry-run` + contrato JSON de contexto.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `31 passed, 0 failed`.
+
+- 🚧 `P12.F2.T64` Continuar SDD pendiente enterprise: ampliar `sync-docs` a múltiples documentos canónicos y secciones gestionadas (`#587`).
   - salida esperada:
-    - issue de implementación creada y enlazada desde plan activo.
-    - contrato CLI para `sync-docs` ampliado con flags explícitas y validación determinista.
-    - tests de contrato (`dry-run`, `json`, validación de argumentos) en verde.
+    - soporte multi-documento determinista en `runSddSyncDocs`.
+    - mapeo por archivo/sección gestionada con fail-safe explícito ante conflictos.
+    - tests y CLI en verde con trazabilidad de todos los archivos sincronizados.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -303,6 +303,26 @@ test('parseLifecycleCliArgs soporta subcomandos SDD', () => {
       sddSyncDocsDryRun: true,
     }
   );
+  assert.deepEqual(
+    parseLifecycleCliArgs([
+      'sdd',
+      'sync-docs',
+      '--change=rgo-1700-01',
+      '--stage=pre_push',
+      '--task=P12.F2.T63',
+      '--json',
+    ]),
+    {
+      command: 'sdd',
+      purgeArtifacts: false,
+      json: true,
+      sddCommand: 'sync-docs',
+      sddSyncDocsDryRun: false,
+      sddSyncDocsChange: 'rgo-1700-01',
+      sddSyncDocsStage: 'PRE_PUSH',
+      sddSyncDocsTask: 'P12.F2.T63',
+    }
+  );
 });
 
 test('parseLifecycleCliArgs soporta analytics hotspots report', () => {
@@ -1141,7 +1161,15 @@ test('runLifecycleCli sdd sync-docs dry-run devuelve diff sin modificar el archi
       return true;
     }) as typeof process.stdout.write;
 
-    const code = await runLifecycleCli(['sdd', 'sync-docs', '--dry-run', '--json']);
+    const code = await runLifecycleCli([
+      'sdd',
+      'sync-docs',
+      '--change=rgo-1700-01',
+      '--stage=pre_commit',
+      '--task=P12.F2.T63',
+      '--dry-run',
+      '--json',
+    ]);
     assert.equal(code, 0);
     const after = readFileSync(canonicalDoc, 'utf8');
     assert.equal(before, after);
@@ -1149,11 +1177,19 @@ test('runLifecycleCli sdd sync-docs dry-run devuelve diff sin modificar el archi
     const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
       command?: string;
       dryRun?: boolean;
+      context?: {
+        change?: string | null;
+        stage?: string | null;
+        task?: string | null;
+      };
       updated?: boolean;
       files?: Array<{ updated?: boolean; diffMarkdown?: string }>;
     };
     assert.equal(payload.command, 'pumuki sdd sync-docs');
     assert.equal(payload.dryRun, true);
+    assert.equal(payload.context?.change, 'rgo-1700-01');
+    assert.equal(payload.context?.stage, 'PRE_COMMIT');
+    assert.equal(payload.context?.task, 'P12.F2.T63');
     assert.equal(payload.updated, true);
     assert.equal(payload.files?.[0]?.updated, true);
     assert.match(payload.files?.[0]?.diffMarkdown ?? '', /sdd-status/i);

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -87,6 +87,9 @@ type ParsedArgs = {
   sddChangeId?: string;
   sddTtlMinutes?: number;
   sddSyncDocsDryRun?: boolean;
+  sddSyncDocsChange?: string;
+  sddSyncDocsStage?: SddStage;
+  sddSyncDocsTask?: string;
   adapterCommand?: 'install';
   adapterAgent?: AdapterAgent;
   adapterDryRun?: boolean;
@@ -120,7 +123,7 @@ Pumuki lifecycle commands:
   pumuki sdd session --open --change=<change-id> [--ttl-minutes=<n>] [--json]
   pumuki sdd session --refresh [--ttl-minutes=<n>] [--json]
   pumuki sdd session --close [--json]
-  pumuki sdd sync-docs [--dry-run] [--json]
+  pumuki sdd sync-docs [--change=<change-id>] [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json]
 `.trim();
 
 const LOOP_RUN_POLICY: GatePolicy = {
@@ -420,6 +423,9 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   let sddChangeId: ParsedArgs['sddChangeId'];
   let sddTtlMinutes: ParsedArgs['sddTtlMinutes'];
   let sddSyncDocsDryRun = false;
+  let sddSyncDocsChange: ParsedArgs['sddSyncDocsChange'];
+  let sddSyncDocsStage: ParsedArgs['sddSyncDocsStage'];
+  let sddSyncDocsTask: ParsedArgs['sddSyncDocsTask'];
   let adapterCommand: ParsedArgs['adapterCommand'];
   let adapterAgent: ParsedArgs['adapterAgent'];
   let adapterDryRun = false;
@@ -617,11 +623,15 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         continue;
       }
       if (arg.startsWith('--stage=')) {
-        if (sddCommand !== 'validate') {
-          throw new Error(`--stage is only supported with "pumuki sdd validate".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'validate') {
+          sddStage = parseSddStage(arg.slice('--stage='.length));
+          continue;
         }
-        sddStage = parseSddStage(arg.slice('--stage='.length));
-        continue;
+        if (sddCommand === 'sync-docs') {
+          sddSyncDocsStage = parseSddStage(arg.slice('--stage='.length));
+          continue;
+        }
+        throw new Error(`--stage is only supported with "pumuki sdd validate" or "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
       }
       if (arg === '--open') {
         if (sddCommand !== 'session') {
@@ -645,10 +655,29 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         continue;
       }
       if (arg.startsWith('--change=')) {
-        if (sddCommand !== 'session') {
-          throw new Error(`--change is only supported with "pumuki sdd session".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'session') {
+          sddChangeId = arg.slice('--change='.length).trim();
+          continue;
         }
-        sddChangeId = arg.slice('--change='.length).trim();
+        if (sddCommand === 'sync-docs') {
+          const changeValue = arg.slice('--change='.length).trim();
+          if (changeValue.length === 0) {
+            throw new Error(`Invalid --change value "${arg}".`);
+          }
+          sddSyncDocsChange = changeValue;
+          continue;
+        }
+        throw new Error(`--change is only supported with "pumuki sdd session" or "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+      }
+      if (arg.startsWith('--task=')) {
+        if (sddCommand !== 'sync-docs') {
+          throw new Error(`--task is only supported with "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+        }
+        const taskValue = arg.slice('--task='.length).trim();
+        if (taskValue.length === 0) {
+          throw new Error(`Invalid --task value "${arg}".`);
+        }
+        sddSyncDocsTask = taskValue;
         continue;
       }
       if (arg.startsWith('--ttl-minutes=')) {
@@ -685,7 +714,7 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
     if (sddCommand === 'sync-docs') {
       if (sddSessionAction || sddChangeId || typeof sddTtlMinutes === 'number') {
         throw new Error(
-          `"pumuki sdd sync-docs" only supports [--dry-run] [--json].\n\n${HELP_TEXT}`
+          `"pumuki sdd sync-docs" only supports [--change=<change-id>] [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json].\n\n${HELP_TEXT}`
         );
       }
       return {
@@ -694,6 +723,9 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         json,
         sddCommand,
         sddSyncDocsDryRun,
+        ...(sddSyncDocsChange ? { sddSyncDocsChange } : {}),
+        ...(sddSyncDocsStage ? { sddSyncDocsStage } : {}),
+        ...(sddSyncDocsTask ? { sddSyncDocsTask } : {}),
       };
     }
 
@@ -1696,12 +1728,15 @@ export const runLifecycleCli = async (
           const syncResult = runSddSyncDocs({
             repoRoot: process.cwd(),
             dryRun: parsed.sddSyncDocsDryRun === true,
+            change: parsed.sddSyncDocsChange,
+            stage: parsed.sddSyncDocsStage,
+            task: parsed.sddSyncDocsTask,
           });
           if (parsed.json) {
             writeInfo(JSON.stringify(syncResult, null, 2));
           } else {
             writeInfo(
-              `[pumuki][sdd] sync-docs dry_run=${syncResult.dryRun ? 'yes' : 'no'} updated=${syncResult.updated ? 'yes' : 'no'} files=${syncResult.files.length}`
+              `[pumuki][sdd] sync-docs dry_run=${syncResult.dryRun ? 'yes' : 'no'} updated=${syncResult.updated ? 'yes' : 'no'} files=${syncResult.files.length} change=${syncResult.context.change ?? 'none'} stage=${syncResult.context.stage ?? 'none'} task=${syncResult.context.task ?? 'none'}`
             );
             for (const file of syncResult.files) {
               writeInfo(

--- a/integrations/sdd/__tests__/syncDocs.test.ts
+++ b/integrations/sdd/__tests__/syncDocs.test.ts
@@ -61,6 +61,9 @@ test('runSddSyncDocs dry-run previsualiza diff y no modifica archivo', async () 
     const after = readFileSync(canonicalPath, 'utf8');
 
     assert.equal(result.dryRun, true);
+    assert.equal(result.context.change, null);
+    assert.equal(result.context.stage, null);
+    assert.equal(result.context.task, null);
     assert.equal(result.updated, true);
     assert.equal(result.files.length, 1);
     assert.equal(result.files[0]?.updated, true);
@@ -94,9 +97,40 @@ test('runSddSyncDocs aplica cambios deterministas y segunda ejecución no cambia
     });
 
     assert.equal(first.updated, true);
+    assert.equal(first.context.change, null);
+    assert.equal(first.context.stage, null);
+    assert.equal(first.context.task, null);
     assert.match(synced, /openspec_installed:/);
     assert.equal(second.updated, false);
     assert.equal(second.files[0]?.updated, false);
+  });
+});
+
+test('runSddSyncDocs incluye contexto explícito change/stage/task en resultado', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-context-', (repoRoot) => {
+    writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+
+    const result = runSddSyncDocs({
+      repoRoot,
+      dryRun: true,
+      change: 'rgo-1700-01',
+      stage: 'PRE_PUSH',
+      task: 'P12.F2.T63',
+    });
+
+    assert.equal(result.context.change, 'rgo-1700-01');
+    assert.equal(result.context.stage, 'PRE_PUSH');
+    assert.equal(result.context.task, 'P12.F2.T63');
   });
 });
 

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { readSddStatus } from './policy';
+import type { SddStage } from './types';
 
 export const SDD_SYNC_DOCS_CANONICAL_FILES = [
   'docs/technical/08-validation/refactor/pumuki-integration-feedback.md',
@@ -34,6 +35,11 @@ export type SddSyncDocsResult = {
   command: 'pumuki sdd sync-docs';
   dryRun: boolean;
   repoRoot: string;
+  context: {
+    change: string | null;
+    stage: SddStage | null;
+    task: string | null;
+  };
   updated: boolean;
   files: ReadonlyArray<SddSyncDocsFileResult>;
 };
@@ -135,9 +141,15 @@ const applyManagedSection = (params: {
 export const runSddSyncDocs = (params?: {
   repoRoot?: string;
   dryRun?: boolean;
+  change?: string;
+  stage?: SddStage;
+  task?: string;
 }): SddSyncDocsResult => {
   const repoRoot = resolve(params?.repoRoot ?? process.cwd());
   const dryRun = params?.dryRun === true;
+  const change = params?.change?.trim() ? params.change.trim() : null;
+  const stage = params?.stage ?? null;
+  const task = params?.task?.trim() ? params.task.trim() : null;
 
   const updates = SDD_SYNC_DOCS_CANONICAL_FILES.map((relativePath) => {
     const absolutePath = resolve(repoRoot, relativePath);
@@ -192,6 +204,11 @@ export const runSddSyncDocs = (params?: {
     command: 'pumuki sdd sync-docs',
     dryRun,
     repoRoot,
+    context: {
+      change,
+      stage,
+      task,
+    },
     updated: files.some((file) => file.updated),
     files,
   };


### PR DESCRIPTION
## Summary
Extends `pumuki sdd sync-docs` with explicit enterprise context flags and deterministic JSON/text traceability.

## What changed
- Added context support in `runSddSyncDocs`:
  - `change`, `stage`, `task`.
  - result now includes `context` payload.
- Extended CLI parser and runtime for `pumuki sdd sync-docs`:
  - accepts `--change=<id> --stage=<PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI> --task=<task-id>`.
  - validates arguments deterministically.
  - prints context in text mode and JSON output.
- Added tests:
  - `integrations/sdd/__tests__/syncDocs.test.ts` (context contract).
  - `integrations/lifecycle/__tests__/cli.test.ts` (parse + runtime JSON context).
- Updated tracking:
  - `T63` closed (`✅`),
  - `T64` activated (`🚧`) with issue #587.

## Tests
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts`

## Traceability
- Fix issue: #585
- Next SDD task: #587
