### PR TITLE
docs: sync tracking after closing #594

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,8 +7,8 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
-- Última task cerrada (`✅`): `P12.F2.T66` (señales reales de gate/evidence en `learning.json`, issue `#591`, PR `#593`).
-- Task activa (`🚧`): `P12.F2.T67` (hacer `rule_updates` accionable en `learning.json`, issue `#594`).
+- Última task cerrada (`✅`): `P12.F2.T67` (`rule_updates` accionable en `learning.json`, issue `#594`, PR `#596`).
+- Task activa (`🚧`): `P12.F2.T68` (nuevo comando `pumuki sdd learn` con `--dry-run/--json`, issue `#597`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1920,11 +1920,22 @@ Criterio de salida F5:
     - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `35 passed, 0 failed`.
     - `npm run -s typecheck` => `exit 0`.
 
-- 🚧 `P12.F2.T67` Continuar SDD pendiente enterprise: hacer `rule_updates` accionable en `learning.json` (`#594`).
+- ✅ `P12.F2.T67` Continuar SDD pendiente enterprise: hacer `rule_updates` accionable en `learning.json` (`#594`).
+  - cierre ejecutado:
+    - `runSddSyncDocs` ahora deriva `rule_updates` de señales de evidencia/gate (`missing`, `invalid`, `blocked`, `allowed`) de forma determinista.
+    - añadidas recomendaciones específicas por familia de señal (`evidence.*`, `ai-gate.*`, `sdd.*`, `snapshot.*`).
+    - ampliada cobertura en `syncDocs` para escenarios `invalid` y `allow` además de `blocked`/persistencia.
+    - documentación de contrato actualizada en `docs/CONFIGURATION.md`.
+    - PR mergeada: `#596` (`commit 51d894c8835c9b04cb57dd810197ac7fc3d0cd3e`).
+  - evidencia:
+    - `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts` => `37 passed, 0 failed`.
+    - `npm run -s typecheck` => `exit 0`.
+
+- 🚧 `P12.F2.T68` Continuar SDD pendiente enterprise: añadir comando dedicado `pumuki sdd learn` (`#597`).
   - salida esperada:
-    - `rule_updates` deja de ser siempre vacío y refleja recomendaciones deterministas derivadas de señales de gate/evidence.
-    - orden estable en dry-run/no dry-run y sin regresión del contrato actual.
-    - tests en verde para escenarios `missing`, `invalid`, `blocked`, `allowed`.
+    - CLI con `pumuki sdd learn --change=<id> --stage=<stage> --task=<id> [--dry-run] [--json]`.
+    - persistencia de `learning.json` sin depender de `sync-docs`.
+    - contrato compatible con artefacto de aprendizaje actual y tests en verde.
 
 Criterio de salida F6:
 - veredicto final trazable y cierre administrativo completo.


### PR DESCRIPTION
## Summary
- mark P12.F2.T67 as completed with refs to #594/#596
- set P12.F2.T68 as the single active 🚧 task linked to #597
- sync master tracking registry with latest closed/active tasks

## Evidence
- npm run -s validation:tracking-single-active

Ref: #594, #597
