### PR TITLE
release: pumuki 6.3.65 (fix pre-commit.com exec + metadata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - No user-facing changes yet.
 
+## [6.3.65] - 2026-04-06
+
+### Fixed
+
+- **Integración con pre-commit.com**: si el hook `pre-commit` termina en `exec … pre_commit`, el bloque gestionado por Pumuki se insertaba **después** y nunca se ejecutaba. Ahora se detecta esa plantilla y el bloque Pumuki se coloca **justo después del shebang**, antes del `exec`. Tras actualizar, ejecutar `pumuki install` en el consumer para reescribir `.git/hooks/pre-commit`.
+
 ## [6.3.64] - 2026-04-05
 
 ### Fixed

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ This file keeps only the operational highlights and rollout notes that matter wh
 
 ## 2026-04 (CLI stability and macOS notifications)
 
+### 2026-04-06 (v6.3.65)
+
+- **pre-commit.com + `exec`**: Pumuki ya no inserta su bloque gestionado *después* del `exec` del hook generado por pre-commit (código inalcanzable). Tras actualizar a **6.3.65**, ejecutar `pumuki install` en el consumer para reordenar `.git/hooks/pre-commit`.
+- Rollout: repin a `pumuki@6.3.65`; validar que un `git commit` dispara el gate (salida `[pumuki]` / policy) antes de que corra pre-commit.
+
 ### 2026-04-05 (v6.3.64)
 
 - **Notificaciones multiplataforma**: fuera de macOS, avisos críticos van a **stderr** por defecto (terminal visible). `PUMUKI_DISABLE_STDERR_NOTIFICATIONS=1` lo silencia para CI/scripts. En macOS, `PUMUKI_NOTIFICATION_STDERR_MIRROR=1` añade copia en terminal; si `osascript`/banner falla, stderr actúa como respaldo.

--- a/docs/tracking/plan-activo-de-trabajo.md
+++ b/docs/tracking/plan-activo-de-trabajo.md
@@ -16,10 +16,11 @@
 
 ## Estado actual
 
-- Frente activo: ver **Prioridad ordenada** (abajo); una sola fila `🚧`.
+- Frente activo: `release-6.3.65-pre-commit-exec-fix`
+- Detalle operativo: ver **Prioridad ordenada** (abajo); una sola fila `🚧`.
 - Origen: `ast-intelligence-hooks`
 - Contexto: este archivo vive en el repo **Pumuki** pero el orden incluye **impacto en consumidores** (RuralGO, SAAS, Flux) cuando el ciclo de release lo exige; no es “solo un repo”, es el **espejo operativo** acordado en `AGENTS.md`.
-- Línea **6.3.64** en npm y repin aplicado en ramas acordadas; ciclo publicación+repin **cerrado** (`npm view pumuki version` → **6.3.64** @latest).
+- Línea **6.3.65** en preparación (fix hook `pre-commit` + pre-commit.com); tras `npm publish`, repin consumidores y `pumuki install`. Hasta entonces @latest npm sigue en **6.3.64**.
 - Estado global: **sin tareas PUMUKI-2xx abiertas en este espejo**; repin **6.3.64** en **SAAS** `main`, **Flux_training** `main`, **R_GO** `develop` (PR https://github.com/SwiftEnProfundidad/R_GO/pull/1514 → `b899ee6a1`). **R_GO `main`** sigue muy por detrás de `develop` (orden ~10³ commits); no es un fast-forward de producto: la promoción a `main` es release aparte.
 
 ## Cola externa real

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.64",
+  "version": "6.3.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.64",
+      "version": "6.3.65",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.64",
+  "version": "6.3.65",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/__tests__/package-install-smoke-consumer-npm-lib.test.ts
+++ b/scripts/__tests__/package-install-smoke-consumer-npm-lib.test.ts
@@ -41,7 +41,7 @@ test('verifyInstalledPumukiBinaryVersion valida npx --no-install pumuki status -
   const workspace = createWorkspace();
   try {
     await withFakeNpx(
-      '#!/usr/bin/env sh\nprintf \'{"packageVersion":"6.3.64","version":{"effective":"6.3.64"}}\\n\'\nexit 0\n',
+      '#!/usr/bin/env sh\nprintf \'{"packageVersion":"6.3.65","version":{"effective":"6.3.65"}}\\n\'\nexit 0\n',
       () => {
         verifyInstalledPumukiBinaryVersion(workspace);
       }
@@ -82,7 +82,7 @@ test('verifyInstalledPumukiBinaryVersion usa fallback local cuando npx --no-inst
     const localPumukiBin = join(localBinDir, 'pumuki');
     writeFileSync(
       localPumukiBin,
-      '#!/usr/bin/env sh\nprintf \'{"packageVersion":"6.3.64","version":{"effective":"6.3.64"}}\\n\'\nexit 0\n',
+      '#!/usr/bin/env sh\nprintf \'{"packageVersion":"6.3.65","version":{"effective":"6.3.65"}}\\n\'\nexit 0\n',
       'utf8'
     );
     chmodSync(localPumukiBin, 0o755);


### PR DESCRIPTION
## Incluye
- Fix ya mergeado: hook `pre-commit` con `exec` de pre-commit.com (PR #741).
- Bump **6.3.65**: `package.json`, `package-lock.json`, `CHANGELOG.md`, `RELEASE_NOTES.md`, tracking, smoke tests version string.

## Post-merge
- Tag `v6.3.65` y `npm publish`.
- Consumidores: repin + `pumuki install`.