### PR TITLE
docs: make tracking task names human-readable

### DIFF
--- a/docs/registro-maestro-de-seguimiento.md
+++ b/docs/registro-maestro-de-seguimiento.md
@@ -7,8 +7,8 @@
 ## Estado actual
 - Plan activo: `docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md`
 - Estado del plan: BLOQUE CERRADO (standby operativo)
-- Última task cerrada (`✅`): `P12.F2.T74` (cierre consolidado del bloque y backlog siguiente preparado).
-- Task activa (`🚧`): `P12.F2.T75` (cursor kanban de continuidad; esperando nueva orden, sin deuda técnica abierta de este bloque).
+- Última task cerrada (`✅`): **Cierre consolidado del bloque P12.F2** (ID interno: `P12.F2.T74`).
+- Task activa (`🚧`): **En espera de nueva orden** (ID interno: `P12.F2.T75`; sin deuda técnica abierta del bloque actual).
 
 ## Historial resumido
 - No se mantienen MDs históricos de seguimiento en este repositorio.

--- a/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
+++ b/docs/seguimiento-completo-validacion-ruralgo-03-03-2026.md
@@ -2007,7 +2007,7 @@ Criterio de salida F5:
     - `npm view pumuki dist-tags --json` => `"latest": "6.3.37"`.
     - `npm view pumuki@6.3.37 version` => `6.3.37`.
 
-- ✅ `P12.F2.T74` Consolidar cierre del bloque P12.F2 y preparar siguiente backlog enterprise.
+- ✅ **Cierre consolidado del bloque P12.F2** (ID interno: `P12.F2.T74`).
   - cierre ejecutado:
     - bloque `P12.F2` consolidado con trazabilidad completa (issues/PRs/releases y evidencias de validación).
     - backlog siguiente preparado en modo standby, sin deuda técnica abierta obligatoria del bloque actual.
@@ -2018,7 +2018,7 @@ Criterio de salida F5:
     - `gh pr view 610 --json state,mergedAt` => `MERGED`.
     - `npm view pumuki dist-tags --json` => `"latest": "6.3.37"`.
 
-- 🚧 `P12.F2.T75` Cursor kanban de continuidad (esperando nueva orden de producto; sin deuda técnica pendiente de este bloque).
+- 🚧 **En espera de nueva orden** (ID interno: `P12.F2.T75`; sin deuda técnica pendiente de este bloque).
   - salida esperada:
     - mantener una sola `🚧` activa por política del tablero.
     - no ejecutar trabajo técnico nuevo hasta instrucción explícita del usuario.


### PR DESCRIPTION
## Summary
- replace cryptic task-first labels with human-first names
- keep internal ids as secondary references only
- no behavior changes, only readability/tracking UX
