### PR TITLE
feat(backend-guidelines): add magic numbers heuristic foundation

### DIFF
--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -172,6 +172,7 @@ test('detects frontend TypeScript heuristic findings in production path', () => 
     'heuristics.ts.jwt-decode-without-verify.ast',
     'heuristics.ts.jwt-sign-no-expiration.ast',
     'heuristics.ts.jwt-verify-ignore-expiration.ast',
+    'heuristics.ts.magic-number.ast',
     'heuristics.ts.new-promise-async.ast',
     'heuristics.ts.process-env-mutation.ast',
     'heuristics.ts.process-exit.ast',
@@ -346,6 +347,7 @@ test('detects backend TypeScript heuristic findings in production path', () => {
     'heuristics.ts.jwt-decode-without-verify.ast',
     'heuristics.ts.jwt-sign-no-expiration.ast',
     'heuristics.ts.jwt-verify-ignore-expiration.ast',
+    'heuristics.ts.magic-number.ast',
     'heuristics.ts.new-promise-async.ast',
     'heuristics.ts.process-env-mutation.ast',
     'heuristics.ts.process-exit.ast',
@@ -1788,7 +1790,33 @@ test('extracts typed heuristic facts with expected metadata', () => {
     },
   });
 
-  assert.equal(extracted.length, 150);
+  assert.equal(extracted.length, 151);
   assert.equal(extracted.every((fact) => fact.kind === 'Heuristic'), true);
   assert.equal(extracted.every((fact) => fact.source === 'heuristics:ast'), true);
+});
+
+test('detects magic number heuristic facts in backend production path', () => {
+  const extracted = extractHeuristicFacts({
+    facts: [
+      fileContentFact(
+        'apps/backend/src/orders/service.ts',
+        [
+          'export const retry = (attempts: number) => {',
+          '  if (attempts > 3) return 3;',
+          '  return notify(3);',
+          '};',
+        ].join('\n')
+      ),
+    ],
+    detectedPlatforms: {
+      backend: { detected: true },
+    },
+  });
+
+  const magicNumberFact = extracted.find(
+    (finding) => finding.ruleId === 'heuristics.ts.magic-number.ast'
+  );
+
+  assert.ok(magicNumberFact);
+  assert.deepEqual(magicNumberFact?.lines, [2, 3]);
 });

--- a/core/facts/detectors/typescript/index.test.ts
+++ b/core/facts/detectors/typescript/index.test.ts
@@ -13,6 +13,7 @@ import {
   findUndefinedInBaseTypeUnionLines,
   findUnknownWithoutGuardLines,
   findUnknownTypeAssertionLines,
+  findMagicNumberLiteralLines,
   hasAsyncPromiseExecutor,
   hasConcreteDependencyInstantiation,
   hasConsoleErrorCall,
@@ -24,6 +25,7 @@ import {
   hasExplicitAnyType,
   hasFrameworkDependencyImport,
   hasFunctionConstructorUsage,
+  hasMagicNumberLiteral,
   hasNetworkCallWithoutErrorHandling,
   hasMixedCommandQueryClass,
   hasMixedCommandQueryInterface,
@@ -882,6 +884,72 @@ test('hasLargeClassDeclaration detecta clases con 300 lineas o mas', () => {
   assert.equal(hasLargeClassDeclaration(oversizedClassAst), true);
   assert.equal(hasLargeClassDeclaration(thresholdClassAst), true);
   assert.equal(hasLargeClassDeclaration(compactClassAst), false);
+});
+
+test('hasMagicNumberLiteral detecta literales numericos repetidos en contexto ejecutable y descarta declarativos', () => {
+  const magicAst = {
+    type: 'Program',
+    body: [
+      {
+        type: 'ExpressionStatement',
+        expression: {
+          type: 'CallExpression',
+          callee: { type: 'Identifier', name: 'retry' },
+          arguments: [{ type: 'NumericLiteral', value: 42, loc: { start: { line: 3 }, end: { line: 3 } } }],
+        },
+      },
+      {
+        type: 'VariableDeclaration',
+        kind: 'const',
+        declarations: [
+          {
+            type: 'VariableDeclarator',
+            id: { type: 'Identifier', name: 'timeoutMs' },
+            init: { type: 'NumericLiteral', value: 42, loc: { start: { line: 5 }, end: { line: 5 } } },
+          },
+        ],
+      },
+      {
+        type: 'ExpressionStatement',
+        expression: {
+          type: 'BinaryExpression',
+          operator: '>',
+          left: { type: 'Identifier', name: 'elapsedMs' },
+          right: { type: 'NumericLiteral', value: 42, loc: { start: { line: 7 }, end: { line: 7 } } },
+        },
+      },
+      {
+        type: 'ReturnStatement',
+        argument: { type: 'NumericLiteral', value: 1, loc: { start: { line: 9 }, end: { line: 9 } } },
+      },
+    ],
+  };
+
+  const ignoredAst = {
+    type: 'Program',
+    body: [
+      {
+        type: 'VariableDeclaration',
+        kind: 'const',
+        declarations: [
+          {
+            type: 'VariableDeclarator',
+            id: { type: 'Identifier', name: 'port' },
+            init: { type: 'NumericLiteral', value: 3000, loc: { start: { line: 2 }, end: { line: 2 } } },
+          },
+        ],
+      },
+      {
+        type: 'ReturnStatement',
+        argument: { type: 'NumericLiteral', value: 1, loc: { start: { line: 4 }, end: { line: 4 } } },
+      },
+    ],
+  };
+
+  assert.equal(hasMagicNumberLiteral(magicAst), true);
+  assert.deepEqual(findMagicNumberLiteralLines(magicAst), [3, 7]);
+  assert.equal(hasMagicNumberLiteral(ignoredAst), false);
+  assert.deepEqual(findMagicNumberLiteralLines(ignoredAst), []);
 });
 
 test('hasRecordStringUnknownType detecta Record<string, unknown>', () => {

--- a/core/facts/detectors/typescript/index.ts
+++ b/core/facts/detectors/typescript/index.ts
@@ -21,6 +21,7 @@ const concreteDependencyNames = new Set<string>([
 ]);
 const GOD_CLASS_MAX_LINES = 300;
 const networkCallCalleePattern = /^(fetch|axios|get|post|put|patch|delete|request)$/i;
+const ignoredMagicNumberValues = new Set<number>([0, 1]);
 type AstNode = Record<string, string | number | boolean | bigint | symbol | null | Date | object>;
 type TypeScriptSemanticNode = {
   kind: 'class' | 'property' | 'call' | 'member';
@@ -1546,6 +1547,16 @@ export const hasAsyncPromiseExecutor = (node: unknown): boolean => {
   });
 };
 
+export const hasMagicNumberLiteral = (node: unknown): boolean => {
+  return [...collectMagicNumberOccurrences(node).values()].some(
+    (occurrence) => occurrence.count >= 2
+  );
+};
+
+export const findMagicNumberLiteralLines = (node: unknown): readonly number[] => {
+  return collectRepeatedMagicNumberLines(node);
+};
+
 export const hasWithStatement = (node: unknown): boolean => {
   return hasNode(node, (value) => value.type === 'WithStatement');
 };
@@ -1757,6 +1768,92 @@ const nodeLineSpan = (node: unknown): number => {
     return 0;
   }
   return Math.max(0, end - start + 1);
+};
+
+type MagicNumberOccurrence = {
+  count: number;
+  lines: number[];
+};
+
+const magicNumberValueFromNode = (node: unknown): number | undefined => {
+  if (!isObject(node) || node.type !== 'NumericLiteral' || typeof node.value !== 'number') {
+    return undefined;
+  }
+  if (!Number.isFinite(node.value) || ignoredMagicNumberValues.has(node.value)) {
+    return undefined;
+  }
+  return node.value;
+};
+
+const isExecutableMagicNumberContext = (
+  value: AstNode,
+  ancestors: ReadonlyArray<AstNode>
+): boolean => {
+  const parent = ancestors[ancestors.length - 1];
+  if (!isObject(parent)) {
+    return false;
+  }
+
+  switch (parent.type) {
+    case 'BinaryExpression':
+      return parent.left === value || parent.right === value;
+    case 'CallExpression':
+    case 'NewExpression':
+      return Array.isArray(parent.arguments) && parent.arguments.includes(value);
+    case 'AssignmentExpression':
+      return parent.right === value;
+    case 'ReturnStatement':
+      return parent.argument === value;
+    case 'SwitchCase':
+      return parent.test === value;
+    default:
+      return false;
+  }
+};
+
+const collectMagicNumberOccurrences = (
+  node: unknown
+): ReadonlyMap<number, MagicNumberOccurrence> => {
+  const occurrences = new Map<number, MagicNumberOccurrence>();
+
+  const walk = (value: unknown, ancestors: ReadonlyArray<AstNode>): void => {
+    if (!isObject(value)) {
+      return;
+    }
+
+    const numericValue = magicNumberValueFromNode(value);
+    if (typeof numericValue === 'number' && isExecutableMagicNumberContext(value, ancestors)) {
+      const current = occurrences.get(numericValue) ?? { count: 0, lines: [] };
+      current.count += 1;
+      const line = toPositiveLine(value);
+      if (typeof line === 'number') {
+        current.lines.push(line);
+      }
+      occurrences.set(numericValue, current);
+    }
+
+    const nextAncestors = [...ancestors, value];
+    for (const child of Object.values(value)) {
+      if (Array.isArray(child)) {
+        for (const entry of child) {
+          walk(entry, nextAncestors);
+        }
+        continue;
+      }
+      walk(child, nextAncestors);
+    }
+  };
+
+  walk(node, []);
+  return occurrences;
+};
+
+const collectRepeatedMagicNumberLines = (node: unknown): readonly number[] => {
+  return sortedUniqueLines(
+    [...collectMagicNumberOccurrences(node).values()]
+      .filter((occurrence) => occurrence.count >= 2)
+      .flatMap((occurrence) => occurrence.lines)
+  );
 };
 
 export const hasLargeClassDeclaration = (node: unknown): boolean => {

--- a/core/facts/detectors/typescript/index.ts
+++ b/core/facts/detectors/typescript/index.ts
@@ -1793,22 +1793,22 @@ const isExecutableMagicNumberContext = (
   if (!isObject(parent)) {
     return false;
   }
-
-  switch (parent.type) {
-    case 'BinaryExpression':
-      return parent.left === value || parent.right === value;
-    case 'CallExpression':
-    case 'NewExpression':
-      return Array.isArray(parent.arguments) && parent.arguments.includes(value);
-    case 'AssignmentExpression':
-      return parent.right === value;
-    case 'ReturnStatement':
-      return parent.argument === value;
-    case 'SwitchCase':
-      return parent.test === value;
-    default:
-      return false;
+  if (parent.type === 'BinaryExpression') {
+    return parent.left === value || parent.right === value;
   }
+  if (parent.type === 'CallExpression' || parent.type === 'NewExpression') {
+    return Array.isArray(parent.arguments) && parent.arguments.includes(value);
+  }
+  if (parent.type === 'AssignmentExpression') {
+    return parent.right === value;
+  }
+  if (parent.type === 'ReturnStatement') {
+    return parent.argument === value;
+  }
+  if (parent.type === 'SwitchCase') {
+    return parent.test === value;
+  }
+  return false;
 };
 
 const collectMagicNumberOccurrences = (

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -401,6 +401,7 @@ const astDetectorRegistry: ReadonlyArray<ASTDetectorRegistryEntry> = [
   { detect: TS.hasSetTimeoutStringCallback, ruleId: 'heuristics.ts.set-timeout-string.ast', code: 'HEURISTICS_SET_TIMEOUT_STRING_AST', message: 'AST heuristic detected setTimeout with a string callback.' },
   { detect: TS.hasSetIntervalStringCallback, ruleId: 'heuristics.ts.set-interval-string.ast', code: 'HEURISTICS_SET_INTERVAL_STRING_AST', message: 'AST heuristic detected setInterval with a string callback.' },
   { detect: TS.hasAsyncPromiseExecutor, ruleId: 'heuristics.ts.new-promise-async.ast', code: 'HEURISTICS_NEW_PROMISE_ASYNC_AST', message: 'AST heuristic detected async Promise executor usage.' },
+  { detect: TS.hasMagicNumberLiteral, locateLines: TS.findMagicNumberLiteralLines, ruleId: 'heuristics.ts.magic-number.ast', code: 'HEURISTICS_MAGIC_NUMBER_AST', message: 'AST heuristic detected magic number usage.' },
   { detect: TS.hasWithStatement, ruleId: 'heuristics.ts.with-statement.ast', code: 'HEURISTICS_WITH_STATEMENT_AST', message: 'AST heuristic detected with-statement usage.' },
   { detect: TS.hasDeleteOperator, ruleId: 'heuristics.ts.delete-operator.ast', code: 'HEURISTICS_DELETE_OPERATOR_AST', message: 'AST heuristic detected delete-operator usage.' },
   { detect: TS.hasDebuggerStatement, ruleId: 'heuristics.ts.debugger.ast', code: 'HEURISTICS_DEBUGGER_AST', message: 'AST heuristic detected debugger statement usage.' },

--- a/core/rules/presets/heuristics/typescript.test.ts
+++ b/core/rules/presets/heuristics/typescript.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { typescriptRules } from './typescript';
 
 test('typescriptRules define reglas heurísticas locked para plataforma generic', () => {
-  assert.equal(typescriptRules.length, 19);
+  assert.equal(typescriptRules.length, 20);
 
   const ids = typescriptRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -16,6 +16,7 @@ test('typescriptRules define reglas heurísticas locked para plataforma generic'
     'heuristics.ts.set-timeout-string.ast',
     'heuristics.ts.set-interval-string.ast',
     'heuristics.ts.new-promise-async.ast',
+    'heuristics.ts.magic-number.ast',
     'heuristics.ts.with-statement.ast',
     'heuristics.ts.delete-operator.ast',
     'heuristics.ts.debugger.ast',
@@ -32,6 +33,10 @@ test('typescriptRules define reglas heurísticas locked para plataforma generic'
   assert.equal(
     byId.get('heuristics.ts.empty-catch.ast')?.then.code,
     'HEURISTICS_EMPTY_CATCH_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.ts.magic-number.ast')?.then.code,
+    'HEURISTICS_MAGIC_NUMBER_AST'
   );
   assert.equal(
     byId.get('heuristics.ts.debugger.ast')?.then.code,

--- a/core/rules/presets/heuristics/typescript.ts
+++ b/core/rules/presets/heuristics/typescript.ts
@@ -164,6 +164,24 @@ export const typescriptRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.ts.magic-number.ast',
+    description: 'Detects repeated magic number usage in TypeScript/TSX production files.',
+    severity: 'WARN',
+    platform: 'generic',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.ts.magic-number.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message: 'AST heuristic detected magic number usage.',
+      code: 'HEURISTICS_MAGIC_NUMBER_AST',
+    },
+  },
+  {
     id: 'heuristics.ts.with-statement.ast',
     description: 'Detects with-statement usage in TypeScript/TSX production files.',
     severity: 'WARN',

--- a/docs/codex-skills/backend-enterprise-rules.md
+++ b/docs/codex-skills/backend-enterprise-rules.md
@@ -252,9 +252,9 @@ const { data } = await supabase
 ❌ **God classes** - Servicios con >500 líneas
 ❌ **Anemic domain models** - Entidades solo con getters/setters
 ❌ **Magic numbers** - Usar constantes con nombres descriptivos
+❌ **Mocks en producción** - Usar fakes/spies de test; en runtime productivo, solo adaptadores y datos reales
 ❌ **Callback hell** - Usar async/await
 ❌ **Hardcoded values** - Config en variables de entorno
-❌ **Mocks en producción** - Solo datos reales
 ❌ **try-catch silenciosos** - Siempre loggear o propagar (AST: common.error.empty_catch)
 ❌ **Lógica en controllers** - Mover a servicios/use cases
 

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -54,6 +54,22 @@ test('normaliza hardcoded values backend al guideline foundation canonico', () =
   assert.equal(rules[0]?.platform, 'backend');
 });
 
+test('normaliza magic numbers backend al guideline foundation canonico', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'backend-guidelines',
+    sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+    sourceContent: '❌ Magic numbers - Usar constantes con nombres descriptivos',
+  });
+
+  assert.equal(rules.length, 1);
+  assert.equal(
+    rules[0]?.id,
+    'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos'
+  );
+  assert.equal(rules[0]?.evaluationMode, 'AUTO');
+  assert.equal(rules[0]?.platform, 'backend');
+});
+
 test('normaliza regla frontend SOLID a id canonico', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'frontend-guidelines',

--- a/integrations/config/__tests__/skillsRuleSet.test.ts
+++ b/integrations/config/__tests__/skillsRuleSet.test.ts
@@ -659,6 +659,65 @@ test('mapea hardcoded values al heuristic AST reusable más cercano', async () =
   );
 });
 
+test('mapea magic numbers al heuristic AST nuevo del slice backend', async () => {
+  await withCoreSkillsDisabled(async () =>
+    withTempDir('pumuki-skills-ruleset-backend-guideline-magic-numbers-', async (tempRoot) => {
+      mkdirSync(join(tempRoot, 'apps/backend'), { recursive: true });
+
+      const lock = {
+        version: '1.0',
+        compilerVersion: '1.0.0',
+        generatedAt: '2026-02-07T23:15:00.000Z',
+        bundles: [
+          {
+            name: 'backend-guidelines',
+            version: '1.0.0',
+            source: 'file:docs/codex-skills/backend-enterprise-rules.md',
+            hash: 'c'.repeat(64),
+            rules: [
+              {
+                id: 'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos',
+                description: 'Avoid magic numbers in backend runtime code.',
+                severity: 'ERROR',
+                platform: 'backend',
+                sourceSkill: 'backend-guidelines',
+                sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+                evaluationMode: 'AUTO',
+                locked: true,
+                confidence: 'HIGH',
+              },
+            ],
+          },
+        ],
+      } as const;
+
+      writeFileSync(join(tempRoot, 'skills.lock.json'), JSON.stringify(lock, null, 2));
+
+      const result = loadSkillsRuleSetForStage('PRE_COMMIT', tempRoot);
+      assert.deepEqual(result.unsupportedAutoRuleIds, []);
+      assert.equal(result.rules.length, 1);
+      assert.equal(result.mappedHeuristicRuleIds.has('heuristics.ts.magic-number.ast'), true);
+
+      const magicNumbersRule = result.rules[0];
+      assert.ok(magicNumbersRule);
+      assert.equal(
+        magicNumbersRule.id,
+        'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos'
+      );
+      assert.equal(magicNumbersRule.when.kind, 'Heuristic');
+      if (magicNumbersRule.when.kind !== 'Heuristic') {
+        assert.fail('Expected heuristic condition for backend magic numbers guideline.');
+      }
+      assert.equal(magicNumbersRule.when.where?.ruleId, 'heuristics.ts.magic-number.ast');
+      assert.deepEqual(collectHeuristicPrefixes(magicNumbersRule.when), ['apps/backend/']);
+      assert.equal(
+        magicNumbersRule.then.source?.includes('ast_nodes=[heuristics.ts.magic-number.ast]'),
+        true
+      );
+    })
+  );
+});
+
 test('enriquce mensaje de no-solid-violations con criterios accionables y métricas observadas', async () => {
   await withCoreSkillsDisabled(async () =>
     withTempDir('pumuki-skills-ruleset-solid-actionable-message-', async (tempRoot) => {

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -184,6 +184,8 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     heuristicDetector('typescript.hardcoded-secret-token', [
       'heuristics.ts.hardcoded-secret-token.ast',
     ]),
+  'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos':
+    heuristicDetector('typescript.magic-number', ['heuristics.ts.magic-number.ast']),
   'skills.frontend.no-empty-catch': heuristicDetector('typescript.empty-catch', [
     'heuristics.ts.empty-catch.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -457,6 +457,14 @@ const normalizeKnownRuleTarget = (
     ) {
       return 'skills.backend.guideline.backend.hardcoded-values-config-en-variables-de-entorno';
     }
+    if (
+      platform === 'backend' &&
+      (includes('magic numbers') ||
+        includes('usar constantes con nombres descriptivos') ||
+        includes('magic numbers - usar constantes con nombres descriptivos'))
+    ) {
+      return 'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos';
+    }
     if (includes('solid') || includes('single responsibility') || includes('srp')) {
       return `${prefix}.no-solid-violations`;
     }


### PR DESCRIPTION
## Summary
- add a new TypeScript AST heuristic for repeated magic numbers in executable contexts
- map backend magic numbers guideline to the new heuristic foundation
- prepare the next backend guideline source text for production mocks

## Validation
- ./node_modules/.bin/tsx --test core/facts/detectors/typescript/index.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/typescript.test.ts integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsRuleSet.test.ts