### PR TITLE
test: tracking parser accepts bold around Frente activo

### DIFF
--- a/scripts/__tests__/release-metadata-alignment.test.ts
+++ b/scripts/__tests__/release-metadata-alignment.test.ts
@@ -33,7 +33,7 @@ const extractReleaseNotesVersion = (source: string): string | undefined => {
 };
 
 const extractTrackingFront = (source: string): string | undefined => {
-  const match = source.match(/^- Frente activo: `([^`]+)`/m);
+  const match = source.match(/^- Frente activo:\s*(?:\*\*)?`([^`]+)`(?:\*\*)?/m);
   return match?.[1];
 };
 


### PR DESCRIPTION
## Cambio
- Ajusta `extractTrackingFront` en `release-metadata-alignment.test.ts` para aceptar markdown `**`slug`**` en `plan-activo-de-trabajo.md`.

## Motivo
CI / `npm test` fallaba cuando la línea `Frente activo` usaba negritas alrededor del código.

## Consumidores
Sin impacto en runtime npm; no requiere nueva versión publicada ni repin en RuralGO solo por este commit.