### PR TITLE
test(mcp): align v2.1 evidence fixtures with validateEvidenceChain (develop)

### DIFF
--- a/docs/tracking/plan-activo-de-trabajo.md
+++ b/docs/tracking/plan-activo-de-trabajo.md
@@ -31,6 +31,7 @@
 
 ## Donde estamos (operativo)
 
+- ✅ **Tests MCP v2.1** en `release/6.3.65` (commit `34b98b8`); propagación a **`develop`**: PR https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/748 (`chore/mcp-tests-v21-seal`, cherry-pick del mismo cambio).
 - ✅ Ajustes de tests (PRE_WRITE en `skills.policy`, doctor/cli JSON, Jest `evaluateRules`) y `npm test` verde en rama `refactor/cli-complexity-reduction-phase4-rebase2`.
 - ✅ Notificaciones macOS: modal de bloqueo **activo por defecto** si las notificaciones están habilitadas; desactivar modal con `"blockedDialogEnabled": false` o `PUMUKI_MACOS_BLOCKED_DIALOG=0`. Botones Desactivar / Silenciar 30 min / Mantener activas normalizados + parseo `osascript` más robusto.
 - ✅ **Bug consumidor (RuralGO / pre-commit en pre-push)** — publicado en **6.3.70** (npm): con `.ai_evidence.json` **trackeado**, `PRE_PUSH` en **ALLOW/WARN** ya **no reescribe** el fichero (evita “files were modified by this hook”). Opt-in legado: `PUMUKI_PRE_PUSH_ALWAYS_WRITE_TRACKED_EVIDENCE=1`. En `gate.blocked` con modal activo se omite el banner `osascript` duplicado; panel Swift `KeyableFloatingPanel` + `becomesKeyOnlyIfNeeded=false` para aceptar clics.

--- a/integrations/mcp/__tests__/enterpriseStdioServer.cli.test.ts
+++ b/integrations/mcp/__tests__/enterpriseStdioServer.cli.test.ts
@@ -59,6 +59,7 @@ test('pumuki enterprise stdio bridge responde initialize y tools/list', async ()
       ...process.env,
       PUMUKI_ENTERPRISE_MCP_PORT: '0',
       PUMUKI_ENTERPRISE_MCP_HOST: '127.0.0.1',
+      PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE: 'advisory',
     },
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/integrations/mcp/__tests__/evidenceContextServer-collections.test.ts
+++ b/integrations/mcp/__tests__/evidenceContextServer-collections.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import {
   createEvidencePayload,
   safeFetchRequest,
+  sealEvidenceV21ForTests,
   test,
   withEvidenceServer,
   withTempDir,
@@ -17,6 +18,7 @@ test('returns rulesets endpoint sorted deterministically', async () => {
       { platform: 'backend', bundle: 'backend', hash: 'bbb' },
       { platform: 'ios', bundle: 'ios', hash: 'aaa' },
     ];
+    sealEvidenceV21ForTests(payload);
     writeFileSync(join(repoRoot, '.ai_evidence.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
     await withEvidenceServer(repoRoot, async (baseUrl) => {
@@ -125,6 +127,7 @@ test('returns platforms endpoint with detectedOnly toggle', async () => {
       backend: { detected: true, confidence: 'HIGH' },
       ios: { detected: true, confidence: 'MEDIUM' },
     };
+    sealEvidenceV21ForTests(payload);
     writeFileSync(join(repoRoot, '.ai_evidence.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
     await withEvidenceServer(repoRoot, async (baseUrl) => {
@@ -260,6 +263,7 @@ test('returns ledger endpoint sorted deterministically', async () => {
         lastSeen: '2026-02-01T10:00:00.000Z',
       },
     ];
+    sealEvidenceV21ForTests(payload);
     writeFileSync(join(repoRoot, '.ai_evidence.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
     await withEvidenceServer(repoRoot, async (baseUrl) => {
@@ -405,6 +409,7 @@ test('returns snapshot endpoint with deterministic findings ordering', async () 
         lines: [10],
       },
     ];
+    sealEvidenceV21ForTests(payload);
     writeFileSync(join(repoRoot, '.ai_evidence.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
     await withEvidenceServer(repoRoot, async (baseUrl) => {

--- a/integrations/mcp/__tests__/evidenceContextServer-findings.test.ts
+++ b/integrations/mcp/__tests__/evidenceContextServer-findings.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import {
   createEvidencePayload,
   safeFetchRequest,
+  sealEvidenceV21ForTests,
   test,
   withEvidenceServer,
   withTempDir,
@@ -36,6 +37,7 @@ test('returns findings endpoint with deterministic ordering and filters', async 
         lines: [10],
       },
     ];
+    sealEvidenceV21ForTests(payload);
     writeFileSync(join(repoRoot, '.ai_evidence.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
     await withEvidenceServer(repoRoot, async (baseUrl) => {

--- a/integrations/mcp/__tests__/evidenceContextServer-payload.test.ts
+++ b/integrations/mcp/__tests__/evidenceContextServer-payload.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import {
   createEvidencePayload,
   safeFetchRequest,
+  sealEvidenceV21ForTests,
   test,
   withEvidenceServer,
   withTempDir,
@@ -64,6 +65,7 @@ test('returns summary payload from dedicated summary endpoint', async () => {
         lastSeen: '2026-02-01T10:00:00.000Z',
       },
     ];
+    sealEvidenceV21ForTests(payload);
     writeFileSync(join(repoRoot, '.ai_evidence.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
     await withEvidenceServer(repoRoot, async (baseUrl) => {

--- a/integrations/mcp/__tests__/evidenceContextServerFixtures.ts
+++ b/integrations/mcp/__tests__/evidenceContextServerFixtures.ts
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import test from 'node:test';
-import { startEvidenceContextServer } from '../evidenceContextServer';
+import type { AiEvidenceV2_1 } from '../../evidence/schema';
 import { withTempDir } from '../../__tests__/helpers/tempDir';
+import { startEvidenceContextServer } from '../evidenceContextServer';
+import { sealEvidenceV21ForTests } from './sealEvidenceV21ForTests';
 
-const createEvidencePayload = () => {
-  return {
+const createEvidencePayload = (): AiEvidenceV2_1 => {
+  const evidence: AiEvidenceV2_1 = {
     version: '2.1',
     timestamp: '2026-02-01T10:00:00.000Z',
     snapshot: {
@@ -43,6 +45,7 @@ const createEvidencePayload = () => {
       ],
     },
   };
+  return sealEvidenceV21ForTests(evidence);
 };
 
 const withEvidenceServer = async (
@@ -77,4 +80,11 @@ const safeFetchRequest = async (url: string, init?: RequestInit): Promise<Respon
   }
 };
 
-export { createEvidencePayload, safeFetchRequest, withEvidenceServer, test, withTempDir };
+export {
+  createEvidencePayload,
+  safeFetchRequest,
+  sealEvidenceV21ForTests,
+  withEvidenceServer,
+  test,
+  withTempDir,
+};

--- a/integrations/mcp/__tests__/evidencePayloadStatus.test.ts
+++ b/integrations/mcp/__tests__/evidencePayloadStatus.test.ts
@@ -6,8 +6,10 @@ import { withTempDir } from '../../__tests__/helpers/tempDir';
 import type { AiEvidenceV2_1 } from '../../evidence/schema';
 import { CONTEXT_API_CAPABILITIES } from '../evidencePayloadConfig';
 import { toStatusPayload } from '../evidencePayloadStatus';
+import { sealEvidenceV21ForTests } from './sealEvidenceV21ForTests';
 
-const createEvidence = (): AiEvidenceV2_1 => ({
+const createEvidence = (): AiEvidenceV2_1 => {
+  const evidence: AiEvidenceV2_1 = {
   version: '2.1',
   timestamp: '2026-02-19T09:00:00.000Z',
   snapshot: {
@@ -76,7 +78,9 @@ const createEvidence = (): AiEvidenceV2_1 => ({
       },
     ],
   },
-});
+};
+  return sealEvidenceV21ForTests(evidence);
+};
 
 test('toStatusPayload devuelve degraded cuando falta .ai_evidence.json', async () => {
   await withTempDir('pumuki-status-payload-missing-', async (repoRoot) => {

--- a/integrations/mcp/__tests__/evidencePayloads.test.ts
+++ b/integrations/mcp/__tests__/evidencePayloads.test.ts
@@ -14,9 +14,10 @@ import {
   toStatusPayload,
   toSummaryPayload,
 } from '../evidencePayloads';
+import { sealEvidenceV21ForTests } from './sealEvidenceV21ForTests';
 
 const createEvidence = (): AiEvidenceV2_1 => {
-  return {
+  const evidence: AiEvidenceV2_1 = {
     version: '2.1',
     timestamp: '2026-02-01T10:00:00.000Z',
     snapshot: {
@@ -90,6 +91,7 @@ const createEvidence = (): AiEvidenceV2_1 => {
       ],
     },
   };
+  return sealEvidenceV21ForTests(evidence);
 };
 
 test('parseBooleanQuery normaliza valores truthy/falsy', () => {

--- a/integrations/mcp/__tests__/sealEvidenceV21ForTests.ts
+++ b/integrations/mcp/__tests__/sealEvidenceV21ForTests.ts
@@ -1,0 +1,7 @@
+import type { AiEvidenceV2_1 } from '../../evidence/schema';
+import { buildEvidenceChain } from '../../evidence/evidenceChain';
+
+export const sealEvidenceV21ForTests = (evidence: AiEvidenceV2_1): AiEvidenceV2_1 => {
+  evidence.evidence_chain = buildEvidenceChain({ evidence });
+  return evidence;
+};


### PR DESCRIPTION
Cherry-pick desde `release/6.3.65` (commit equivalente al `34b98b8` allí).

- Sellado `evidence_chain` en fixtures MCP para que `readEvidence` pase validación v2.1.
- `PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE=advisory` en el test del stdio enterprise para incluir `ai_gate_check` en `tools/list`.

Evidencia local: `npm run test:mcp` (159/159).