### PR TITLE
feat: add dedicated pumuki sdd learn command (#597)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -190,6 +190,7 @@ Behavior:
 - `--dry-run`: includes learning payload in JSON output with `learning.written=false` and does not write files.
 - non dry-run: persists `learning.json` deterministically and reports digest/path in output.
 - `rule_updates`: deterministic recommendations derived from evidence/gate signals (`missing`, `invalid`, `blocked`, `allowed`).
+- dedicated command: `pumuki sdd learn --change=<id> [--stage=<stage>] [--task=<task>] [--dry-run] [--json]` generates/persists the same artifact without requiring `sync-docs`.
 
 ## Gate telemetry export (optional)
 

--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -323,6 +323,27 @@ test('parseLifecycleCliArgs soporta subcomandos SDD', () => {
       sddSyncDocsTask: 'P12.F2.T63',
     }
   );
+  assert.deepEqual(
+    parseLifecycleCliArgs([
+      'sdd',
+      'learn',
+      '--change=rgo-1700-02',
+      '--stage=pre_write',
+      '--task=P12.F2.T68',
+      '--dry-run',
+      '--json',
+    ]),
+    {
+      command: 'sdd',
+      purgeArtifacts: false,
+      json: true,
+      sddCommand: 'learn',
+      sddLearnDryRun: true,
+      sddLearnChange: 'rgo-1700-02',
+      sddLearnStage: 'PRE_WRITE',
+      sddLearnTask: 'P12.F2.T68',
+    }
+  );
 });
 
 test('parseLifecycleCliArgs soporta analytics hotspots report', () => {
@@ -457,6 +478,10 @@ test('parseLifecycleCliArgs rechaza help implícito y flags no soportados', () =
   assert.throws(
     () => parseLifecycleCliArgs(['status', '--deep']),
     /only supported with "pumuki doctor"/i
+  );
+  assert.throws(
+    () => parseLifecycleCliArgs(['sdd', 'learn']),
+    /Missing --change=<change-id> for "pumuki sdd learn"/i
   );
 });
 
@@ -1207,6 +1232,61 @@ test('runLifecycleCli sdd sync-docs dry-run devuelve diff sin modificar el archi
     assert.equal(payload.updated, true);
     assert.equal(payload.files?.[0]?.updated, true);
     assert.match(payload.files?.[0]?.diffMarkdown ?? '', /sdd-status/i);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli sdd learn dry-run genera learning payload sin requerir archivos canónicos', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+  try {
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli([
+      'sdd',
+      'learn',
+      '--change=rgo-1700-03',
+      '--stage=pre_write',
+      '--task=P12.F2.T68',
+      '--dry-run',
+      '--json',
+    ]);
+    assert.equal(code, 0);
+
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      command?: string;
+      dryRun?: boolean;
+      context?: {
+        change?: string;
+        stage?: string | null;
+        task?: string | null;
+      };
+      learning?: {
+        path?: string;
+        written?: boolean;
+      };
+    };
+    assert.equal(payload.command, 'pumuki sdd learn');
+    assert.equal(payload.dryRun, true);
+    assert.equal(payload.context?.change, 'rgo-1700-03');
+    assert.equal(payload.context?.stage, 'PRE_WRITE');
+    assert.equal(payload.context?.task, 'P12.F2.T68');
+    assert.equal(payload.learning?.path, 'openspec/changes/rgo-1700-03/learning.json');
+    assert.equal(payload.learning?.written, false);
+    assert.equal(
+      existsSync(join(repo, 'openspec', 'changes', 'rgo-1700-03', 'learning.json')),
+      false
+    );
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -27,6 +27,7 @@ import {
   openSddSession,
   readSddStatus,
   refreshSddSession,
+  runSddLearn,
   runSddSyncDocs,
   type SddStage,
 } from '../sdd';
@@ -62,7 +63,7 @@ type LifecycleCommand =
   | 'adapter'
   | 'analytics';
 
-type SddCommand = 'status' | 'validate' | 'session' | 'sync-docs';
+type SddCommand = 'status' | 'validate' | 'session' | 'sync-docs' | 'learn';
 type LoopCommand = 'run' | 'status' | 'stop' | 'resume' | 'list' | 'export';
 type AnalyticsCommand = 'hotspots';
 type AnalyticsHotspotsCommand = 'report' | 'diagnose';
@@ -90,6 +91,10 @@ type ParsedArgs = {
   sddSyncDocsChange?: string;
   sddSyncDocsStage?: SddStage;
   sddSyncDocsTask?: string;
+  sddLearnDryRun?: boolean;
+  sddLearnChange?: string;
+  sddLearnStage?: SddStage;
+  sddLearnTask?: string;
   adapterCommand?: 'install';
   adapterAgent?: AdapterAgent;
   adapterDryRun?: boolean;
@@ -124,6 +129,7 @@ Pumuki lifecycle commands:
   pumuki sdd session --refresh [--ttl-minutes=<n>] [--json]
   pumuki sdd session --close [--json]
   pumuki sdd sync-docs [--change=<change-id>] [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json]
+  pumuki sdd learn --change=<change-id> [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json]
 `.trim();
 
 const LOOP_RUN_POLICY: GatePolicy = {
@@ -426,6 +432,10 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   let sddSyncDocsChange: ParsedArgs['sddSyncDocsChange'];
   let sddSyncDocsStage: ParsedArgs['sddSyncDocsStage'];
   let sddSyncDocsTask: ParsedArgs['sddSyncDocsTask'];
+  let sddLearnDryRun = false;
+  let sddLearnChange: ParsedArgs['sddLearnChange'];
+  let sddLearnStage: ParsedArgs['sddLearnStage'];
+  let sddLearnTask: ParsedArgs['sddLearnTask'];
   let adapterCommand: ParsedArgs['adapterCommand'];
   let adapterAgent: ParsedArgs['adapterAgent'];
   let adapterDryRun = false;
@@ -604,7 +614,8 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
       subcommandRaw !== 'status' &&
       subcommandRaw !== 'validate' &&
       subcommandRaw !== 'session' &&
-      subcommandRaw !== 'sync-docs'
+      subcommandRaw !== 'sync-docs' &&
+      subcommandRaw !== 'learn'
     ) {
       throw new Error(`Unsupported SDD subcommand "${subcommandRaw}".\n\n${HELP_TEXT}`);
     }
@@ -616,11 +627,15 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         continue;
       }
       if (arg === '--dry-run') {
-        if (sddCommand !== 'sync-docs') {
-          throw new Error(`--dry-run is only supported with "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'sync-docs') {
+          sddSyncDocsDryRun = true;
+          continue;
         }
-        sddSyncDocsDryRun = true;
-        continue;
+        if (sddCommand === 'learn') {
+          sddLearnDryRun = true;
+          continue;
+        }
+        throw new Error(`--dry-run is only supported with "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
       }
       if (arg.startsWith('--stage=')) {
         if (sddCommand === 'validate') {
@@ -631,7 +646,11 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
           sddSyncDocsStage = parseSddStage(arg.slice('--stage='.length));
           continue;
         }
-        throw new Error(`--stage is only supported with "pumuki sdd validate" or "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'learn') {
+          sddLearnStage = parseSddStage(arg.slice('--stage='.length));
+          continue;
+        }
+        throw new Error(`--stage is only supported with "pumuki sdd validate", "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
       }
       if (arg === '--open') {
         if (sddCommand !== 'session') {
@@ -667,18 +686,34 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
           sddSyncDocsChange = changeValue;
           continue;
         }
-        throw new Error(`--change is only supported with "pumuki sdd session" or "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'learn') {
+          const changeValue = arg.slice('--change='.length).trim();
+          if (changeValue.length === 0) {
+            throw new Error(`Invalid --change value "${arg}".`);
+          }
+          sddLearnChange = changeValue;
+          continue;
+        }
+        throw new Error(`--change is only supported with "pumuki sdd session", "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
       }
       if (arg.startsWith('--task=')) {
-        if (sddCommand !== 'sync-docs') {
-          throw new Error(`--task is only supported with "pumuki sdd sync-docs".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'sync-docs') {
+          const taskValue = arg.slice('--task='.length).trim();
+          if (taskValue.length === 0) {
+            throw new Error(`Invalid --task value "${arg}".`);
+          }
+          sddSyncDocsTask = taskValue;
+          continue;
         }
-        const taskValue = arg.slice('--task='.length).trim();
-        if (taskValue.length === 0) {
-          throw new Error(`Invalid --task value "${arg}".`);
+        if (sddCommand === 'learn') {
+          const taskValue = arg.slice('--task='.length).trim();
+          if (taskValue.length === 0) {
+            throw new Error(`Invalid --task value "${arg}".`);
+          }
+          sddLearnTask = taskValue;
+          continue;
         }
-        sddSyncDocsTask = taskValue;
-        continue;
+        throw new Error(`--task is only supported with "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
       }
       if (arg.startsWith('--ttl-minutes=')) {
         if (sddCommand !== 'session') {
@@ -726,6 +761,26 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         ...(sddSyncDocsChange ? { sddSyncDocsChange } : {}),
         ...(sddSyncDocsStage ? { sddSyncDocsStage } : {}),
         ...(sddSyncDocsTask ? { sddSyncDocsTask } : {}),
+      };
+    }
+    if (sddCommand === 'learn') {
+      if (sddSessionAction || sddChangeId || typeof sddTtlMinutes === 'number') {
+        throw new Error(
+          `"pumuki sdd learn" only supports --change=<change-id> [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json].\n\n${HELP_TEXT}`
+        );
+      }
+      if (!sddLearnChange || sddLearnChange.length === 0) {
+        throw new Error(`Missing --change=<change-id> for "pumuki sdd learn".\n\n${HELP_TEXT}`);
+      }
+      return {
+        command: commandRaw,
+        purgeArtifacts: false,
+        json,
+        sddCommand,
+        sddLearnDryRun,
+        sddLearnChange,
+        ...(sddLearnStage ? { sddLearnStage } : {}),
+        ...(sddLearnTask ? { sddLearnTask } : {}),
       };
     }
 
@@ -1746,6 +1801,26 @@ export const runLifecycleCli = async (
                 writeInfo(file.diffMarkdown);
               }
             }
+          }
+          return 0;
+        }
+        if (parsed.sddCommand === 'learn') {
+          const learnResult = runSddLearn({
+            repoRoot: process.cwd(),
+            dryRun: parsed.sddLearnDryRun === true,
+            change: parsed.sddLearnChange,
+            stage: parsed.sddLearnStage,
+            task: parsed.sddLearnTask,
+          });
+          if (parsed.json) {
+            writeInfo(JSON.stringify(learnResult, null, 2));
+          } else {
+            writeInfo(
+              `[pumuki][sdd] learn dry_run=${learnResult.dryRun ? 'yes' : 'no'} change=${learnResult.context.change} stage=${learnResult.context.stage ?? 'none'} task=${learnResult.context.task ?? 'none'} written=${learnResult.learning.written ? 'yes' : 'no'} digest=${learnResult.learning.digest}`
+            );
+            writeInfo(
+              `[pumuki][sdd] learning_path=${learnResult.learning.path} failed=${learnResult.learning.artifact.failed_patterns.length} successful=${learnResult.learning.artifact.successful_patterns.length} anomalies=${learnResult.learning.artifact.gate_anomalies.length} updates=${learnResult.learning.artifact.rule_updates.length}`
+            );
           }
           return 0;
         }

--- a/integrations/sdd/index.ts
+++ b/integrations/sdd/index.ts
@@ -9,4 +9,4 @@ export type {
 } from './types';
 export { evaluateSddPolicy, readSddStatus } from './policy';
 export { closeSddSession, openSddSession, readSddSession, refreshSddSession } from './sessionStore';
-export { runSddSyncDocs } from './syncDocs';
+export { runSddLearn, runSddSyncDocs } from './syncDocs';

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -73,6 +73,18 @@ export type SddSyncDocsResult = {
   };
 };
 
+export type SddLearnResult = {
+  command: 'pumuki sdd learn';
+  dryRun: boolean;
+  repoRoot: string;
+  context: {
+    change: string;
+    stage: SddStage | null;
+    task: string | null;
+  };
+  learning: NonNullable<SddSyncDocsResult['learning']>;
+};
+
 const normalizeSectionBody = (value: string): string => value.trim().replace(/\r\n/g, '\n');
 
 const computeDigest = (value: string): string =>
@@ -377,5 +389,47 @@ export const runSddSyncDocs = (params?: {
     updated,
     files,
     ...(learning ? { learning } : {}),
+  };
+};
+
+export const runSddLearn = (params?: {
+  repoRoot?: string;
+  dryRun?: boolean;
+  change?: string;
+  stage?: SddStage;
+  task?: string;
+  now?: () => Date;
+  evidenceReader?: (repoRoot: string) => EvidenceReadResult;
+}): SddLearnResult => {
+  const change = params?.change?.trim();
+  if (!change) {
+    throw new Error('[pumuki][sdd] learn requires --change=<change-id>.');
+  }
+
+  const result = runSddSyncDocs({
+    repoRoot: params?.repoRoot,
+    dryRun: params?.dryRun,
+    change,
+    stage: params?.stage,
+    task: params?.task,
+    now: params?.now,
+    evidenceReader: params?.evidenceReader,
+    targets: [],
+  });
+
+  if (!result.learning) {
+    throw new Error('[pumuki][sdd] learn could not generate learning artifact.');
+  }
+
+  return {
+    command: 'pumuki sdd learn',
+    dryRun: result.dryRun,
+    repoRoot: result.repoRoot,
+    context: {
+      change,
+      stage: result.context.stage,
+      task: result.context.task,
+    },
+    learning: result.learning,
   };
 };


### PR DESCRIPTION
## Summary
- add a dedicated `pumuki sdd learn` command with `--change`, optional `--stage/--task`, `--dry-run`, and `--json`
- implement `runSddLearn` in SDD integration and keep payload contract compatible with `sync-docs` learning artifact
- extend lifecycle CLI parser/runtime and add regression tests
- update configuration docs with command usage

## Evidence
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`

Closes #597
