### PR TITLE
feat: harden policy-as-code strict unsigned contract and lifecycle metadata (#606)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -229,7 +229,7 @@ Expected JSONL keys for enterprise audit ingestion:
 - `schema=telemetry_event_v1` with `schema_version=1.0`
 - `stage`, `gate_outcome`, `severity_counts`
 - `policy.bundle`, `policy.hash`, `policy.version`, `policy.signature`, `policy.policy_source`
-- `policy.validation_status`, `policy.validation_code` (when policy-as-code validation is available)
+- `policy.validation_status`, `policy.validation_code` (when policy-as-code validation is available; status can be `valid|invalid|expired|unknown-source|unsigned`)
 
 ## Heuristic pilot flag
 

--- a/integrations/evidence/schema.ts
+++ b/integrations/evidence/schema.ts
@@ -89,7 +89,7 @@ export type RulesetState = {
   version?: string;
   signature?: string;
   source?: string;
-  validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source';
+  validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source' | 'unsigned';
   validation_code?: string;
   degraded_mode_enabled?: boolean;
   degraded_mode_action?: 'allow' | 'block';

--- a/integrations/gate/__tests__/stagePolicies.test.ts
+++ b/integrations/gate/__tests__/stagePolicies.test.ts
@@ -29,6 +29,26 @@ test('resolvePolicyForStage returns default PRE_PUSH policy when skills policy i
   });
 });
 
+test('resolvePolicyForStage marks unsigned in strict mode when policy-as-code contract is missing', async () => {
+  await withTempDir('pumuki-stage-policy-unsigned-strict-', async (repoRoot) => {
+    const previousStrict = process.env.PUMUKI_POLICY_STRICT;
+    process.env.PUMUKI_POLICY_STRICT = '1';
+    try {
+      const resolved = resolvePolicyForStage('PRE_PUSH', repoRoot);
+      assert.equal(resolved.trace.validation?.status, 'unsigned');
+      assert.equal(resolved.trace.validation?.code, 'POLICY_AS_CODE_UNSIGNED');
+      assert.equal(resolved.trace.validation?.strict, true);
+      assert.equal(resolved.trace.policySource, 'computed-local');
+    } finally {
+      if (typeof previousStrict === 'undefined') {
+        delete process.env.PUMUKI_POLICY_STRICT;
+      } else {
+        process.env.PUMUKI_POLICY_STRICT = previousStrict;
+      }
+    }
+  });
+});
+
 test('resolvePolicyForStage applies PRE_PUSH override from skills.policy.json', async () => {
   await withTempDir('pumuki-stage-policy-direct-override-', async (repoRoot) => {
     const skillsPolicy = {

--- a/integrations/gate/stagePolicies.ts
+++ b/integrations/gate/stagePolicies.ts
@@ -49,9 +49,10 @@ export type ResolvedStagePolicy = {
     signature?: string;
     policySource?: string;
     validation?: {
-      status: 'valid' | 'invalid' | 'expired' | 'unknown-source';
+      status: 'valid' | 'invalid' | 'expired' | 'unknown-source' | 'unsigned';
       code:
         | 'POLICY_AS_CODE_VALID'
+        | 'POLICY_AS_CODE_UNSIGNED'
         | 'POLICY_AS_CODE_CONTRACT_INVALID'
         | 'POLICY_AS_CODE_CONTRACT_EXPIRED'
         | 'POLICY_AS_CODE_SIGNATURE_MISMATCH'
@@ -307,6 +308,21 @@ const resolvePolicyAsCodeTraceMetadata = (params: {
   const contractPath = join(params.repoRoot, POLICY_AS_CODE_CONTRACT_PATH);
 
   if (!existsSync(contractPath)) {
+    if (strict) {
+      return {
+        version: computedVersion,
+        signature: computedSignature,
+        policySource: 'computed-local',
+        validation: {
+          status: 'unsigned',
+          code: 'POLICY_AS_CODE_UNSIGNED',
+          message:
+            'Policy-as-code contract is missing; runtime policy metadata is unsigned.',
+          strict,
+        },
+      };
+    }
+
     return {
       version: computedVersion,
       signature: computedSignature,

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -419,6 +419,75 @@ test('runPlatformGate bloquea en modo strict cuando policy-as-code es inválida'
   assert.equal(policyFinding?.source, 'policy-as-code');
 });
 
+test('runPlatformGate bloquea en modo strict cuando policy-as-code está unsigned', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'staged' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+
+  let emittedFindings: ReadonlyArray<Finding> = [];
+
+  const result = await runPlatformGate({
+    policy,
+    policyTrace: {
+      source: 'default',
+      bundle: 'gate-policy.default.PRE_COMMIT',
+      hash: 'f'.repeat(64),
+      version: 'policy-as-code/default@1.0',
+      signature: 'a'.repeat(64),
+      policySource: 'computed-local',
+      validation: {
+        status: 'unsigned',
+        code: 'POLICY_AS_CODE_UNSIGNED',
+        message: 'Policy-as-code contract is missing; runtime policy metadata is unsigned.',
+        strict: true,
+      },
+    },
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => [],
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {},
+        skillsRuleSet: {
+          rules: [],
+          activeBundles: [],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        findings: [],
+      }),
+      evaluateGate: () => ({ outcome: 'ALLOW' }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emittedFindings = paramsArg.findings;
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 1);
+  const policyFinding = emittedFindings.find(
+    (finding) => finding.ruleId === 'governance.policy-as-code.invalid'
+  );
+  assert.ok(policyFinding);
+  assert.equal(policyFinding?.code, 'POLICY_AS_CODE_UNSIGNED');
+  assert.equal(policyFinding?.source, 'policy-as-code');
+});
+
 test('runPlatformGate bloquea en modo strict cuando policy-as-code está expirada', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_PUSH',

--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -570,9 +570,25 @@ test('runLifecycleCli status --json --remote-checks añade diagnóstico remoto e
     assert.equal(code, 0);
     const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
       remoteCiDiagnostics?: { status?: string; blockers?: Array<{ code?: string }> };
+      policyValidation?: {
+        stages?: {
+          PRE_COMMIT?: { validationCode?: string };
+          PRE_PUSH?: { validationCode?: string };
+          CI?: { validationCode?: string };
+        };
+      };
     };
     assert.equal(payload.remoteCiDiagnostics?.status, 'blocked');
     assert.equal(payload.remoteCiDiagnostics?.blockers?.[0]?.code, 'REMOTE_CI_BILLING_LOCK');
+    assert.equal(
+      payload.policyValidation?.stages?.PRE_COMMIT?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(
+      payload.policyValidation?.stages?.PRE_PUSH?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(payload.policyValidation?.stages?.CI?.validationCode, 'POLICY_AS_CODE_VALID');
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);
@@ -675,6 +691,13 @@ test('runLifecycleCli doctor --deep --json expone checks enterprise determinista
           overall?: string;
         };
       };
+      policyValidation?: {
+        stages?: {
+          PRE_COMMIT?: { validationCode?: string };
+          PRE_PUSH?: { validationCode?: string };
+          CI?: { validationCode?: string };
+        };
+      };
     };
     assert.equal(payload.deep?.enabled, true);
     assert.equal(payload.deep?.checks?.some((check) => check.id === 'upstream-readiness'), true);
@@ -687,6 +710,15 @@ test('runLifecycleCli doctor --deep --json expone checks enterprise determinista
       payload.deep?.contract?.overall === 'incompatible',
       true
     );
+    assert.equal(
+      payload.policyValidation?.stages?.PRE_COMMIT?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(
+      payload.policyValidation?.stages?.PRE_PUSH?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(payload.policyValidation?.stages?.CI?.validationCode, 'POLICY_AS_CODE_VALID');
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);
@@ -820,6 +852,13 @@ test('runLifecycleCli sdd validate PRE_WRITE autocura recibo MCP faltante y perm
         allowed?: boolean;
         violations?: Array<{ code?: string }>;
       };
+      policy_validation?: {
+        stages?: {
+          PRE_COMMIT?: { validationCode?: string };
+          PRE_PUSH?: { validationCode?: string };
+          CI?: { validationCode?: string };
+        };
+      };
     };
     assert.equal(payload.ai_gate?.allowed, true);
     assert.equal(
@@ -828,6 +867,15 @@ test('runLifecycleCli sdd validate PRE_WRITE autocura recibo MCP faltante y perm
       ),
       false
     );
+    assert.equal(
+      payload.policy_validation?.stages?.PRE_COMMIT?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(
+      payload.policy_validation?.stages?.PRE_PUSH?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(payload.policy_validation?.stages?.CI?.validationCode, 'POLICY_AS_CODE_VALID');
     assert.equal(existsSync(resolveMcpAiGateReceiptPath(repo)), true);
   } finally {
     process.stdout.write = originalStdoutWrite;
@@ -937,8 +985,24 @@ test('runLifecycleCli sdd validate PRE_WRITE permite continuar con recibo MCP v�
       ai_gate?: {
         allowed?: boolean;
       };
+      policy_validation?: {
+        stages?: {
+          PRE_COMMIT?: { validationCode?: string };
+          PRE_PUSH?: { validationCode?: string };
+          CI?: { validationCode?: string };
+        };
+      };
     };
     assert.equal(payload.ai_gate?.allowed, true);
+    assert.equal(
+      payload.policy_validation?.stages?.PRE_COMMIT?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(
+      payload.policy_validation?.stages?.PRE_PUSH?.validationCode,
+      'POLICY_AS_CODE_VALID'
+    );
+    assert.equal(payload.policy_validation?.stages?.CI?.validationCode, 'POLICY_AS_CODE_VALID');
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.chdir(previousCwd);

--- a/integrations/lifecycle/__tests__/doctor.test.ts
+++ b/integrations/lifecycle/__tests__/doctor.test.ts
@@ -147,6 +147,9 @@ test('runLifecycleDoctor marca issue bloqueante cuando hay rutas trackeadas en n
     });
 
     assert.equal(report.repoRoot, repoRoot);
+    assert.equal(typeof report.policyValidation.stages.PRE_COMMIT.hash, 'string');
+    assert.equal(typeof report.policyValidation.stages.PRE_PUSH.hash, 'string');
+    assert.equal(typeof report.policyValidation.stages.CI.hash, 'string');
     assert.deepEqual(report.trackedNodeModulesPaths, ['node_modules/pkg/index.js']);
     assert.equal(report.issues.some((issue) => issue.severity === 'error'), true);
     assert.equal(doctorHasBlockingIssues(report), true);

--- a/integrations/lifecycle/__tests__/status.test.ts
+++ b/integrations/lifecycle/__tests__/status.test.ts
@@ -94,6 +94,12 @@ test('readLifecycleStatus compone estado desde git + hooks + lifecycle config', 
       'pre-commit': { exists: true, managedBlockPresent: true },
       'pre-push': { exists: true, managedBlockPresent: false },
     });
+    assert.equal(typeof status.policyValidation.stages.PRE_COMMIT.hash, 'string');
+    assert.equal(typeof status.policyValidation.stages.PRE_PUSH.hash, 'string');
+    assert.equal(typeof status.policyValidation.stages.CI.hash, 'string');
+    assert.equal(status.policyValidation.stages.PRE_COMMIT.validationCode, 'POLICY_AS_CODE_VALID');
+    assert.equal(status.policyValidation.stages.PRE_PUSH.validationCode, 'POLICY_AS_CODE_VALID');
+    assert.equal(status.policyValidation.stages.CI.validationCode, 'POLICY_AS_CODE_VALID');
 
     assert.deepEqual(git.resolveCalls, ['/tmp/ignored-cwd']);
     assert.deepEqual(git.listTrackedCalls, [repoRoot]);

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -10,6 +10,10 @@ import {
 import { runLifecycleInstall } from './install';
 import { runLifecycleRemove } from './remove';
 import { readLifecycleStatus } from './status';
+import {
+  readLifecyclePolicyValidationSnapshot,
+  type LifecyclePolicyValidationSnapshot,
+} from './policyValidationSnapshot';
 import { runLifecycleUninstall } from './uninstall';
 import { runLifecycleUpdate } from './update';
 import { runOpenSpecBootstrap } from './openSpecBootstrap';
@@ -977,6 +981,11 @@ const printDoctorReport = (
   writeInfo(
     `[pumuki] hook pre-push: ${report.hookStatus['pre-push'].managedBlockPresent ? 'managed' : 'missing'}`
   );
+  writeInfo(
+    `[pumuki] policy-as-code: PRE_COMMIT=${report.policyValidation.stages.PRE_COMMIT.validationCode ?? 'n/a'} strict=${report.policyValidation.stages.PRE_COMMIT.strict ? 'yes' : 'no'} ` +
+    `PRE_PUSH=${report.policyValidation.stages.PRE_PUSH.validationCode ?? 'n/a'} strict=${report.policyValidation.stages.PRE_PUSH.strict ? 'yes' : 'no'} ` +
+    `CI=${report.policyValidation.stages.CI.validationCode ?? 'n/a'} strict=${report.policyValidation.stages.CI.strict ? 'yes' : 'no'}`
+  );
 
   for (const issue of report.issues) {
     writeInfo(`[pumuki] ${issue.severity.toUpperCase()}: ${issue.message}`);
@@ -1016,6 +1025,7 @@ const PRE_WRITE_INSTALL_REMEDIATION_COMMAND =
 type PreWriteValidationEnvelope = {
   sdd: ReturnType<typeof evaluateSddPolicy>;
   ai_gate: ReturnType<typeof evaluateAiGate>;
+  policy_validation: LifecyclePolicyValidationSnapshot;
   automation: PreWriteAutomationTrace;
   bootstrap: {
     enabled: boolean;
@@ -1229,12 +1239,14 @@ const resolveAiGateViolationLocation = (code: string) => {
 const buildPreWriteValidationEnvelope = (
   result: ReturnType<typeof evaluateSddPolicy>,
   aiGate: ReturnType<typeof evaluateAiGate>,
+  policyValidation: LifecyclePolicyValidationSnapshot,
   automation: PreWriteAutomationTrace,
   bootstrap: PreWriteOpenSpecBootstrapTrace,
   nextAction: PreWriteValidationEnvelope['next_action']
 ): PreWriteValidationEnvelope => ({
   sdd: result,
   ai_gate: aiGate,
+  policy_validation: policyValidation,
   automation: {
     attempted: automation.attempted,
     actions: [...automation.actions],
@@ -1397,6 +1409,11 @@ export const runLifecycleCli = async (
           );
           writeInfo(
             `[pumuki] tracked node_modules paths: ${status.trackedNodeModulesCount}`
+          );
+          writeInfo(
+            `[pumuki] policy-as-code: PRE_COMMIT=${status.policyValidation.stages.PRE_COMMIT.validationCode ?? 'n/a'} strict=${status.policyValidation.stages.PRE_COMMIT.strict ? 'yes' : 'no'} ` +
+            `PRE_PUSH=${status.policyValidation.stages.PRE_PUSH.validationCode ?? 'n/a'} strict=${status.policyValidation.stages.PRE_PUSH.strict ? 'yes' : 'no'} ` +
+            `CI=${status.policyValidation.stages.CI.validationCode ?? 'n/a'} strict=${status.policyValidation.stages.CI.strict ? 'yes' : 'no'}`
           );
           if (remoteCiDiagnostics) {
             printRemoteCiDiagnostics(remoteCiDiagnostics);
@@ -1656,6 +1673,7 @@ export const runLifecycleCli = async (
           let result = evaluateSddPolicy({
             stage: parsed.sddStage ?? 'PRE_COMMIT',
           });
+          const policyValidation = readLifecyclePolicyValidationSnapshot(process.cwd());
           const preWriteAutoBootstrapEnabled = process.env.PUMUKI_PREWRITE_AUTO_BOOTSTRAP !== '0';
           const preWriteBootstrapTrace: PreWriteOpenSpecBootstrapTrace = {
             enabled: preWriteAutoBootstrapEnabled,
@@ -1727,11 +1745,15 @@ export const runLifecycleCli = async (
                   ? buildPreWriteValidationEnvelope(
                     result,
                     aiGate,
+                    policyValidation,
                     automationTrace,
                     preWriteBootstrapTrace,
                     nextAction
                   )
-                  : result,
+                  : {
+                    ...result,
+                    policy_validation: policyValidation,
+                  },
                 null,
                 2
               )
@@ -1739,6 +1761,11 @@ export const runLifecycleCli = async (
           } else {
             writeInfo(
               `[pumuki][sdd] stage=${result.stage} allowed=${result.decision.allowed ? 'yes' : 'no'} code=${result.decision.code}`
+            );
+            writeInfo(
+              `[pumuki][sdd] policy-as-code: PRE_COMMIT=${policyValidation.stages.PRE_COMMIT.validationCode ?? 'n/a'} strict=${policyValidation.stages.PRE_COMMIT.strict ? 'yes' : 'no'} ` +
+              `PRE_PUSH=${policyValidation.stages.PRE_PUSH.validationCode ?? 'n/a'} strict=${policyValidation.stages.PRE_PUSH.strict ? 'yes' : 'no'} ` +
+              `CI=${policyValidation.stages.CI.validationCode ?? 'n/a'} strict=${policyValidation.stages.CI.strict ? 'yes' : 'no'}`
             );
             writeInfo(
               withOptionalLocation(

--- a/integrations/lifecycle/doctor.ts
+++ b/integrations/lifecycle/doctor.ts
@@ -5,6 +5,10 @@ import { resolvePolicyForStage } from '../gate/stagePolicies';
 import { getPumukiHooksStatus } from './hookManager';
 import { LifecycleGitService, type ILifecycleGitService } from './gitService';
 import { getCurrentPumukiVersion } from './packageInfo';
+import {
+  readLifecyclePolicyValidationSnapshot,
+  type LifecyclePolicyValidationSnapshot,
+} from './policyValidationSnapshot';
 import { readLifecycleState, type LifecycleState } from './state';
 import {
   detectOpenSpecInstallation,
@@ -71,6 +75,7 @@ export type LifecycleDoctorReport = {
   lifecycleState: LifecycleState;
   trackedNodeModulesPaths: ReadonlyArray<string>;
   hookStatus: ReturnType<typeof getPumukiHooksStatus>;
+  policyValidation: LifecyclePolicyValidationSnapshot;
   issues: ReadonlyArray<DoctorIssue>;
   deep?: DoctorDeepReport;
 };
@@ -653,6 +658,7 @@ export const runLifecycleDoctor = (params?: {
     lifecycleState,
     trackedNodeModulesPaths,
     hookStatus,
+    policyValidation: readLifecyclePolicyValidationSnapshot(repoRoot),
     issues,
     deep,
   };

--- a/integrations/lifecycle/policyValidationSnapshot.ts
+++ b/integrations/lifecycle/policyValidationSnapshot.ts
@@ -1,0 +1,51 @@
+import type { SkillsStage } from '../config/skillsLock';
+import {
+  resolvePolicyForStage,
+  type ResolvedStagePolicy,
+} from '../gate/stagePolicies';
+
+export type LifecyclePolicyValidationStageSnapshot = {
+  source: ResolvedStagePolicy['trace']['source'];
+  bundle: string;
+  hash: string;
+  version: string | null;
+  signature: string | null;
+  policySource: string | null;
+  validationStatus: NonNullable<ResolvedStagePolicy['trace']['validation']>['status'] | null;
+  validationCode: NonNullable<ResolvedStagePolicy['trace']['validation']>['code'] | null;
+  strict: boolean;
+};
+
+export type LifecyclePolicyValidationSnapshot = {
+  stages: Record<SkillsStage, LifecyclePolicyValidationStageSnapshot>;
+};
+
+const POLICY_STAGES: ReadonlyArray<SkillsStage> = ['PRE_COMMIT', 'PRE_PUSH', 'CI'];
+
+const toStageSnapshot = (
+  resolved: ResolvedStagePolicy
+): LifecyclePolicyValidationStageSnapshot => {
+  return {
+    source: resolved.trace.source,
+    bundle: resolved.trace.bundle,
+    hash: resolved.trace.hash,
+    version: resolved.trace.version ?? null,
+    signature: resolved.trace.signature ?? null,
+    policySource: resolved.trace.policySource ?? null,
+    validationStatus: resolved.trace.validation?.status ?? null,
+    validationCode: resolved.trace.validation?.code ?? null,
+    strict: resolved.trace.validation?.strict ?? false,
+  };
+};
+
+export const readLifecyclePolicyValidationSnapshot = (
+  repoRoot: string
+): LifecyclePolicyValidationSnapshot => {
+  const resolvedByStage = Object.fromEntries(
+    POLICY_STAGES.map((stage) => [stage, toStageSnapshot(resolvePolicyForStage(stage, repoRoot))])
+  ) as Record<SkillsStage, LifecyclePolicyValidationStageSnapshot>;
+
+  return {
+    stages: resolvedByStage,
+  };
+};

--- a/integrations/lifecycle/status.ts
+++ b/integrations/lifecycle/status.ts
@@ -1,6 +1,10 @@
 import { getPumukiHooksStatus } from './hookManager';
 import { LifecycleGitService, type ILifecycleGitService } from './gitService';
 import { getCurrentPumukiVersion } from './packageInfo';
+import {
+  readLifecyclePolicyValidationSnapshot,
+  type LifecyclePolicyValidationSnapshot,
+} from './policyValidationSnapshot';
 import { readLifecycleState, type LifecycleState } from './state';
 
 export type LifecycleStatus = {
@@ -9,6 +13,7 @@ export type LifecycleStatus = {
   lifecycleState: LifecycleState;
   hookStatus: ReturnType<typeof getPumukiHooksStatus>;
   trackedNodeModulesCount: number;
+  policyValidation: LifecyclePolicyValidationSnapshot;
 };
 
 export const readLifecycleStatus = (params?: {
@@ -26,5 +31,6 @@ export const readLifecycleStatus = (params?: {
     lifecycleState: readLifecycleState(git, repoRoot),
     hookStatus: getPumukiHooksStatus(repoRoot),
     trackedNodeModulesCount,
+    policyValidation: readLifecyclePolicyValidationSnapshot(repoRoot),
   };
 };

--- a/integrations/telemetry/gateTelemetry.ts
+++ b/integrations/telemetry/gateTelemetry.ts
@@ -25,7 +25,7 @@ type PolicyTrace = ResolvedStagePolicy['trace'] & {
   signature?: string;
   policySource?: string;
   validation?: {
-    status: 'valid' | 'invalid' | 'expired' | 'unknown-source';
+    status: 'valid' | 'invalid' | 'expired' | 'unknown-source' | 'unsigned';
     code: string;
   };
   degraded?: {
@@ -189,7 +189,7 @@ export type GateTelemetryEventV1 = {
     version?: string;
     signature?: string;
     policy_source?: string;
-    validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source';
+    validation_status?: 'valid' | 'invalid' | 'expired' | 'unknown-source' | 'unsigned';
     validation_code?: string;
     degraded_mode_enabled?: boolean;
     degraded_mode_action?: 'allow' | 'block';


### PR DESCRIPTION
## Summary
- enforce deterministic `unsigned` policy-as-code validation when contract file is missing in strict mode
- expose policy validation metadata in lifecycle JSON/status/doctor/sdd validate surfaces
- keep telemetry/evidence schema aligned with new `unsigned` validation status
- add regression coverage for strict unsigned blocking and lifecycle JSON metadata

## Linked Issue
- Closes #606

## Evidence
- `npx --yes tsx@4.21.0 --test integrations/gate/__tests__/stagePolicies.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/lifecycle/__tests__/status.test.ts integrations/lifecycle/__tests__/doctor.test.ts integrations/lifecycle/__tests__/cli.test.ts`
- `npm run -s typecheck`
