### PR TITLE
feat: enrich SDD learning artifact with gate/evidence signals (#591)

### DIFF
--- a/integrations/sdd/__tests__/syncDocs.test.ts
+++ b/integrations/sdd/__tests__/syncDocs.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { runSddSyncDocs } from '../syncDocs';
+import type { EvidenceReadResult } from '../../evidence/readEvidence';
 
 const runGit = (cwd: string, args: ReadonlyArray<string>): string =>
   execFileSync('git', args, { cwd, encoding: 'utf8' });
@@ -38,6 +39,36 @@ const writeCanonicalDoc = (repoRoot: string, body: string): string => {
   writeFileSync(path, body, 'utf8');
   return path;
 };
+
+const buildValidBlockedEvidenceResult = (): EvidenceReadResult => ({
+  kind: 'valid',
+  evidence: {
+    timestamp: '2026-03-04T10:10:00.000Z',
+    snapshot: {
+      outcome: 'BLOCK',
+    },
+    ai_gate: {
+      status: 'BLOCKED',
+      violations: [
+        {
+          code: 'EVIDENCE_STALE',
+        },
+      ],
+    },
+    sdd_metrics: {
+      decision: {
+        allowed: false,
+        code: 'SDD_CHANGE_INCOMPLETE',
+      },
+    },
+  } as Extract<EvidenceReadResult, { kind: 'valid' }>['evidence'],
+  source_descriptor: {
+    source: 'local-file',
+    path: '/repo/.ai_evidence.json',
+    digest: 'sha256:abcd',
+    generated_at: '2026-03-04T10:10:00.000Z',
+  },
+});
 
 test('runSddSyncDocs dry-run previsualiza diff y no modifica archivo', async () => {
   await withFixtureRepo('pumuki-sdd-sync-docs-dry-run-', (repoRoot) => {
@@ -137,7 +168,11 @@ test('runSddSyncDocs incluye contexto explícito change/stage/task en resultado'
     assert.equal(result.learning?.artifact.version, '1.0');
     assert.equal(result.learning?.artifact.change_id, 'rgo-1700-01');
     assert.equal(result.learning?.artifact.generated_at, '2026-03-04T10:00:00.000Z');
-    assert.deepEqual(result.learning?.artifact.successful_patterns, ['sync-docs.completed']);
+    assert.deepEqual(result.learning?.artifact.successful_patterns, [
+      'sync-docs.completed',
+      'sync-docs.updated',
+    ]);
+    assert.deepEqual(result.learning?.artifact.gate_anomalies, ['evidence.missing']);
     assert.equal(
       existsSync(join(repoRoot, 'openspec', 'changes', 'rgo-1700-01', 'learning.json')),
       false
@@ -174,6 +209,7 @@ test('runSddSyncDocs persiste learning artifact cuando change está presente y n
     assert.equal(result.learning?.artifact.stage, 'PRE_COMMIT');
     assert.equal(result.learning?.artifact.task, 'P12.F2.T65');
     assert.equal(result.learning?.artifact.generated_at, '2026-03-04T10:05:00.000Z');
+    assert.deepEqual(result.learning?.artifact.gate_anomalies, ['evidence.missing']);
     assert.equal(existsSync(learningPath), true);
     const stored = readFileSync(learningPath, 'utf8');
     const parsed = JSON.parse(stored) as {
@@ -182,12 +218,57 @@ test('runSddSyncDocs persiste learning artifact cuando change está presente y n
       stage: string | null;
       task: string | null;
       generated_at: string;
+      failed_patterns: string[];
+      successful_patterns: string[];
+      gate_anomalies: string[];
     };
     assert.equal(parsed.version, '1.0');
     assert.equal(parsed.change_id, 'rgo-1700-02');
     assert.equal(parsed.stage, 'PRE_COMMIT');
     assert.equal(parsed.task, 'P12.F2.T65');
     assert.equal(parsed.generated_at, '2026-03-04T10:05:00.000Z');
+    assert.deepEqual(parsed.failed_patterns, []);
+    assert.deepEqual(parsed.successful_patterns, ['sync-docs.completed', 'sync-docs.updated']);
+    assert.deepEqual(parsed.gate_anomalies, ['evidence.missing']);
+  });
+});
+
+test('runSddSyncDocs agrega señales de gate cuando evidenceReader devuelve evidencia bloqueada', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-learning-signals-', (repoRoot) => {
+    writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+
+    const result = runSddSyncDocs({
+      repoRoot,
+      dryRun: true,
+      change: 'rgo-1700-03',
+      stage: 'PRE_WRITE',
+      task: 'P12.F2.T66',
+      evidenceReader: () => buildValidBlockedEvidenceResult(),
+      now: () => new Date('2026-03-04T10:10:00.000Z'),
+    });
+
+    assert.deepEqual(result.learning?.artifact.failed_patterns, [
+      'ai-gate.blocked',
+      'sdd.blocked.SDD_CHANGE_INCOMPLETE',
+    ]);
+    assert.deepEqual(result.learning?.artifact.successful_patterns, [
+      'sync-docs.completed',
+      'sync-docs.updated',
+    ]);
+    assert.deepEqual(result.learning?.artifact.gate_anomalies, [
+      'ai-gate.violation.EVIDENCE_STALE',
+      'snapshot.outcome.block',
+    ]);
   });
 });
 

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { readEvidenceResult, type EvidenceReadResult } from '../evidence/readEvidence';
 import { readSddStatus } from './policy';
 import type { SddStage } from './types';
 
@@ -184,6 +185,59 @@ const applyManagedSection = (params: {
   return { nextSource, result };
 };
 
+const toSortedArray = (set: Set<string>): string[] => {
+  return [...set].sort((left, right) => left.localeCompare(right));
+};
+
+const collectLearningSignals = (params: {
+  updated: boolean;
+  evidenceResult: EvidenceReadResult;
+}): {
+  failedPatterns: string[];
+  successfulPatterns: string[];
+  gateAnomalies: string[];
+} => {
+  const failedPatterns = new Set<string>();
+  const successfulPatterns = new Set<string>();
+  const gateAnomalies = new Set<string>();
+
+  successfulPatterns.add('sync-docs.completed');
+  successfulPatterns.add(params.updated ? 'sync-docs.updated' : 'sync-docs.no_changes');
+
+  if (params.evidenceResult.kind === 'missing') {
+    gateAnomalies.add('evidence.missing');
+  } else if (params.evidenceResult.kind === 'invalid') {
+    gateAnomalies.add(`evidence.invalid.${params.evidenceResult.reason}`);
+  } else {
+    const evidence = params.evidenceResult.evidence;
+    if (evidence.ai_gate.status === 'BLOCKED') {
+      failedPatterns.add('ai-gate.blocked');
+      for (const violation of evidence.ai_gate.violations) {
+        gateAnomalies.add(`ai-gate.violation.${violation.code}`);
+      }
+    } else {
+      successfulPatterns.add('ai-gate.allowed');
+    }
+    if (evidence.snapshot.outcome === 'BLOCK') {
+      gateAnomalies.add('snapshot.outcome.block');
+    }
+    const sddDecision = evidence.sdd_metrics?.decision;
+    if (sddDecision) {
+      if (sddDecision.allowed) {
+        successfulPatterns.add('sdd.allowed');
+      } else {
+        failedPatterns.add(`sdd.blocked.${sddDecision.code}`);
+      }
+    }
+  }
+
+  return {
+    failedPatterns: toSortedArray(failedPatterns),
+    successfulPatterns: toSortedArray(successfulPatterns),
+    gateAnomalies: toSortedArray(gateAnomalies),
+  };
+};
+
 export const runSddSyncDocs = (params?: {
   repoRoot?: string;
   dryRun?: boolean;
@@ -192,6 +246,7 @@ export const runSddSyncDocs = (params?: {
   task?: string;
   targets?: ReadonlyArray<SddSyncDocsTarget>;
   now?: () => Date;
+  evidenceReader?: (repoRoot: string) => EvidenceReadResult;
 }): SddSyncDocsResult => {
   const repoRoot = resolve(params?.repoRoot ?? process.cwd());
   const dryRun = params?.dryRun === true;
@@ -200,6 +255,7 @@ export const runSddSyncDocs = (params?: {
   const task = params?.task?.trim() ? params.task.trim() : null;
   const targets = params?.targets ?? DEFAULT_SYNC_DOCS_TARGETS;
   const now = params?.now ?? (() => new Date());
+  const evidenceReader = params?.evidenceReader ?? readEvidenceResult;
 
   const updates = targets.map((target) => {
     const absolutePath = resolve(repoRoot, target.path);
@@ -259,16 +315,20 @@ export const runSddSyncDocs = (params?: {
   const updated = files.some((file) => file.updated);
   let learning: SddSyncDocsResult['learning'];
   if (change) {
+    const signals = collectLearningSignals({
+      updated,
+      evidenceResult: evidenceReader(repoRoot),
+    });
     const artifact = {
       version: '1.0' as const,
       change_id: change,
       stage,
       task,
       generated_at: now().toISOString(),
-      failed_patterns: [] as string[],
-      successful_patterns: ['sync-docs.completed'],
+      failed_patterns: signals.failedPatterns,
+      successful_patterns: signals.successfulPatterns,
       rule_updates: [] as string[],
-      gate_anomalies: [] as string[],
+      gate_anomalies: signals.gateAnomalies,
       sync_docs: {
         updated,
         file_paths: files.map((file) => file.path),


### PR DESCRIPTION
## Summary
- enrich `runSddSyncDocs` learning artifact with deterministic runtime signals from evidence
- populate `failed_patterns`, `successful_patterns`, and `gate_anomalies` from missing/invalid/valid evidence states
- add test coverage for dry-run/non-dry-run learning payloads and blocked evidence scenarios

## Evidence
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

Closes #591
