### PR TITLE
feat(backend-guidelines): map hardcoded values foundation

### DIFF
--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -38,6 +38,22 @@ test('normaliza try-catch silenciosos backend al guideline foundation canonico',
   assert.equal(rules[0]?.platform, 'backend');
 });
 
+test('normaliza hardcoded values backend al guideline foundation canonico', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'backend-guidelines',
+    sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+    sourceContent: '❌ Hardcoded values - Config en variables de entorno',
+  });
+
+  assert.equal(rules.length, 1);
+  assert.equal(
+    rules[0]?.id,
+    'skills.backend.guideline.backend.hardcoded-values-config-en-variables-de-entorno'
+  );
+  assert.equal(rules[0]?.evaluationMode, 'AUTO');
+  assert.equal(rules[0]?.platform, 'backend');
+});
+
 test('normaliza regla frontend SOLID a id canonico', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'frontend-guidelines',

--- a/integrations/config/__tests__/skillsRuleSet.test.ts
+++ b/integrations/config/__tests__/skillsRuleSet.test.ts
@@ -592,6 +592,73 @@ test('mapea try-catch silenciosos al heuristic AST reusable de empty catch', asy
   );
 });
 
+test('mapea hardcoded values al heuristic AST reusable más cercano', async () => {
+  await withCoreSkillsDisabled(async () =>
+    withTempDir('pumuki-skills-ruleset-backend-guideline-hardcoded-values-', async (tempRoot) => {
+      mkdirSync(join(tempRoot, 'apps/backend'), { recursive: true });
+
+      const lock = {
+        version: '1.0',
+        compilerVersion: '1.0.0',
+        generatedAt: '2026-02-07T23:15:00.000Z',
+        bundles: [
+          {
+            name: 'backend-guidelines',
+            version: '1.0.0',
+            source: 'file:docs/codex-skills/backend-enterprise-rules.md',
+            hash: 'c'.repeat(64),
+            rules: [
+              {
+                id: 'skills.backend.guideline.backend.hardcoded-values-config-en-variables-de-entorno',
+                description: 'Avoid hardcoded backend configuration values.',
+                severity: 'ERROR',
+                platform: 'backend',
+                sourceSkill: 'backend-guidelines',
+                sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+                evaluationMode: 'AUTO',
+                locked: true,
+                confidence: 'MEDIUM',
+              },
+            ],
+          },
+        ],
+      } as const;
+
+      writeFileSync(join(tempRoot, 'skills.lock.json'), JSON.stringify(lock, null, 2));
+
+      const result = loadSkillsRuleSetForStage('PRE_COMMIT', tempRoot);
+      assert.deepEqual(result.unsupportedAutoRuleIds, []);
+      assert.equal(result.rules.length, 1);
+      assert.equal(
+        result.mappedHeuristicRuleIds.has('heuristics.ts.hardcoded-secret-token.ast'),
+        true
+      );
+
+      const hardcodedValuesRule = result.rules[0];
+      assert.ok(hardcodedValuesRule);
+      assert.equal(
+        hardcodedValuesRule.id,
+        'skills.backend.guideline.backend.hardcoded-values-config-en-variables-de-entorno'
+      );
+      assert.equal(hardcodedValuesRule.when.kind, 'Heuristic');
+      if (hardcodedValuesRule.when.kind !== 'Heuristic') {
+        assert.fail('Expected heuristic condition for backend hardcoded values guideline.');
+      }
+      assert.equal(
+        hardcodedValuesRule.when.where?.ruleId,
+        'heuristics.ts.hardcoded-secret-token.ast'
+      );
+      assert.deepEqual(collectHeuristicPrefixes(hardcodedValuesRule.when), ['apps/backend/']);
+      assert.equal(
+        hardcodedValuesRule.then.source?.includes(
+          'ast_nodes=[heuristics.ts.hardcoded-secret-token.ast]'
+        ),
+        true
+      );
+    })
+  );
+});
+
 test('enriquce mensaje de no-solid-violations con criterios accionables y métricas observadas', async () => {
   await withCoreSkillsDisabled(async () =>
     withTempDir('pumuki-skills-ruleset-solid-actionable-message-', async (tempRoot) => {

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -180,6 +180,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
   ),
   'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar':
     heuristicDetector('typescript.empty-catch', ['heuristics.ts.empty-catch.ast']),
+  'skills.backend.guideline.backend.hardcoded-values-config-en-variables-de-entorno':
+    heuristicDetector('typescript.hardcoded-secret-token', [
+      'heuristics.ts.hardcoded-secret-token.ast',
+    ]),
   'skills.frontend.no-empty-catch': heuristicDetector('typescript.empty-catch', [
     'heuristics.ts.empty-catch.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -449,6 +449,14 @@ const normalizeKnownRuleTarget = (
     ) {
       return 'skills.backend.guideline.backend.try-catch-silenciosos-siempre-loggear-o-propagar';
     }
+    if (
+      platform === 'backend' &&
+      (includes('hardcoded values') ||
+        includes('config en variables de entorno') ||
+        includes('hardcoded values - config en variables de entorno'))
+    ) {
+      return 'skills.backend.guideline.backend.hardcoded-values-config-en-variables-de-entorno';
+    }
     if (includes('solid') || includes('single responsibility') || includes('srp')) {
       return `${prefix}.no-solid-violations`;
     }


### PR DESCRIPTION
Summary
- normalize the backend hardcoded values guideline to a canonical rule id
- map it to the closest reusable AST heuristic currently available
- add parser and ruleset regression coverage for the third backend guideline slice

Validation
- ./node_modules/.bin/tsx --test integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsRuleSet.test.ts