### PR TITLE
feat(backend-guidelines): map silent catch foundation

### DIFF
--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -22,6 +22,22 @@ test('normaliza reglas backend de SOLID/Clean Architecture/God Class a ids canon
   assert.equal(rules.every((rule) => rule.evaluationMode === 'AUTO'), true);
 });
 
+test('normaliza try-catch silenciosos backend al guideline foundation canonico', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'backend-guidelines',
+    sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+    sourceContent: '❌ Try-catch silenciosos - Siempre loggear o propagar',
+  });
+
+  assert.equal(rules.length, 1);
+  assert.equal(
+    rules[0]?.id,
+    'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar'
+  );
+  assert.equal(rules[0]?.evaluationMode, 'AUTO');
+  assert.equal(rules[0]?.platform, 'backend');
+});
+
 test('normaliza regla frontend SOLID a id canonico', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'frontend-guidelines',

--- a/integrations/config/__tests__/skillsRuleSet.test.ts
+++ b/integrations/config/__tests__/skillsRuleSet.test.ts
@@ -533,6 +533,65 @@ test('mapea el primer backend guideline foundation a heuristic AST reusable', as
   );
 });
 
+test('mapea try-catch silenciosos al heuristic AST reusable de empty catch', async () => {
+  await withCoreSkillsDisabled(async () =>
+    withTempDir('pumuki-skills-ruleset-backend-guideline-empty-catch-', async (tempRoot) => {
+      mkdirSync(join(tempRoot, 'apps/backend'), { recursive: true });
+
+      const lock = {
+        version: '1.0',
+        compilerVersion: '1.0.0',
+        generatedAt: '2026-02-07T23:15:00.000Z',
+        bundles: [
+          {
+            name: 'backend-guidelines',
+            version: '1.0.0',
+            source: 'file:docs/codex-skills/backend-enterprise-rules.md',
+            hash: 'b'.repeat(64),
+            rules: [
+              {
+                id: 'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar',
+                description: 'Avoid silent catch blocks in backend runtime code.',
+                severity: 'ERROR',
+                platform: 'backend',
+                sourceSkill: 'backend-guidelines',
+                sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+                evaluationMode: 'AUTO',
+                locked: true,
+                confidence: 'HIGH',
+              },
+            ],
+          },
+        ],
+      } as const;
+
+      writeFileSync(join(tempRoot, 'skills.lock.json'), JSON.stringify(lock, null, 2));
+
+      const result = loadSkillsRuleSetForStage('PRE_COMMIT', tempRoot);
+      assert.deepEqual(result.unsupportedAutoRuleIds, []);
+      assert.equal(result.rules.length, 1);
+      assert.equal(result.mappedHeuristicRuleIds.has('heuristics.ts.empty-catch.ast'), true);
+
+      const silentCatchRule = result.rules[0];
+      assert.ok(silentCatchRule);
+      assert.equal(
+        silentCatchRule.id,
+        'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar'
+      );
+      assert.equal(silentCatchRule.when.kind, 'Heuristic');
+      if (silentCatchRule.when.kind !== 'Heuristic') {
+        assert.fail('Expected heuristic condition for backend silent catch guideline.');
+      }
+      assert.equal(silentCatchRule.when.where?.ruleId, 'heuristics.ts.empty-catch.ast');
+      assert.deepEqual(collectHeuristicPrefixes(silentCatchRule.when), ['apps/backend/']);
+      assert.equal(
+        silentCatchRule.then.source?.includes('ast_nodes=[heuristics.ts.empty-catch.ast]'),
+        true
+      );
+    })
+  );
+});
+
 test('enriquce mensaje de no-solid-violations con criterios accionables y métricas observadas', async () => {
   await withCoreSkillsDisabled(async () =>
     withTempDir('pumuki-skills-ruleset-solid-actionable-message-', async (tempRoot) => {

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -178,6 +178,8 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     'typescript.new-promise-async',
     ['heuristics.ts.new-promise-async.ast']
   ),
+  'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar':
+    heuristicDetector('typescript.empty-catch', ['heuristics.ts.empty-catch.ast']),
   'skills.frontend.no-empty-catch': heuristicDetector('typescript.empty-catch', [
     'heuristics.ts.empty-catch.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -440,6 +440,15 @@ const normalizeKnownRuleTarget = (
 
   if (platform === 'backend' || platform === 'frontend') {
     const prefix = platform === 'backend' ? 'skills.backend' : 'skills.frontend';
+    if (
+      platform === 'backend' &&
+      (includes('try-catch silenciosos') ||
+        includes('try catch silenciosos') ||
+        includes('silenciosos siempre loggear o propagar') ||
+        includes('siempre loggear o propagar'))
+    ) {
+      return 'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar';
+    }
     if (includes('solid') || includes('single responsibility') || includes('srp')) {
       return `${prefix}.no-solid-violations`;
     }


### PR DESCRIPTION
Summary
- normalize the backend silent catch guideline to a canonical rule id
- map it to the existing empty catch AST heuristic runtime
- add parser and ruleset regression coverage for the second backend guideline slice

Validation
- ./node_modules/.bin/tsx --test integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsRuleSet.test.ts