### PR TITLE
feat: actionable rule updates for SDD learning artifact (#594)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -167,12 +167,15 @@ Payload schema (`v1.0`):
   "version": "1.0",
   "change_id": "rgo-1700-01",
   "stage": "PRE_COMMIT",
-  "task": "P12.F2.T65",
+  "task": "P12.F2.T67",
   "generated_at": "2026-03-04T10:05:00.000Z",
-  "failed_patterns": [],
-  "successful_patterns": ["sync-docs.completed"],
-  "rule_updates": [],
-  "gate_anomalies": [],
+  "failed_patterns": ["ai-gate.blocked"],
+  "successful_patterns": ["sync-docs.completed", "sync-docs.updated"],
+  "rule_updates": [
+    "ai-gate.unblock.required",
+    "ai-gate.violation.EVIDENCE_STALE.review"
+  ],
+  "gate_anomalies": ["ai-gate.violation.EVIDENCE_STALE"],
   "sync_docs": {
     "updated": true,
     "file_paths": [
@@ -186,6 +189,7 @@ Behavior:
 
 - `--dry-run`: includes learning payload in JSON output with `learning.written=false` and does not write files.
 - non dry-run: persists `learning.json` deterministically and reports digest/path in output.
+- `rule_updates`: deterministic recommendations derived from evidence/gate signals (`missing`, `invalid`, `blocked`, `allowed`).
 
 ## Gate telemetry export (optional)
 

--- a/integrations/sdd/__tests__/syncDocs.test.ts
+++ b/integrations/sdd/__tests__/syncDocs.test.ts
@@ -70,6 +70,43 @@ const buildValidBlockedEvidenceResult = (): EvidenceReadResult => ({
   },
 });
 
+const buildValidAllowedEvidenceResult = (): EvidenceReadResult => ({
+  kind: 'valid',
+  evidence: {
+    timestamp: '2026-03-04T10:20:00.000Z',
+    snapshot: {
+      outcome: 'ALLOW',
+    },
+    ai_gate: {
+      status: 'ALLOWED',
+      violations: [],
+    },
+    sdd_metrics: {
+      decision: {
+        allowed: true,
+        code: 'ALLOWED',
+      },
+    },
+  } as Extract<EvidenceReadResult, { kind: 'valid' }>['evidence'],
+  source_descriptor: {
+    source: 'local-file',
+    path: '/repo/.ai_evidence.json',
+    digest: 'sha256:efgh',
+    generated_at: '2026-03-04T10:20:00.000Z',
+  },
+});
+
+const buildInvalidSchemaEvidenceResult = (): EvidenceReadResult => ({
+  kind: 'invalid',
+  reason: 'schema',
+  source_descriptor: {
+    source: 'local-file',
+    path: '/repo/.ai_evidence.json',
+    digest: 'sha256:invalid',
+    generated_at: null,
+  },
+});
+
 test('runSddSyncDocs dry-run previsualiza diff y no modifica archivo', async () => {
   await withFixtureRepo('pumuki-sdd-sync-docs-dry-run-', (repoRoot) => {
     const canonicalPath = writeCanonicalDoc(
@@ -173,6 +210,7 @@ test('runSddSyncDocs incluye contexto explícito change/stage/task en resultado'
       'sync-docs.updated',
     ]);
     assert.deepEqual(result.learning?.artifact.gate_anomalies, ['evidence.missing']);
+    assert.deepEqual(result.learning?.artifact.rule_updates, ['evidence.bootstrap.required']);
     assert.equal(
       existsSync(join(repoRoot, 'openspec', 'changes', 'rgo-1700-01', 'learning.json')),
       false
@@ -220,6 +258,7 @@ test('runSddSyncDocs persiste learning artifact cuando change está presente y n
       generated_at: string;
       failed_patterns: string[];
       successful_patterns: string[];
+      rule_updates: string[];
       gate_anomalies: string[];
     };
     assert.equal(parsed.version, '1.0');
@@ -229,6 +268,7 @@ test('runSddSyncDocs persiste learning artifact cuando change está presente y n
     assert.equal(parsed.generated_at, '2026-03-04T10:05:00.000Z');
     assert.deepEqual(parsed.failed_patterns, []);
     assert.deepEqual(parsed.successful_patterns, ['sync-docs.completed', 'sync-docs.updated']);
+    assert.deepEqual(parsed.rule_updates, ['evidence.bootstrap.required']);
     assert.deepEqual(parsed.gate_anomalies, ['evidence.missing']);
   });
 });
@@ -269,6 +309,85 @@ test('runSddSyncDocs agrega señales de gate cuando evidenceReader devuelve evid
       'ai-gate.violation.EVIDENCE_STALE',
       'snapshot.outcome.block',
     ]);
+    assert.deepEqual(result.learning?.artifact.rule_updates, [
+      'ai-gate.unblock.required',
+      'ai-gate.violation.EVIDENCE_STALE.review',
+      'sdd.SDD_CHANGE_INCOMPLETE.remediate',
+      'snapshot.outcome.review',
+    ]);
+  });
+});
+
+test('runSddSyncDocs genera rule_updates para evidencia inválida de schema', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-learning-invalid-', (repoRoot) => {
+    writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+
+    const result = runSddSyncDocs({
+      repoRoot,
+      dryRun: true,
+      change: 'rgo-1700-04',
+      stage: 'PRE_WRITE',
+      task: 'P12.F2.T67',
+      evidenceReader: () => buildInvalidSchemaEvidenceResult(),
+      now: () => new Date('2026-03-04T10:30:00.000Z'),
+    });
+
+    assert.deepEqual(result.learning?.artifact.failed_patterns, []);
+    assert.deepEqual(result.learning?.artifact.successful_patterns, [
+      'sync-docs.completed',
+      'sync-docs.updated',
+    ]);
+    assert.deepEqual(result.learning?.artifact.gate_anomalies, ['evidence.invalid.schema']);
+    assert.deepEqual(result.learning?.artifact.rule_updates, [
+      'evidence.rebuild.required',
+      'evidence.schema.repair',
+    ]);
+  });
+});
+
+test('runSddSyncDocs mantiene rule_updates vacío cuando la evidencia válida está en allow', async () => {
+  await withFixtureRepo('pumuki-sdd-sync-docs-learning-allow-', (repoRoot) => {
+    writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+
+    const result = runSddSyncDocs({
+      repoRoot,
+      dryRun: true,
+      change: 'rgo-1700-05',
+      stage: 'PRE_WRITE',
+      task: 'P12.F2.T67',
+      evidenceReader: () => buildValidAllowedEvidenceResult(),
+      now: () => new Date('2026-03-04T10:35:00.000Z'),
+    });
+
+    assert.deepEqual(result.learning?.artifact.failed_patterns, []);
+    assert.deepEqual(result.learning?.artifact.successful_patterns, [
+      'ai-gate.allowed',
+      'sdd.allowed',
+      'sync-docs.completed',
+      'sync-docs.updated',
+    ]);
+    assert.deepEqual(result.learning?.artifact.gate_anomalies, []);
+    assert.deepEqual(result.learning?.artifact.rule_updates, []);
   });
 });
 

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -196,30 +196,43 @@ const collectLearningSignals = (params: {
   failedPatterns: string[];
   successfulPatterns: string[];
   gateAnomalies: string[];
+  ruleUpdates: string[];
 } => {
   const failedPatterns = new Set<string>();
   const successfulPatterns = new Set<string>();
   const gateAnomalies = new Set<string>();
+  const ruleUpdates = new Set<string>();
 
   successfulPatterns.add('sync-docs.completed');
   successfulPatterns.add(params.updated ? 'sync-docs.updated' : 'sync-docs.no_changes');
 
   if (params.evidenceResult.kind === 'missing') {
     gateAnomalies.add('evidence.missing');
+    ruleUpdates.add('evidence.bootstrap.required');
   } else if (params.evidenceResult.kind === 'invalid') {
     gateAnomalies.add(`evidence.invalid.${params.evidenceResult.reason}`);
+    ruleUpdates.add('evidence.rebuild.required');
+    if (params.evidenceResult.reason === 'schema') {
+      ruleUpdates.add('evidence.schema.repair');
+    }
+    if (params.evidenceResult.reason === 'evidence-chain-invalid') {
+      ruleUpdates.add('evidence.chain.repair');
+    }
   } else {
     const evidence = params.evidenceResult.evidence;
     if (evidence.ai_gate.status === 'BLOCKED') {
       failedPatterns.add('ai-gate.blocked');
+      ruleUpdates.add('ai-gate.unblock.required');
       for (const violation of evidence.ai_gate.violations) {
         gateAnomalies.add(`ai-gate.violation.${violation.code}`);
+        ruleUpdates.add(`ai-gate.violation.${violation.code}.review`);
       }
     } else {
       successfulPatterns.add('ai-gate.allowed');
     }
     if (evidence.snapshot.outcome === 'BLOCK') {
       gateAnomalies.add('snapshot.outcome.block');
+      ruleUpdates.add('snapshot.outcome.review');
     }
     const sddDecision = evidence.sdd_metrics?.decision;
     if (sddDecision) {
@@ -227,6 +240,7 @@ const collectLearningSignals = (params: {
         successfulPatterns.add('sdd.allowed');
       } else {
         failedPatterns.add(`sdd.blocked.${sddDecision.code}`);
+        ruleUpdates.add(`sdd.${sddDecision.code}.remediate`);
       }
     }
   }
@@ -235,6 +249,7 @@ const collectLearningSignals = (params: {
     failedPatterns: toSortedArray(failedPatterns),
     successfulPatterns: toSortedArray(successfulPatterns),
     gateAnomalies: toSortedArray(gateAnomalies),
+    ruleUpdates: toSortedArray(ruleUpdates),
   };
 };
 
@@ -327,7 +342,7 @@ export const runSddSyncDocs = (params?: {
       generated_at: now().toISOString(),
       failed_patterns: signals.failedPatterns,
       successful_patterns: signals.successfulPatterns,
-      rule_updates: [] as string[],
+      rule_updates: signals.ruleUpdates,
       gate_anomalies: signals.gateAnomalies,
       sync_docs: {
         updated,


### PR DESCRIPTION
## Summary
- make `rule_updates` deterministic and actionable in `runSddSyncDocs`
- derive recommendations from evidence states: `missing`, `invalid`, `blocked`, and `allowed`
- extend sync-docs learning tests for blocked, invalid, allowed, and persisted payload scenarios
- update `docs/CONFIGURATION.md` learning artifact contract example

## Evidence
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

Closes #594
