### PR TITLE
feat(backend-guidelines): add production mocks foundation

### DIFF
--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1820,3 +1820,27 @@ test('detects magic number heuristic facts in backend production path', () => {
   assert.ok(magicNumberFact);
   assert.deepEqual(magicNumberFact?.lines, [2, 3]);
 });
+
+test('detects production mock artifact heuristic facts in backend production path', () => {
+  const extracted = extractHeuristicFacts({
+    facts: [
+      fileContentFact(
+        'apps/backend/src/orders/service.ts',
+        [
+          'import { buildRepository } from "../mocks/user-repository";',
+          'const sinon = require("sinon");',
+        ].join('\n')
+      ),
+    ],
+    detectedPlatforms: {
+      backend: { detected: true },
+    },
+  });
+
+  const productionMockFact = extracted.find(
+    (finding) => finding.ruleId === 'heuristics.ts.production-mock-artifact.ast'
+  );
+
+  assert.ok(productionMockFact);
+  assert.deepEqual(productionMockFact?.lines, [1, 2]);
+});

--- a/core/facts/detectors/typescript/index.test.ts
+++ b/core/facts/detectors/typescript/index.test.ts
@@ -14,6 +14,7 @@ import {
   findUnknownWithoutGuardLines,
   findUnknownTypeAssertionLines,
   findMagicNumberLiteralLines,
+  findProductionMockArtifactUsageLines,
   hasAsyncPromiseExecutor,
   hasConcreteDependencyInstantiation,
   hasConsoleErrorCall,
@@ -26,6 +27,7 @@ import {
   hasFrameworkDependencyImport,
   hasFunctionConstructorUsage,
   hasMagicNumberLiteral,
+  hasProductionMockArtifactUsage,
   hasNetworkCallWithoutErrorHandling,
   hasMixedCommandQueryClass,
   hasMixedCommandQueryInterface,
@@ -950,6 +952,40 @@ test('hasMagicNumberLiteral detecta literales numericos repetidos en contexto ej
   assert.deepEqual(findMagicNumberLiteralLines(magicAst), [3, 7]);
   assert.equal(hasMagicNumberLiteral(ignoredAst), false);
   assert.deepEqual(findMagicNumberLiteralLines(ignoredAst), []);
+});
+
+test('hasProductionMockArtifactUsage detecta imports/requires de doubles en runtime productivo', () => {
+  const importAst = {
+    type: 'ImportDeclaration',
+    source: { type: 'StringLiteral', value: '../mocks/user-repository', loc: { start: { line: 3 }, end: { line: 3 } } },
+    specifiers: [],
+    loc: { start: { line: 3 }, end: { line: 3 } },
+  };
+  const requireAst = {
+    type: 'CallExpression',
+    callee: { type: 'Identifier', name: 'require' },
+    arguments: [{ type: 'StringLiteral', value: 'sinon', loc: { start: { line: 7 }, end: { line: 7 } } }],
+    loc: { start: { line: 7 }, end: { line: 7 } },
+  };
+  const cleanAst = {
+    type: 'Program',
+    body: [
+      {
+        type: 'ImportDeclaration',
+        source: { type: 'StringLiteral', value: '../adapters/user-repository', loc: { start: { line: 1 }, end: { line: 1 } } },
+        specifiers: [],
+      },
+    ],
+  };
+  const mixedAst = {
+    type: 'Program',
+    body: [importAst, { type: 'ExpressionStatement', expression: requireAst }],
+  };
+
+  assert.equal(hasProductionMockArtifactUsage(importAst), true);
+  assert.equal(hasProductionMockArtifactUsage(requireAst), true);
+  assert.equal(hasProductionMockArtifactUsage(cleanAst), false);
+  assert.deepEqual(findProductionMockArtifactUsageLines(mixedAst), [3, 7]);
 });
 
 test('hasRecordStringUnknownType detecta Record<string, unknown>', () => {

--- a/core/facts/detectors/typescript/index.ts
+++ b/core/facts/detectors/typescript/index.ts
@@ -22,6 +22,8 @@ const concreteDependencyNames = new Set<string>([
 const GOD_CLASS_MAX_LINES = 300;
 const networkCallCalleePattern = /^(fetch|axios|get|post|put|patch|delete|request)$/i;
 const ignoredMagicNumberValues = new Set<number>([0, 1]);
+const runtimeTestDoubleLibraryPattern = /^(sinon|testdouble|ts-mockito|jest-mock|vitest)$/i;
+const runtimeTestDoublePathPattern = /(^|\/)(__mocks__|mocks|fakes|spies|stubs)(\/|$)|\.(mock|fake|spy|stub)$/i;
 type AstNode = Record<string, string | number | boolean | bigint | symbol | null | Date | object>;
 type TypeScriptSemanticNode = {
   kind: 'class' | 'property' | 'call' | 'member';
@@ -1555,6 +1557,52 @@ export const hasMagicNumberLiteral = (node: unknown): boolean => {
 
 export const findMagicNumberLiteralLines = (node: unknown): readonly number[] => {
   return collectRepeatedMagicNumberLines(node);
+};
+
+const runtimeTestDoubleSpecifier = (node: unknown): string | undefined => {
+  if (!isObject(node) || node.type !== 'StringLiteral' || typeof node.value !== 'string') {
+    return undefined;
+  }
+  return node.value;
+};
+
+const matchesRuntimeTestDoubleImport = (specifier: string): boolean => {
+  return (
+    runtimeTestDoubleLibraryPattern.test(specifier) ||
+    runtimeTestDoublePathPattern.test(specifier)
+  );
+};
+
+const isRuntimeTestDoubleImportNode = (value: AstNode): boolean => {
+  if (value.type === 'ImportDeclaration') {
+    const specifier = runtimeTestDoubleSpecifier(value.source);
+    return typeof specifier === 'string' && matchesRuntimeTestDoubleImport(specifier);
+  }
+
+  if (
+    value.type === 'CallExpression' &&
+    isObject(value.callee) &&
+    value.callee.type === 'Identifier' &&
+    value.callee.name === 'require' &&
+    Array.isArray(value.arguments)
+  ) {
+    return value.arguments.some((argument) => {
+      const specifier = runtimeTestDoubleSpecifier(argument);
+      return typeof specifier === 'string' && matchesRuntimeTestDoubleImport(specifier);
+    });
+  }
+
+  return false;
+};
+
+export const hasProductionMockArtifactUsage = (node: unknown): boolean => {
+  return hasNode(node, (value) => isRuntimeTestDoubleImportNode(value));
+};
+
+export const findProductionMockArtifactUsageLines = (node: unknown): readonly number[] => {
+  return collectLineMatchesWithAncestors(node, (value) => isRuntimeTestDoubleImportNode(value), {
+    max: 8,
+  });
 };
 
 export const hasWithStatement = (node: unknown): boolean => {

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -402,6 +402,7 @@ const astDetectorRegistry: ReadonlyArray<ASTDetectorRegistryEntry> = [
   { detect: TS.hasSetIntervalStringCallback, ruleId: 'heuristics.ts.set-interval-string.ast', code: 'HEURISTICS_SET_INTERVAL_STRING_AST', message: 'AST heuristic detected setInterval with a string callback.' },
   { detect: TS.hasAsyncPromiseExecutor, ruleId: 'heuristics.ts.new-promise-async.ast', code: 'HEURISTICS_NEW_PROMISE_ASYNC_AST', message: 'AST heuristic detected async Promise executor usage.' },
   { detect: TS.hasMagicNumberLiteral, locateLines: TS.findMagicNumberLiteralLines, ruleId: 'heuristics.ts.magic-number.ast', code: 'HEURISTICS_MAGIC_NUMBER_AST', message: 'AST heuristic detected magic number usage.' },
+  { detect: TS.hasProductionMockArtifactUsage, locateLines: TS.findProductionMockArtifactUsageLines, ruleId: 'heuristics.ts.production-mock-artifact.ast', code: 'HEURISTICS_PRODUCTION_MOCK_ARTIFACT_AST', message: 'AST heuristic detected test doubles imported or required in production backend code.' },
   { detect: TS.hasWithStatement, ruleId: 'heuristics.ts.with-statement.ast', code: 'HEURISTICS_WITH_STATEMENT_AST', message: 'AST heuristic detected with-statement usage.' },
   { detect: TS.hasDeleteOperator, ruleId: 'heuristics.ts.delete-operator.ast', code: 'HEURISTICS_DELETE_OPERATOR_AST', message: 'AST heuristic detected delete-operator usage.' },
   { detect: TS.hasDebuggerStatement, ruleId: 'heuristics.ts.debugger.ast', code: 'HEURISTICS_DEBUGGER_AST', message: 'AST heuristic detected debugger statement usage.' },

--- a/core/rules/presets/heuristics/typescript.test.ts
+++ b/core/rules/presets/heuristics/typescript.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { typescriptRules } from './typescript';
 
 test('typescriptRules define reglas heurísticas locked para plataforma generic', () => {
-  assert.equal(typescriptRules.length, 20);
+  assert.equal(typescriptRules.length, 21);
 
   const ids = typescriptRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -17,6 +17,7 @@ test('typescriptRules define reglas heurísticas locked para plataforma generic'
     'heuristics.ts.set-interval-string.ast',
     'heuristics.ts.new-promise-async.ast',
     'heuristics.ts.magic-number.ast',
+    'heuristics.ts.production-mock-artifact.ast',
     'heuristics.ts.with-statement.ast',
     'heuristics.ts.delete-operator.ast',
     'heuristics.ts.debugger.ast',
@@ -37,6 +38,10 @@ test('typescriptRules define reglas heurísticas locked para plataforma generic'
   assert.equal(
     byId.get('heuristics.ts.magic-number.ast')?.then.code,
     'HEURISTICS_MAGIC_NUMBER_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.ts.production-mock-artifact.ast')?.then.code,
+    'HEURISTICS_PRODUCTION_MOCK_ARTIFACT_AST'
   );
   assert.equal(
     byId.get('heuristics.ts.debugger.ast')?.then.code,

--- a/core/rules/presets/heuristics/typescript.ts
+++ b/core/rules/presets/heuristics/typescript.ts
@@ -182,6 +182,24 @@ export const typescriptRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.ts.production-mock-artifact.ast',
+    description: 'Detects imports or requires of mocks/fakes/spies/stubs in TypeScript/TSX runtime code.',
+    severity: 'WARN',
+    platform: 'generic',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.ts.production-mock-artifact.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message: 'AST heuristic detected test doubles imported or required in production backend code.',
+      code: 'HEURISTICS_PRODUCTION_MOCK_ARTIFACT_AST',
+    },
+  },
+  {
     id: 'heuristics.ts.with-statement.ast',
     description: 'Detects with-statement usage in TypeScript/TSX production files.',
     severity: 'WARN',

--- a/docs/codex-skills/backend-enterprise-rules.md
+++ b/docs/codex-skills/backend-enterprise-rules.md
@@ -250,9 +250,9 @@ const { data } = await supabase
 
 ### Anti-patterns a EVITAR:
 ❌ **God classes** - Servicios con >500 líneas
-❌ **Anemic domain models** - Entidades solo con getters/setters
 ❌ **Magic numbers** - Usar constantes con nombres descriptivos
 ❌ **Mocks en producción** - Usar fakes/spies de test; en runtime productivo, solo adaptadores y datos reales
+❌ **Anemic domain models** - Entidades con comportamiento, no solo getters/setters
 ❌ **Callback hell** - Usar async/await
 ❌ **Hardcoded values** - Config en variables de entorno
 ❌ **try-catch silenciosos** - Siempre loggear o propagar (AST: common.error.empty_catch)

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -70,6 +70,23 @@ test('normaliza magic numbers backend al guideline foundation canonico', () => {
   assert.equal(rules[0]?.platform, 'backend');
 });
 
+test('normaliza mocks en producción backend al guideline foundation canonico', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'backend-guidelines',
+    sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+    sourceContent:
+      '❌ Mocks en producción - Usar fakes/spies de test; en runtime productivo, solo adaptadores y datos reales',
+  });
+
+  assert.equal(rules.length, 1);
+  assert.equal(
+    rules[0]?.id,
+    'skills.backend.guideline.backend.mocks-en-produccion-usar-fakes-spies-de-test'
+  );
+  assert.equal(rules[0]?.evaluationMode, 'AUTO');
+  assert.equal(rules[0]?.platform, 'backend');
+});
+
 test('normaliza regla frontend SOLID a id canonico', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'frontend-guidelines',

--- a/integrations/config/__tests__/skillsRuleSet.test.ts
+++ b/integrations/config/__tests__/skillsRuleSet.test.ts
@@ -718,6 +718,73 @@ test('mapea magic numbers al heuristic AST nuevo del slice backend', async () =>
   );
 });
 
+test('mapea mocks en producción al heuristic AST nuevo del slice backend', async () => {
+  await withCoreSkillsDisabled(async () =>
+    withTempDir('pumuki-skills-ruleset-backend-guideline-production-mocks-', async (tempRoot) => {
+      mkdirSync(join(tempRoot, 'apps/backend'), { recursive: true });
+
+      const lock = {
+        version: '1.0',
+        compilerVersion: '1.0.0',
+        generatedAt: '2026-02-07T23:15:00.000Z',
+        bundles: [
+          {
+            name: 'backend-guidelines',
+            version: '1.0.0',
+            source: 'file:docs/codex-skills/backend-enterprise-rules.md',
+            hash: 'd'.repeat(64),
+            rules: [
+              {
+                id: 'skills.backend.guideline.backend.mocks-en-produccion-usar-fakes-spies-de-test',
+                description: 'Avoid runtime mocks, fakes, spies or stubs in backend code.',
+                severity: 'ERROR',
+                platform: 'backend',
+                sourceSkill: 'backend-guidelines',
+                sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+                evaluationMode: 'AUTO',
+                locked: true,
+                confidence: 'HIGH',
+              },
+            ],
+          },
+        ],
+      } as const;
+
+      writeFileSync(join(tempRoot, 'skills.lock.json'), JSON.stringify(lock, null, 2));
+
+      const result = loadSkillsRuleSetForStage('PRE_COMMIT', tempRoot);
+      assert.deepEqual(result.unsupportedAutoRuleIds, []);
+      assert.equal(result.rules.length, 1);
+      assert.equal(
+        result.mappedHeuristicRuleIds.has('heuristics.ts.production-mock-artifact.ast'),
+        true
+      );
+
+      const runtimeMocksRule = result.rules[0];
+      assert.ok(runtimeMocksRule);
+      assert.equal(
+        runtimeMocksRule.id,
+        'skills.backend.guideline.backend.mocks-en-produccion-usar-fakes-spies-de-test'
+      );
+      assert.equal(runtimeMocksRule.when.kind, 'Heuristic');
+      if (runtimeMocksRule.when.kind !== 'Heuristic') {
+        assert.fail('Expected heuristic condition for backend runtime test doubles guideline.');
+      }
+      assert.equal(
+        runtimeMocksRule.when.where?.ruleId,
+        'heuristics.ts.production-mock-artifact.ast'
+      );
+      assert.deepEqual(collectHeuristicPrefixes(runtimeMocksRule.when), ['apps/backend/']);
+      assert.equal(
+        runtimeMocksRule.then.source?.includes(
+          'ast_nodes=[heuristics.ts.production-mock-artifact.ast]'
+        ),
+        true
+      );
+    })
+  );
+});
+
 test('enriquce mensaje de no-solid-violations con criterios accionables y métricas observadas', async () => {
   await withCoreSkillsDisabled(async () =>
     withTempDir('pumuki-skills-ruleset-solid-actionable-message-', async (tempRoot) => {

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -186,6 +186,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     ]),
   'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos':
     heuristicDetector('typescript.magic-number', ['heuristics.ts.magic-number.ast']),
+  'skills.backend.guideline.backend.mocks-en-produccion-usar-fakes-spies-de-test':
+    heuristicDetector('typescript.production-mock-artifact', [
+      'heuristics.ts.production-mock-artifact.ast',
+    ]),
   'skills.frontend.no-empty-catch': heuristicDetector('typescript.empty-catch', [
     'heuristics.ts.empty-catch.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -465,6 +465,16 @@ const normalizeKnownRuleTarget = (
     ) {
       return 'skills.backend.guideline.backend.magic-numbers-usar-constantes-con-nombres-descriptivos';
     }
+    if (
+      platform === 'backend' &&
+      (includes('mocks en producción') ||
+        includes('mocks en produccion') ||
+        includes('usar fakes/spies de test') ||
+        includes('runtime productivo') ||
+        includes('solo adaptadores y datos reales'))
+    ) {
+      return 'skills.backend.guideline.backend.mocks-en-produccion-usar-fakes-spies-de-test';
+    }
     if (includes('solid') || includes('single responsibility') || includes('srp')) {
       return `${prefix}.no-solid-violations`;
     }


### PR DESCRIPTION
## Summary
- add a new TypeScript AST heuristic for production mock artifacts in backend runtime
- map backend production mocks guideline to the new heuristic foundation
- prepare anemic domain models as the next canonical backend guideline in docs

## Validation
- ./node_modules/.bin/tsx --test core/facts/detectors/typescript/index.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/typescript.test.ts integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsRuleSet.test.ts