### PR TITLE
feature: multi-document sync-docs targets with fail-safe behavior (#587)

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,8 +7,8 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Última task cerrada (`✅`): `P12.F2.T63` (extender `pumuki sdd sync-docs` con `--change --stage --task`, issue `#585`).
-- Task activa (`🚧`): `P12.F2.T64` (ampliar `sync-docs` a múltiples documentos/secciones gestionadas, issue `#587`).
+- Última task cerrada (`✅`): `P12.F2.T64` (ampliar `sync-docs` a múltiples documentos/secciones gestionadas, issue `#587`).
+- Task activa (`🚧`): `P12.F2.T65` (artefacto learning por change en `sync-docs`, issue `#589`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1884,11 +1884,22 @@ Criterio de salida F5:
   - evidencia:
     - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `31 passed, 0 failed`.
 
-- 🚧 `P12.F2.T64` Continuar SDD pendiente enterprise: ampliar `sync-docs` a múltiples documentos canónicos y secciones gestionadas (`#587`).
+- ✅ `P12.F2.T64` Continuar SDD pendiente enterprise: ampliar `sync-docs` a múltiples documentos canónicos y secciones gestionadas (`#587`).
+  - cierre ejecutado:
+    - `runSddSyncDocs` soporta objetivos múltiples (`targets`) con secciones gestionadas por archivo.
+    - actualización determinista por archivo/sección y salida con diffs por cada target.
+    - fail-safe preservado: conflicto en cualquier archivo aborta el sync antes de cualquier escritura parcial.
+    - cobertura de tests ampliada para:
+      - actualización multi-documento.
+      - garantía fail-safe sin escrituras parciales.
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `33 passed, 0 failed`.
+
+- 🚧 `P12.F2.T65` Continuar SDD pendiente enterprise: artefacto de aprendizaje machine-readable por change durante `sync-docs` (`#589`).
   - salida esperada:
-    - soporte multi-documento determinista en `runSddSyncDocs`.
-    - mapeo por archivo/sección gestionada con fail-safe explícito ante conflictos.
-    - tests y CLI en verde con trazabilidad de todos los archivos sincronizados.
+    - contrato `learning` determinista en salida JSON.
+    - persistencia opcional en `openspec/changes/<change>/learning.json` cuando se provee `--change`.
+    - tests de escritura/dry-run/error y documentación mínima del esquema.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.

--- a/integrations/sdd/__tests__/syncDocs.test.ts
+++ b/integrations/sdd/__tests__/syncDocs.test.ts
@@ -134,6 +134,133 @@ test('runSddSyncDocs incluye contexto explícito change/stage/task en resultado'
   });
 });
 
+test('runSddSyncDocs soporta múltiples documentos canónicos de forma determinista', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-multi-target-', (repoRoot) => {
+    const firstPath = writeCanonicalDoc(
+      repoRoot,
+      [
+        '# First',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: first',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+    const secondRelativePath = 'docs/ops/secondary-sync.md';
+    const secondPath = join(repoRoot, secondRelativePath);
+    mkdirSync(dirname(secondPath), { recursive: true });
+    writeFileSync(
+      secondPath,
+      [
+        '# Second',
+        '',
+        '<!-- PUMUKI:BEGIN SECONDARY_STATUS -->',
+        '- stale: second',
+        '<!-- PUMUKI:END SECONDARY_STATUS -->',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    const result = runSddSyncDocs({
+      repoRoot,
+      dryRun: false,
+      targets: [
+        {
+          path: 'docs/technical/08-validation/refactor/pumuki-integration-feedback.md',
+          sections: [
+            {
+              id: 'sdd-status',
+              beginMarker: '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+              endMarker: '<!-- PUMUKI:END SDD_STATUS -->',
+              renderBody: () => '- value: first-updated',
+            },
+          ],
+        },
+        {
+          path: secondRelativePath,
+          sections: [
+            {
+              id: 'secondary-status',
+              beginMarker: '<!-- PUMUKI:BEGIN SECONDARY_STATUS -->',
+              endMarker: '<!-- PUMUKI:END SECONDARY_STATUS -->',
+              renderBody: () => '- value: second-updated',
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(result.files.length, 2);
+    assert.equal(result.files[0]?.updated, true);
+    assert.equal(result.files[1]?.updated, true);
+    assert.match(readFileSync(firstPath, 'utf8'), /first-updated/);
+    assert.match(readFileSync(secondPath, 'utf8'), /second-updated/);
+  });
+});
+
+test('runSddSyncDocs es fail-safe: conflicto en un archivo evita escritura parcial de otros archivos', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-failsafe-', (repoRoot) => {
+    const firstPath = writeCanonicalDoc(
+      repoRoot,
+      [
+        '# First',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: first',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+    const secondRelativePath = 'docs/ops/secondary-sync.md';
+    const secondPath = join(repoRoot, secondRelativePath);
+    mkdirSync(dirname(secondPath), { recursive: true });
+    writeFileSync(secondPath, '# Second without markers\n', 'utf8');
+
+    const firstBefore = readFileSync(firstPath, 'utf8');
+    const secondBefore = readFileSync(secondPath, 'utf8');
+
+    assert.throws(
+      () =>
+        runSddSyncDocs({
+          repoRoot,
+          dryRun: false,
+          targets: [
+            {
+              path: 'docs/technical/08-validation/refactor/pumuki-integration-feedback.md',
+              sections: [
+                {
+                  id: 'sdd-status',
+                  beginMarker: '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+                  endMarker: '<!-- PUMUKI:END SDD_STATUS -->',
+                  renderBody: () => '- value: first-updated',
+                },
+              ],
+            },
+            {
+              path: secondRelativePath,
+              sections: [
+                {
+                  id: 'secondary-status',
+                  beginMarker: '<!-- PUMUKI:BEGIN SECONDARY_STATUS -->',
+                  endMarker: '<!-- PUMUKI:END SECONDARY_STATUS -->',
+                  renderBody: () => '- value: second-updated',
+                },
+              ],
+            },
+          ],
+        }),
+      /sync-docs conflict/i
+    );
+
+    const firstAfter = readFileSync(firstPath, 'utf8');
+    const secondAfter = readFileSync(secondPath, 'utf8');
+    assert.equal(firstAfter, firstBefore);
+    assert.equal(secondAfter, secondBefore);
+  });
+});
+
 test('runSddSyncDocs falla con conflicto de marcadores y no toca el archivo', async () => {
   await withFixtureRepo('pumuki-sdd-sync-docs-conflict-', (repoRoot) => {
     const canonicalPath = writeCanonicalDoc(repoRoot, '# Canonical\n\nwithout managed markers\n');

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -4,10 +4,6 @@ import { resolve } from 'node:path';
 import { readSddStatus } from './policy';
 import type { SddStage } from './types';
 
-export const SDD_SYNC_DOCS_CANONICAL_FILES = [
-  'docs/technical/08-validation/refactor/pumuki-integration-feedback.md',
-] as const;
-
 const SDD_STATUS_SECTION = {
   id: 'sdd-status',
   begin: '<!-- PUMUKI:BEGIN SDD_STATUS -->',
@@ -20,6 +16,18 @@ type ManagedSectionSyncResult = {
   before: string;
   after: string;
   diffMarkdown: string;
+};
+
+export type SddSyncDocsManagedSection = {
+  id: string;
+  beginMarker: string;
+  endMarker: string;
+  renderBody: (repoRoot: string) => string;
+};
+
+export type SddSyncDocsTarget = {
+  path: string;
+  sections: ReadonlyArray<SddSyncDocsManagedSection>;
 };
 
 export type SddSyncDocsFileResult = {
@@ -92,6 +100,24 @@ const formatSddStatusManagedBody = (repoRoot: string): string => {
   ].join('\n');
 };
 
+const DEFAULT_SYNC_DOCS_TARGETS: ReadonlyArray<SddSyncDocsTarget> = [
+  {
+    path: 'docs/technical/08-validation/refactor/pumuki-integration-feedback.md',
+    sections: [
+      {
+        id: SDD_STATUS_SECTION.id,
+        beginMarker: SDD_STATUS_SECTION.begin,
+        endMarker: SDD_STATUS_SECTION.end,
+        renderBody: formatSddStatusManagedBody,
+      },
+    ],
+  },
+];
+
+export const SDD_SYNC_DOCS_CANONICAL_FILES = DEFAULT_SYNC_DOCS_TARGETS.map(
+  (target) => target.path
+);
+
 const applyManagedSection = (params: {
   filePath: string;
   source: string;
@@ -144,38 +170,46 @@ export const runSddSyncDocs = (params?: {
   change?: string;
   stage?: SddStage;
   task?: string;
+  targets?: ReadonlyArray<SddSyncDocsTarget>;
 }): SddSyncDocsResult => {
   const repoRoot = resolve(params?.repoRoot ?? process.cwd());
   const dryRun = params?.dryRun === true;
   const change = params?.change?.trim() ? params.change.trim() : null;
   const stage = params?.stage ?? null;
   const task = params?.task?.trim() ? params.task.trim() : null;
+  const targets = params?.targets ?? DEFAULT_SYNC_DOCS_TARGETS;
 
-  const updates = SDD_SYNC_DOCS_CANONICAL_FILES.map((relativePath) => {
-    const absolutePath = resolve(repoRoot, relativePath);
+  const updates = targets.map((target) => {
+    const absolutePath = resolve(repoRoot, target.path);
     if (!existsSync(absolutePath)) {
       throw new Error(
-        `[pumuki][sdd] sync-docs missing canonical file: ${relativePath}`
+        `[pumuki][sdd] sync-docs missing canonical file: ${target.path}`
       );
     }
 
     const currentSource = readFileSync(absolutePath, 'utf8');
-    const renderedStatusBody = formatSddStatusManagedBody(repoRoot);
-    const sectionUpdate = applyManagedSection({
-      filePath: relativePath,
-      source: currentSource,
-      beginMarker: SDD_STATUS_SECTION.begin,
-      endMarker: SDD_STATUS_SECTION.end,
-      renderedBody: renderedStatusBody,
-      sectionId: SDD_STATUS_SECTION.id,
-    });
+    let nextSource = currentSource;
+    const sectionUpdates: ManagedSectionSyncResult[] = [];
+
+    for (const section of target.sections) {
+      const update = applyManagedSection({
+        filePath: target.path,
+        source: nextSource,
+        beginMarker: section.beginMarker,
+        endMarker: section.endMarker,
+        renderedBody: section.renderBody(repoRoot),
+        sectionId: section.id,
+      });
+      nextSource = update.nextSource;
+      sectionUpdates.push(update.result);
+    }
 
     return {
-      relativePath,
+      relativePath: target.path,
       absolutePath,
       currentSource,
-      nextSource: sectionUpdate.nextSource,
-      sections: [sectionUpdate.result] as const,
+      nextSource,
+      sections: sectionUpdates,
     };
   });
 


### PR DESCRIPTION
## Summary
Adds multi-document synchronization support for `pumuki sdd sync-docs` with deterministic per-file sections and fail-safe conflict behavior.

## What changed
- `runSddSyncDocs` now supports `targets` (multiple canonical docs).
- Each target can define multiple managed sections (`id`, markers, renderer).
- Deterministic update/diff output per file and section preserved.
- Fail-safe behavior kept: marker conflict in one target aborts before any partial write.
- New tests:
  - multi-document deterministic sync,
  - fail-safe no partial write when one target conflicts.
- Tracking updated:
  - `T64` closed,
  - `T65` active (`#589`).

## Tests
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts`

## Traceability
- Fix issue: #587
- Next SDD task: #589
