### PR TITLE
docs: align active T72 tracking issue to #606

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -8,7 +8,7 @@
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: EN CURSO
 - Última task cerrada (`✅`): `P12.F2.T71` (release `6.3.36` publicada en npm con `auto-sync`).
-- Task activa (`🚧`): `P12.F2.T72` (hardening pendiente enterprise: `policy-as-code` firmada, issue `#543`).
+- Task activa (`🚧`): `P12.F2.T72` (hardening pendiente enterprise: `policy-as-code` firmada, issue `#606`).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -1982,7 +1982,7 @@ Criterio de salida F5:
     - `npm publish --access public` => `+ pumuki@6.3.36`.
     - `npm view pumuki@6.3.36 version` => `6.3.36`.
 
-- 🚧 `P12.F2.T72` Siguiente hardening enterprise: policy-as-code firmada/versionada (`#543`).
+- 🚧 `P12.F2.T72` Siguiente hardening enterprise: policy-as-code firmada/versionada (`#606`).
   - salida esperada:
     - definir contrato machine-readable de policy con versión/firma y validación estricta.
     - exponer metadatos de validación en salidas de gate/telemetría.


### PR DESCRIPTION
## Summary
- align active task `P12.F2.T72` to an open issue (`#606`)
- remove stale closed-issue reference from tracking docs
- keep single active `🚧` task contract valid

## Validation
- `npm run -s validation:tracking-single-active`
