### PR TITLE
fix: translate evidence gate blocked notification cause

### DIFF
--- a/scripts/__tests__/framework-menu-system-notifications-cause.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-cause.test.ts
@@ -17,6 +17,21 @@ test('resolveBlockedCauseSummary usa mapping conocido por causeCode', () => {
   assert.match(result, /desactualizada/i);
 });
 
+test('resolveBlockedCauseSummary traduce EVIDENCE_GATE_BLOCKED al español', () => {
+  const result = resolveBlockedCauseSummary(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_WRITE',
+      totalViolations: 1,
+      causeMessage: 'Evidence AI gate status is BLOCKED.',
+    },
+    'EVIDENCE_GATE_BLOCKED'
+  );
+
+  assert.match(result, /gate de evidencia/i);
+  assert.doesNotMatch(result, /evidence ai gate status is blocked/i);
+});
+
 test('resolveBlockedCauseSummary traduce mensajes legacy conocidos', () => {
   const result = resolveBlockedCauseSummary(
     {

--- a/scripts/__tests__/framework-menu-system-notifications-remediation.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-remediation.test.ts
@@ -33,6 +33,22 @@ test('resolveBlockedRemediation usa fallback conocido por causeCode', () => {
   assert.match(result, /evidencia/i);
 });
 
+test('resolveBlockedRemediation traduce EVIDENCE_GATE_BLOCKED a una solución válida en español', () => {
+  const result = resolveBlockedRemediation(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_WRITE',
+      totalViolations: 1,
+      remediation: 'Evidence AI gate status is BLOCKED.',
+    },
+    'EVIDENCE_GATE_BLOCKED'
+  );
+
+  assert.match(result, /violaciones bloqueantes/i);
+  assert.match(result, /vuelve a ejecutar el gate/i);
+  assert.doesNotMatch(result, /evidence ai gate status is blocked/i);
+});
+
 test('resolveBlockedRemediation traduce remediaciones legacy en inglés a una salida accionable en español', () => {
   const result = resolveBlockedRemediation(
     {

--- a/scripts/framework-menu-system-notifications-cause.ts
+++ b/scripts/framework-menu-system-notifications-cause.ts
@@ -5,6 +5,7 @@ import {
 } from './framework-menu-system-notifications-text';
 
 const BLOCKED_CAUSE_SUMMARY_BY_CODE: Readonly<Record<string, string>> = {
+  EVIDENCE_GATE_BLOCKED: 'El gate de evidencia de IA está bloqueado.',
   EVIDENCE_MISSING: 'Falta evidencia para validar este paso.',
   EVIDENCE_INVALID: 'La evidencia actual es inválida.',
   EVIDENCE_CHAIN_INVALID: 'La cadena de evidencia no es válida.',
@@ -29,6 +30,9 @@ const toKnownSpanishCauseFromMessage = (message: string): string | null => {
   }
   if (normalized.includes('evidence is stale')) {
     return BLOCKED_CAUSE_SUMMARY_BY_CODE.EVIDENCE_STALE;
+  }
+  if (normalized.includes('evidence ai gate status is blocked')) {
+    return BLOCKED_CAUSE_SUMMARY_BY_CODE.EVIDENCE_GATE_BLOCKED;
   }
   if (normalized.includes('no upstream tracking reference')) {
     return BLOCKED_CAUSE_SUMMARY_BY_CODE.PRE_PUSH_UPSTREAM_MISSING;

--- a/scripts/framework-menu-system-notifications-remediation.ts
+++ b/scripts/framework-menu-system-notifications-remediation.ts
@@ -7,6 +7,7 @@ import {
 type BlockedRemediationVariant = 'banner' | 'dialog';
 
 const BLOCKED_REMEDIATION_BY_CODE: Readonly<Record<string, string>> = {
+  EVIDENCE_GATE_BLOCKED: 'Corrige las violaciones bloqueantes detectadas en la evidencia y vuelve a ejecutar el gate.',
   EVIDENCE_MISSING: 'Genera la evidencia del slice actual y vuelve a validar esta fase.',
   EVIDENCE_INVALID: 'Regenera la evidencia de esta iteración y repite la validación.',
   EVIDENCE_CHAIN_INVALID: 'Regenera la evidencia para restaurar la cadena de integridad y vuelve a validar.',
@@ -68,6 +69,9 @@ const toKnownSpanishRemediationFromMessage = (message: string, causeCode: string
   }
   if (normalized.includes('refresh evidence') || normalized.includes('evidence is stale')) {
     return BLOCKED_REMEDIATION_BY_CODE.EVIDENCE_STALE;
+  }
+  if (normalized.includes('evidence ai gate status is blocked')) {
+    return BLOCKED_REMEDIATION_BY_CODE.EVIDENCE_GATE_BLOCKED;
   }
   if (normalized.includes('split the change')) {
     return BLOCKED_REMEDIATION_BY_CODE.GIT_ATOMICITY_TOO_MANY_SCOPES;


### PR DESCRIPTION
## Summary\n- translate EVIDENCE_GATE_BLOCKED cause summaries to Spanish\n- translate legacy English evidence gate messages in blocked notifications\n- add regression coverage for cause/remediation resolution\n\n## Validation\n- npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-system-notifications-cause.test.ts scripts/__tests__/framework-menu-system-notifications-remediation.test.ts scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts\n- npm run -s typecheck