### PR TITLE
docs(tracking): release/6.3.64 + estado repin consumidores

### DIFF
--- a/docs/tracking/plan-activo-de-trabajo.md
+++ b/docs/tracking/plan-activo-de-trabajo.md
@@ -19,7 +19,7 @@
 - Frente activo: `post-release-6.3.64-consumer-autowire`
 - Origen: `ast-intelligence-hooks`
 - Contexto: **6.3.64** publicada en npm; `postinstall` cablea `pumuki install` en consumidores Git; notificaciones con fallback stderr fuera de macOS; MCP IDE sigue explícito.
-- Estado global: **sin tareas PUMUKI-2xx abiertas en este espejo**; pendiente repin/validación en RuralGO y demás consumidores.
+- Estado global: **sin tareas PUMUKI-2xx abiertas en este espejo**; repin local aplicado en `R_GO`, `SAAS:APP_SUPERMERCADOS`, `Flux_training` (pendiente commit/push en cada repo consumidor).
 
 ## Cola externa real
 
@@ -33,9 +33,10 @@
 - ✅ Notificaciones macOS: dialog modal de anti-spam **desactivado por defecto**; activar con `PUMUKI_MACOS_BLOCKED_DIALOG=1` o `"blockedDialogEnabled": true` en `.pumuki/system-notifications.json`.
 - ✅ Notificaciones fuera de macOS: fallback a **stderr** por defecto (`PUMUKI_DISABLE_STDERR_NOTIFICATIONS=1` para silenciar); en macOS `PUMUKI_NOTIFICATION_STDERR_MIRROR=1` duplica el texto en terminal.
 - ✅ Merge a `develop`: PR https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/732 (`merge` 2026-04-05, commit `413d5308db54dcdd483a5d4a5a5342cc32b51969`). Checks GitHub en rojo por cuota/entorno; merge ejecutado con evidencia local previa (`npm test` / typecheck en rama de release).
-- ✅ Publicación **6.3.64** en npm; tag `v6.3.64` en origin. ⏳ Opcional: rama `release/6.3.64` apuntando a `develop` tras pull si el flujo del repo la exige (`git push origin origin/develop:release/6.3.64` cuando haya red).
+- ✅ Publicación **6.3.64** en npm; tag `v6.3.64` en origin.
+- ✅ Rama remota **`release/6.3.64`** creada en `origin` (apunta al `develop` actual post-merge).
 
 ## Siguiente frente sugerido
 
-- ⏳ Repin consumidores a `6.3.64`; validar `npm install` → hooks; `pumuki status` / `doctor` / commit de prueba.
+- ⏳ **Commit + push** del repin en cada consumidor (`R_GO`, `SAAS`, `Flux_training`); validar `pumuki status` / `doctor` / hook de prueba.
 - ⏳ macOS (repo real): panel Swift con foco y botones persistiendo `muteUntil` / `enabled:false` en `.pumuki/system-notifications.json` del repo correcto.


### PR DESCRIPTION
Actualiza plan activo: rama `release/6.3.64` en origin; repin aplicado localmente en R_GO / SAAS / Flux (commit en cada repo aparte).