### PR TITLE
feature: add pumuki sdd auto-sync orchestration command

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -191,6 +191,7 @@ Behavior:
 - non dry-run: persists `learning.json` deterministically and reports digest/path in output.
 - `rule_updates`: deterministic recommendations derived from evidence/gate signals (`missing`, `invalid`, `blocked`, `allowed`).
 - dedicated command: `pumuki sdd learn --change=<id> [--stage=<stage>] [--task=<task>] [--dry-run] [--json]` generates/persists the same artifact without requiring `sync-docs`.
+- orchestration command: `pumuki sdd auto-sync --change=<id> [--stage=<stage>] [--task=<task>] [--dry-run] [--json]` executes deterministic docs sync plus learning generation in one step.
 
 ## Gate telemetry export (optional)
 

--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -344,6 +344,27 @@ test('parseLifecycleCliArgs soporta subcomandos SDD', () => {
       sddLearnTask: 'P12.F2.T68',
     }
   );
+  assert.deepEqual(
+    parseLifecycleCliArgs([
+      'sdd',
+      'auto-sync',
+      '--change=rgo-1700-04',
+      '--stage=pre_push',
+      '--task=P12.F2.T70',
+      '--dry-run',
+      '--json',
+    ]),
+    {
+      command: 'sdd',
+      purgeArtifacts: false,
+      json: true,
+      sddCommand: 'auto-sync',
+      sddAutoSyncDryRun: true,
+      sddAutoSyncChange: 'rgo-1700-04',
+      sddAutoSyncStage: 'PRE_PUSH',
+      sddAutoSyncTask: 'P12.F2.T70',
+    }
+  );
 });
 
 test('parseLifecycleCliArgs soporta analytics hotspots report', () => {
@@ -482,6 +503,10 @@ test('parseLifecycleCliArgs rechaza help implícito y flags no soportados', () =
   assert.throws(
     () => parseLifecycleCliArgs(['sdd', 'learn']),
     /Missing --change=<change-id> for "pumuki sdd learn"/i
+  );
+  assert.throws(
+    () => parseLifecycleCliArgs(['sdd', 'auto-sync']),
+    /Missing --change=<change-id> for "pumuki sdd auto-sync"/i
   );
 });
 
@@ -1232,6 +1257,89 @@ test('runLifecycleCli sdd sync-docs dry-run devuelve diff sin modificar el archi
     assert.equal(payload.updated, true);
     assert.equal(payload.files?.[0]?.updated, true);
     assert.match(payload.files?.[0]?.diffMarkdown ?? '', /sdd-status/i);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.chdir(previousCwd);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleCli sdd auto-sync dry-run orquesta sync-docs + learning sin modificar archivo canónico', async () => {
+  const repo = createGitRepo();
+  const previousCwd = process.cwd();
+  const printed: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const canonicalDoc = join(
+    repo,
+    'docs',
+    'technical',
+    '08-validation',
+    'refactor',
+    'pumuki-integration-feedback.md'
+  );
+
+  try {
+    mkdirSync(dirname(canonicalDoc), { recursive: true });
+    writeFileSync(
+      canonicalDoc,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    const before = readFileSync(canonicalDoc, 'utf8');
+
+    process.chdir(repo);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      printed.push(String(chunk).trimEnd());
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runLifecycleCli([
+      'sdd',
+      'auto-sync',
+      '--change=rgo-1700-04',
+      '--stage=pre_push',
+      '--task=P12.F2.T70',
+      '--dry-run',
+      '--json',
+    ]);
+    assert.equal(code, 0);
+    const after = readFileSync(canonicalDoc, 'utf8');
+    assert.equal(before, after);
+
+    const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
+      command?: string;
+      dryRun?: boolean;
+      context?: {
+        change?: string;
+        stage?: string | null;
+        task?: string | null;
+      };
+      syncDocs?: {
+        updated?: boolean;
+        files?: Array<{ updated?: boolean; diffMarkdown?: string }>;
+      };
+      learning?: {
+        path?: string;
+        written?: boolean;
+      };
+    };
+    assert.equal(payload.command, 'pumuki sdd auto-sync');
+    assert.equal(payload.dryRun, true);
+    assert.equal(payload.context?.change, 'rgo-1700-04');
+    assert.equal(payload.context?.stage, 'PRE_PUSH');
+    assert.equal(payload.context?.task, 'P12.F2.T70');
+    assert.equal(payload.syncDocs?.updated, true);
+    assert.equal(payload.syncDocs?.files?.[0]?.updated, true);
+    assert.match(payload.syncDocs?.files?.[0]?.diffMarkdown ?? '', /sdd-status/i);
+    assert.equal(payload.learning?.path, 'openspec/changes/rgo-1700-04/learning.json');
+    assert.equal(payload.learning?.written, false);
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -27,6 +27,7 @@ import {
   openSddSession,
   readSddStatus,
   refreshSddSession,
+  runSddAutoSync,
   runSddLearn,
   runSddSyncDocs,
   type SddStage,
@@ -63,7 +64,7 @@ type LifecycleCommand =
   | 'adapter'
   | 'analytics';
 
-type SddCommand = 'status' | 'validate' | 'session' | 'sync-docs' | 'learn';
+type SddCommand = 'status' | 'validate' | 'session' | 'sync-docs' | 'learn' | 'auto-sync';
 type LoopCommand = 'run' | 'status' | 'stop' | 'resume' | 'list' | 'export';
 type AnalyticsCommand = 'hotspots';
 type AnalyticsHotspotsCommand = 'report' | 'diagnose';
@@ -95,6 +96,10 @@ type ParsedArgs = {
   sddLearnChange?: string;
   sddLearnStage?: SddStage;
   sddLearnTask?: string;
+  sddAutoSyncDryRun?: boolean;
+  sddAutoSyncChange?: string;
+  sddAutoSyncStage?: SddStage;
+  sddAutoSyncTask?: string;
   adapterCommand?: 'install';
   adapterAgent?: AdapterAgent;
   adapterDryRun?: boolean;
@@ -130,6 +135,7 @@ Pumuki lifecycle commands:
   pumuki sdd session --close [--json]
   pumuki sdd sync-docs [--change=<change-id>] [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json]
   pumuki sdd learn --change=<change-id> [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json]
+  pumuki sdd auto-sync --change=<change-id> [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json]
 `.trim();
 
 const LOOP_RUN_POLICY: GatePolicy = {
@@ -436,6 +442,10 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
   let sddLearnChange: ParsedArgs['sddLearnChange'];
   let sddLearnStage: ParsedArgs['sddLearnStage'];
   let sddLearnTask: ParsedArgs['sddLearnTask'];
+  let sddAutoSyncDryRun = false;
+  let sddAutoSyncChange: ParsedArgs['sddAutoSyncChange'];
+  let sddAutoSyncStage: ParsedArgs['sddAutoSyncStage'];
+  let sddAutoSyncTask: ParsedArgs['sddAutoSyncTask'];
   let adapterCommand: ParsedArgs['adapterCommand'];
   let adapterAgent: ParsedArgs['adapterAgent'];
   let adapterDryRun = false;
@@ -615,7 +625,8 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
       subcommandRaw !== 'validate' &&
       subcommandRaw !== 'session' &&
       subcommandRaw !== 'sync-docs' &&
-      subcommandRaw !== 'learn'
+      subcommandRaw !== 'learn' &&
+      subcommandRaw !== 'auto-sync'
     ) {
       throw new Error(`Unsupported SDD subcommand "${subcommandRaw}".\n\n${HELP_TEXT}`);
     }
@@ -635,7 +646,11 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
           sddLearnDryRun = true;
           continue;
         }
-        throw new Error(`--dry-run is only supported with "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'auto-sync') {
+          sddAutoSyncDryRun = true;
+          continue;
+        }
+        throw new Error(`--dry-run is only supported with "pumuki sdd sync-docs", "pumuki sdd learn" or "pumuki sdd auto-sync".\n\n${HELP_TEXT}`);
       }
       if (arg.startsWith('--stage=')) {
         if (sddCommand === 'validate') {
@@ -650,7 +665,11 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
           sddLearnStage = parseSddStage(arg.slice('--stage='.length));
           continue;
         }
-        throw new Error(`--stage is only supported with "pumuki sdd validate", "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'auto-sync') {
+          sddAutoSyncStage = parseSddStage(arg.slice('--stage='.length));
+          continue;
+        }
+        throw new Error(`--stage is only supported with "pumuki sdd validate", "pumuki sdd sync-docs", "pumuki sdd learn" or "pumuki sdd auto-sync".\n\n${HELP_TEXT}`);
       }
       if (arg === '--open') {
         if (sddCommand !== 'session') {
@@ -694,7 +713,15 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
           sddLearnChange = changeValue;
           continue;
         }
-        throw new Error(`--change is only supported with "pumuki sdd session", "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'auto-sync') {
+          const changeValue = arg.slice('--change='.length).trim();
+          if (changeValue.length === 0) {
+            throw new Error(`Invalid --change value "${arg}".`);
+          }
+          sddAutoSyncChange = changeValue;
+          continue;
+        }
+        throw new Error(`--change is only supported with "pumuki sdd session", "pumuki sdd sync-docs", "pumuki sdd learn" or "pumuki sdd auto-sync".\n\n${HELP_TEXT}`);
       }
       if (arg.startsWith('--task=')) {
         if (sddCommand === 'sync-docs') {
@@ -713,7 +740,15 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
           sddLearnTask = taskValue;
           continue;
         }
-        throw new Error(`--task is only supported with "pumuki sdd sync-docs" or "pumuki sdd learn".\n\n${HELP_TEXT}`);
+        if (sddCommand === 'auto-sync') {
+          const taskValue = arg.slice('--task='.length).trim();
+          if (taskValue.length === 0) {
+            throw new Error(`Invalid --task value "${arg}".`);
+          }
+          sddAutoSyncTask = taskValue;
+          continue;
+        }
+        throw new Error(`--task is only supported with "pumuki sdd sync-docs", "pumuki sdd learn" or "pumuki sdd auto-sync".\n\n${HELP_TEXT}`);
       }
       if (arg.startsWith('--ttl-minutes=')) {
         if (sddCommand !== 'session') {
@@ -781,6 +816,26 @@ export const parseLifecycleCliArgs = (argv: ReadonlyArray<string>): ParsedArgs =
         sddLearnChange,
         ...(sddLearnStage ? { sddLearnStage } : {}),
         ...(sddLearnTask ? { sddLearnTask } : {}),
+      };
+    }
+    if (sddCommand === 'auto-sync') {
+      if (sddSessionAction || sddChangeId || typeof sddTtlMinutes === 'number') {
+        throw new Error(
+          `"pumuki sdd auto-sync" only supports --change=<change-id> [--stage=PRE_WRITE|PRE_COMMIT|PRE_PUSH|CI] [--task=<task-id>] [--dry-run] [--json].\n\n${HELP_TEXT}`
+        );
+      }
+      if (!sddAutoSyncChange || sddAutoSyncChange.length === 0) {
+        throw new Error(`Missing --change=<change-id> for "pumuki sdd auto-sync".\n\n${HELP_TEXT}`);
+      }
+      return {
+        command: commandRaw,
+        purgeArtifacts: false,
+        json,
+        sddCommand,
+        sddAutoSyncDryRun,
+        sddAutoSyncChange,
+        ...(sddAutoSyncStage ? { sddAutoSyncStage } : {}),
+        ...(sddAutoSyncTask ? { sddAutoSyncTask } : {}),
       };
     }
 
@@ -1821,6 +1876,31 @@ export const runLifecycleCli = async (
             writeInfo(
               `[pumuki][sdd] learning_path=${learnResult.learning.path} failed=${learnResult.learning.artifact.failed_patterns.length} successful=${learnResult.learning.artifact.successful_patterns.length} anomalies=${learnResult.learning.artifact.gate_anomalies.length} updates=${learnResult.learning.artifact.rule_updates.length}`
             );
+          }
+          return 0;
+        }
+        if (parsed.sddCommand === 'auto-sync') {
+          const autoSyncResult = runSddAutoSync({
+            repoRoot: process.cwd(),
+            dryRun: parsed.sddAutoSyncDryRun === true,
+            change: parsed.sddAutoSyncChange,
+            stage: parsed.sddAutoSyncStage,
+            task: parsed.sddAutoSyncTask,
+          });
+          if (parsed.json) {
+            writeInfo(JSON.stringify(autoSyncResult, null, 2));
+          } else {
+            writeInfo(
+              `[pumuki][sdd] auto-sync dry_run=${autoSyncResult.dryRun ? 'yes' : 'no'} change=${autoSyncResult.context.change} stage=${autoSyncResult.context.stage ?? 'none'} task=${autoSyncResult.context.task ?? 'none'} updated=${autoSyncResult.syncDocs.updated ? 'yes' : 'no'} files=${autoSyncResult.syncDocs.files.length} learning_written=${autoSyncResult.learning.written ? 'yes' : 'no'}`
+            );
+            writeInfo(
+              `[pumuki][sdd] learning_path=${autoSyncResult.learning.path} digest=${autoSyncResult.learning.digest}`
+            );
+            for (const file of autoSyncResult.syncDocs.files) {
+              writeInfo(
+                `[pumuki][sdd] file=${file.path} updated=${file.updated ? 'yes' : 'no'} before=${file.beforeDigest} after=${file.afterDigest}`
+              );
+            }
           }
           return 0;
         }

--- a/integrations/sdd/__tests__/index.test.ts
+++ b/integrations/sdd/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import * as sdd from '../index';
 import { evaluateSddPolicy, readSddStatus } from '../policy';
 import { closeSddSession, openSddSession, readSddSession, refreshSddSession } from '../sessionStore';
+import { runSddAutoSync, runSddLearn, runSddSyncDocs } from '../syncDocs';
 
 test('sdd index re-exports policy and sessionStore runtime API', () => {
   assert.strictEqual(sdd.evaluateSddPolicy, evaluateSddPolicy);
@@ -11,6 +12,9 @@ test('sdd index re-exports policy and sessionStore runtime API', () => {
   assert.strictEqual(sdd.readSddSession, readSddSession);
   assert.strictEqual(sdd.refreshSddSession, refreshSddSession);
   assert.strictEqual(sdd.closeSddSession, closeSddSession);
+  assert.strictEqual(sdd.runSddSyncDocs, runSddSyncDocs);
+  assert.strictEqual(sdd.runSddLearn, runSddLearn);
+  assert.strictEqual(sdd.runSddAutoSync, runSddAutoSync);
 });
 
 test('sdd index exposes only the expected runtime symbols', () => {
@@ -21,5 +25,8 @@ test('sdd index exposes only the expected runtime symbols', () => {
     'readSddSession',
     'readSddStatus',
     'refreshSddSession',
+    'runSddAutoSync',
+    'runSddLearn',
+    'runSddSyncDocs',
   ]);
 });

--- a/integrations/sdd/__tests__/syncDocs.test.ts
+++ b/integrations/sdd/__tests__/syncDocs.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
-import { runSddSyncDocs } from '../syncDocs';
+import { runSddAutoSync, runSddSyncDocs } from '../syncDocs';
 import type { EvidenceReadResult } from '../../evidence/readEvidence';
 
 const runGit = (cwd: string, args: ReadonlyArray<string>): string =>
@@ -534,4 +534,86 @@ test('runSddSyncDocs falla con conflicto de marcadores y no toca el archivo', as
     const after = readFileSync(canonicalPath, 'utf8');
     assert.equal(before, after);
   });
+});
+
+test('runSddAutoSync dry-run orquesta sync-docs + learning sin modificar archivos', async () => {
+  await withFixtureRepo('pumuki-sdd-auto-sync-dry-run-', (repoRoot) => {
+    const canonicalPath = writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+    const before = readFileSync(canonicalPath, 'utf8');
+
+    const result = runSddAutoSync({
+      repoRoot,
+      dryRun: true,
+      change: 'rgo-1700-06',
+      stage: 'PRE_PUSH',
+      task: 'P12.F2.T70',
+      now: () => new Date('2026-03-04T11:00:00.000Z'),
+    });
+    const after = readFileSync(canonicalPath, 'utf8');
+
+    assert.equal(result.command, 'pumuki sdd auto-sync');
+    assert.equal(result.dryRun, true);
+    assert.equal(result.context.change, 'rgo-1700-06');
+    assert.equal(result.context.stage, 'PRE_PUSH');
+    assert.equal(result.context.task, 'P12.F2.T70');
+    assert.equal(result.syncDocs.updated, true);
+    assert.equal(result.syncDocs.files.length, 1);
+    assert.equal(result.learning.path, 'openspec/changes/rgo-1700-06/learning.json');
+    assert.equal(result.learning.written, false);
+    assert.equal(before, after);
+  });
+});
+
+test('runSddAutoSync aplica sync-docs y persiste learning en modo escritura', async () => {
+  await withFixtureRepo('pumuki-sdd-auto-sync-write-', (repoRoot) => {
+    const canonicalPath = writeCanonicalDoc(
+      repoRoot,
+      [
+        '# Canonical',
+        '',
+        '<!-- PUMUKI:BEGIN SDD_STATUS -->',
+        '- stale: true',
+        '<!-- PUMUKI:END SDD_STATUS -->',
+        '',
+      ].join('\n')
+    );
+
+    const result = runSddAutoSync({
+      repoRoot,
+      dryRun: false,
+      change: 'rgo-1700-07',
+      stage: 'PRE_COMMIT',
+      task: 'P12.F2.T70',
+      now: () => new Date('2026-03-04T11:05:00.000Z'),
+    });
+
+    assert.equal(result.command, 'pumuki sdd auto-sync');
+    assert.equal(result.syncDocs.updated, true);
+    assert.match(readFileSync(canonicalPath, 'utf8'), /openspec_installed:/);
+    const learningPath = join(repoRoot, 'openspec', 'changes', 'rgo-1700-07', 'learning.json');
+    assert.equal(existsSync(learningPath), true);
+    assert.equal(result.learning.written, true);
+    assert.equal(result.learning.path, 'openspec/changes/rgo-1700-07/learning.json');
+  });
+});
+
+test('runSddAutoSync falla cuando falta --change', () => {
+  assert.throws(
+    () =>
+      runSddAutoSync({
+        repoRoot: process.cwd(),
+        dryRun: true,
+      }),
+    /auto-sync requires --change/i
+  );
 });

--- a/integrations/sdd/index.ts
+++ b/integrations/sdd/index.ts
@@ -9,4 +9,4 @@ export type {
 } from './types';
 export { evaluateSddPolicy, readSddStatus } from './policy';
 export { closeSddSession, openSddSession, readSddSession, refreshSddSession } from './sessionStore';
-export { runSddLearn, runSddSyncDocs } from './syncDocs';
+export { runSddAutoSync, runSddLearn, runSddSyncDocs } from './syncDocs';

--- a/integrations/sdd/syncDocs.ts
+++ b/integrations/sdd/syncDocs.ts
@@ -85,6 +85,22 @@ export type SddLearnResult = {
   learning: NonNullable<SddSyncDocsResult['learning']>;
 };
 
+export type SddAutoSyncResult = {
+  command: 'pumuki sdd auto-sync';
+  dryRun: boolean;
+  repoRoot: string;
+  context: {
+    change: string;
+    stage: SddStage | null;
+    task: string | null;
+  };
+  syncDocs: {
+    updated: boolean;
+    files: ReadonlyArray<SddSyncDocsFileResult>;
+  };
+  learning: NonNullable<SddSyncDocsResult['learning']>;
+};
+
 const normalizeSectionBody = (value: string): string => value.trim().replace(/\r\n/g, '\n');
 
 const computeDigest = (value: string): string =>
@@ -431,5 +447,52 @@ export const runSddLearn = (params?: {
       task: result.context.task,
     },
     learning: result.learning,
+  };
+};
+
+export const runSddAutoSync = (params?: {
+  repoRoot?: string;
+  dryRun?: boolean;
+  change?: string;
+  stage?: SddStage;
+  task?: string;
+  now?: () => Date;
+  evidenceReader?: (repoRoot: string) => EvidenceReadResult;
+  targets?: ReadonlyArray<SddSyncDocsTarget>;
+}): SddAutoSyncResult => {
+  const change = params?.change?.trim();
+  if (!change) {
+    throw new Error('[pumuki][sdd] auto-sync requires --change=<change-id>.');
+  }
+
+  const syncResult = runSddSyncDocs({
+    repoRoot: params?.repoRoot,
+    dryRun: params?.dryRun,
+    change,
+    stage: params?.stage,
+    task: params?.task,
+    now: params?.now,
+    evidenceReader: params?.evidenceReader,
+    targets: params?.targets,
+  });
+
+  if (!syncResult.learning) {
+    throw new Error('[pumuki][sdd] auto-sync could not generate learning artifact.');
+  }
+
+  return {
+    command: 'pumuki sdd auto-sync',
+    dryRun: syncResult.dryRun,
+    repoRoot: syncResult.repoRoot,
+    context: {
+      change,
+      stage: syncResult.context.stage,
+      task: syncResult.context.task,
+    },
+    syncDocs: {
+      updated: syncResult.updated,
+      files: syncResult.files,
+    },
+    learning: syncResult.learning,
   };
 };


### PR DESCRIPTION
## Summary
- add `pumuki sdd auto-sync` as deterministic orchestration command for enterprise SDD closure
- wire parser/runtime/help for `--change`, optional `--stage/--task`, `--dry-run`, and `--json`
- keep fail-safe behavior by reusing sync-docs transactional path while persisting learning payload in one step

## Why
- closes #600
- enterprise consumers requested a single command to run docs sync + learning generation deterministically

## Testing
- `npx --yes tsx@4.21.0 --test integrations/sdd/__tests__/syncDocs.test.ts integrations/sdd/__tests__/index.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`
