### PR TITLE
docs: sync tracking after closing #591

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,8 +7,8 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Última task cerrada (`✅`): `P12.F2.T65` (artefacto learning por change en `sync-docs`, issue `#589`).
-- Task activa (`🚧`): `P12.F2.T66` (enriquecer `learning.json` con señales reales de gate/evidence, issue `#591`).
+- Última task cerrada (`✅`): `P12.F2.T66` (señales reales de gate/evidence en `learning.json`, issue `#591`, PR `#593`).
+- Task activa (`🚧`): `P12.F2.T67` (hacer `rule_updates` accionable en `learning.json`, issue `#594`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1907,11 +1907,24 @@ Criterio de salida F5:
   - evidencia:
     - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `34 passed, 0 failed`.
 
-- 🚧 `P12.F2.T66` Continuar SDD pendiente enterprise: enriquecer `learning.json` con señales reales de gate/evidence (`#591`).
+- ✅ `P12.F2.T66` Continuar SDD pendiente enterprise: enriquecer `learning.json` con señales reales de gate/evidence (`#591`).
+  - cierre ejecutado:
+    - `runSddSyncDocs` incorpora señales deterministas de runtime para poblar:
+      - `failed_patterns`
+      - `successful_patterns`
+      - `gate_anomalies`
+    - el cálculo cubre casos `evidence missing/invalid/valid` y decisión SDD permitida/bloqueada.
+    - soporte explícito para inyectar lector de evidencia en tests (`evidenceReader`) sin romper contrato CLI.
+    - PR mergeada: `#593` (`commit 0da619a3804ec939bc33385cfc57032c195b4ee1`).
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `35 passed, 0 failed`.
+    - `npm run -s typecheck` => `exit 0`.
+
+- 🚧 `P12.F2.T67` Continuar SDD pendiente enterprise: hacer `rule_updates` accionable en `learning.json` (`#594`).
   - salida esperada:
-    - arrays `failed_patterns`, `successful_patterns` y `gate_anomalies` poblados desde señales runtime cuando existan.
-    - orden determinista y comportamiento reproducible en dry-run/no dry-run.
-    - tests de casos poblados y fallback vacío en verde.
+    - `rule_updates` deja de ser siempre vacío y refleja recomendaciones deterministas derivadas de señales de gate/evidence.
+    - orden estable en dry-run/no dry-run y sin regresión del contrato actual.
+    - tests en verde para escenarios `missing`, `invalid`, `blocked`, `allowed`.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- mark P12.F2.T66 as closed with real refs (#591, #593, merge commit)
- set P12.F2.T67 as the single active 🚧 task linked to #594
- sync master tracking registry with latest closed/active tasks

## Evidence
- npm run -s validation:tracking-single-active

Ref: #591, #594
