### PR TITLE
feat(backend-guidelines): add anemic domain foundation

### DIFF
--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1844,3 +1844,30 @@ test('detects production mock artifact heuristic facts in backend production pat
   assert.ok(productionMockFact);
   assert.deepEqual(productionMockFact?.lines, [1, 2]);
 });
+
+test('detects anemic domain model heuristic facts in backend production path', () => {
+  const extracted = extractHeuristicFacts({
+    facts: [
+      fileContentFact(
+        'apps/backend/src/domain/order.entity.ts',
+        [
+          'export class OrderEntity {',
+          '  constructor(private status: string) {}',
+          '  getStatus() { return this.status; }',
+          '  setStatus(status: string) { this.status = status; }',
+          '}',
+        ].join('\n')
+      ),
+    ],
+    detectedPlatforms: {
+      backend: { detected: true },
+    },
+  });
+
+  const anemicDomainFact = extracted.find(
+    (finding) => finding.ruleId === 'heuristics.ts.anemic-domain-model.ast'
+  );
+
+  assert.ok(anemicDomainFact);
+  assert.deepEqual(anemicDomainFact?.lines, [1]);
+});

--- a/core/facts/detectors/typescript/index.test.ts
+++ b/core/facts/detectors/typescript/index.test.ts
@@ -13,8 +13,10 @@ import {
   findUndefinedInBaseTypeUnionLines,
   findUnknownWithoutGuardLines,
   findUnknownTypeAssertionLines,
+  findAnemicDomainModelLines,
   findMagicNumberLiteralLines,
   findProductionMockArtifactUsageLines,
+  hasAnemicDomainModel,
   hasAsyncPromiseExecutor,
   hasConcreteDependencyInstantiation,
   hasConsoleErrorCall,
@@ -986,6 +988,53 @@ test('hasProductionMockArtifactUsage detecta imports/requires de doubles en runt
   assert.equal(hasProductionMockArtifactUsage(requireAst), true);
   assert.equal(hasProductionMockArtifactUsage(cleanAst), false);
   assert.deepEqual(findProductionMockArtifactUsageLines(mixedAst), [3, 7]);
+});
+
+test('hasAnemicDomainModel detecta clases de dominio con solo accessors y sin comportamiento', () => {
+  const anemicAst = {
+    type: 'ClassDeclaration',
+    id: { type: 'Identifier', name: 'OrderEntity' },
+    body: {
+      type: 'ClassBody',
+      body: [
+        { type: 'ClassMethod', kind: 'constructor', key: { type: 'Identifier', name: 'constructor' }, loc: { start: { line: 3 }, end: { line: 3 } } },
+        { type: 'ClassMethod', key: { type: 'Identifier', name: 'getStatus' }, loc: { start: { line: 5 }, end: { line: 5 } } },
+        { type: 'ClassMethod', key: { type: 'Identifier', name: 'setStatus' }, loc: { start: { line: 7 }, end: { line: 7 } } },
+      ],
+    },
+    loc: { start: { line: 1 }, end: { line: 9 } },
+  };
+  const richAst = {
+    type: 'ClassDeclaration',
+    id: { type: 'Identifier', name: 'OrderEntity' },
+    body: {
+      type: 'ClassBody',
+      body: [
+        { type: 'ClassMethod', kind: 'constructor', key: { type: 'Identifier', name: 'constructor' }, loc: { start: { line: 3 }, end: { line: 3 } } },
+        { type: 'ClassMethod', key: { type: 'Identifier', name: 'getStatus' }, loc: { start: { line: 5 }, end: { line: 5 } } },
+        { type: 'ClassMethod', key: { type: 'Identifier', name: 'confirm' }, loc: { start: { line: 7 }, end: { line: 7 } } },
+      ],
+    },
+    loc: { start: { line: 1 }, end: { line: 9 } },
+  };
+  const serviceAst = {
+    type: 'ClassDeclaration',
+    id: { type: 'Identifier', name: 'OrderService' },
+    body: {
+      type: 'ClassBody',
+      body: [
+        { type: 'ClassMethod', kind: 'constructor', key: { type: 'Identifier', name: 'constructor' }, loc: { start: { line: 3 }, end: { line: 3 } } },
+        { type: 'ClassMethod', key: { type: 'Identifier', name: 'getStatus' }, loc: { start: { line: 5 }, end: { line: 5 } } },
+        { type: 'ClassMethod', key: { type: 'Identifier', name: 'setStatus' }, loc: { start: { line: 7 }, end: { line: 7 } } },
+      ],
+    },
+    loc: { start: { line: 1 }, end: { line: 9 } },
+  };
+
+  assert.equal(hasAnemicDomainModel(anemicAst), true);
+  assert.deepEqual(findAnemicDomainModelLines(anemicAst), [1]);
+  assert.equal(hasAnemicDomainModel(richAst), false);
+  assert.equal(hasAnemicDomainModel(serviceAst), false);
 });
 
 test('hasRecordStringUnknownType detecta Record<string, unknown>', () => {

--- a/core/facts/detectors/typescript/index.ts
+++ b/core/facts/detectors/typescript/index.ts
@@ -24,6 +24,7 @@ const networkCallCalleePattern = /^(fetch|axios|get|post|put|patch|delete|reques
 const ignoredMagicNumberValues = new Set<number>([0, 1]);
 const runtimeTestDoubleLibraryPattern = /^(sinon|testdouble|ts-mockito|jest-mock|vitest)$/i;
 const runtimeTestDoublePathPattern = /(^|\/)(__mocks__|mocks|fakes|spies|stubs)(\/|$)|\.(mock|fake|spy|stub)$/i;
+const anemicDomainClassNamePattern = /(Entity|Aggregate|Model)$/i;
 type AstNode = Record<string, string | number | boolean | bigint | symbol | null | Date | object>;
 type TypeScriptSemanticNode = {
   kind: 'class' | 'property' | 'call' | 'member';
@@ -408,6 +409,28 @@ const collectClassMethodDescriptors = (classNode: AstNode): readonly ClassMethod
   }
 
   return descriptors;
+};
+
+const isAccessorLikeMethodName = (name: string): boolean => {
+  return name === 'constructor' || /^(get|set)[A-Z_]/.test(name);
+};
+
+const isAnemicDomainClassNode = (value: AstNode): boolean => {
+  if (value.type !== 'ClassDeclaration' && value.type !== 'ClassExpression') {
+    return false;
+  }
+
+  const className = classNameFromNode(value);
+  if (!anemicDomainClassNamePattern.test(className)) {
+    return false;
+  }
+
+  const descriptors = collectClassMethodDescriptors(value);
+  if (descriptors.length < 2) {
+    return false;
+  }
+
+  return descriptors.every((descriptor) => isAccessorLikeMethodName(descriptor.name));
 };
 
 const interfaceNameFromNode = (node: AstNode): string => {
@@ -1601,6 +1624,16 @@ export const hasProductionMockArtifactUsage = (node: unknown): boolean => {
 
 export const findProductionMockArtifactUsageLines = (node: unknown): readonly number[] => {
   return collectLineMatchesWithAncestors(node, (value) => isRuntimeTestDoubleImportNode(value), {
+    max: 8,
+  });
+};
+
+export const hasAnemicDomainModel = (node: unknown): boolean => {
+  return hasNode(node, (value) => isAnemicDomainClassNode(value));
+};
+
+export const findAnemicDomainModelLines = (node: unknown): readonly number[] => {
+  return collectLineMatchesWithAncestors(node, (value) => isAnemicDomainClassNode(value), {
     max: 8,
   });
 };

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -403,6 +403,7 @@ const astDetectorRegistry: ReadonlyArray<ASTDetectorRegistryEntry> = [
   { detect: TS.hasAsyncPromiseExecutor, ruleId: 'heuristics.ts.new-promise-async.ast', code: 'HEURISTICS_NEW_PROMISE_ASYNC_AST', message: 'AST heuristic detected async Promise executor usage.' },
   { detect: TS.hasMagicNumberLiteral, locateLines: TS.findMagicNumberLiteralLines, ruleId: 'heuristics.ts.magic-number.ast', code: 'HEURISTICS_MAGIC_NUMBER_AST', message: 'AST heuristic detected magic number usage.' },
   { detect: TS.hasProductionMockArtifactUsage, locateLines: TS.findProductionMockArtifactUsageLines, ruleId: 'heuristics.ts.production-mock-artifact.ast', code: 'HEURISTICS_PRODUCTION_MOCK_ARTIFACT_AST', message: 'AST heuristic detected test doubles imported or required in production backend code.' },
+  { detect: TS.hasAnemicDomainModel, locateLines: TS.findAnemicDomainModelLines, ruleId: 'heuristics.ts.anemic-domain-model.ast', code: 'HEURISTICS_ANEMIC_DOMAIN_MODEL_AST', message: 'AST heuristic detected an anemic domain model.' },
   { detect: TS.hasWithStatement, ruleId: 'heuristics.ts.with-statement.ast', code: 'HEURISTICS_WITH_STATEMENT_AST', message: 'AST heuristic detected with-statement usage.' },
   { detect: TS.hasDeleteOperator, ruleId: 'heuristics.ts.delete-operator.ast', code: 'HEURISTICS_DELETE_OPERATOR_AST', message: 'AST heuristic detected delete-operator usage.' },
   { detect: TS.hasDebuggerStatement, ruleId: 'heuristics.ts.debugger.ast', code: 'HEURISTICS_DEBUGGER_AST', message: 'AST heuristic detected debugger statement usage.' },

--- a/core/rules/presets/heuristics/typescript.test.ts
+++ b/core/rules/presets/heuristics/typescript.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { typescriptRules } from './typescript';
 
 test('typescriptRules define reglas heurísticas locked para plataforma generic', () => {
-  assert.equal(typescriptRules.length, 21);
+  assert.equal(typescriptRules.length, 22);
 
   const ids = typescriptRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -18,6 +18,7 @@ test('typescriptRules define reglas heurísticas locked para plataforma generic'
     'heuristics.ts.new-promise-async.ast',
     'heuristics.ts.magic-number.ast',
     'heuristics.ts.production-mock-artifact.ast',
+    'heuristics.ts.anemic-domain-model.ast',
     'heuristics.ts.with-statement.ast',
     'heuristics.ts.delete-operator.ast',
     'heuristics.ts.debugger.ast',
@@ -42,6 +43,10 @@ test('typescriptRules define reglas heurísticas locked para plataforma generic'
   assert.equal(
     byId.get('heuristics.ts.production-mock-artifact.ast')?.then.code,
     'HEURISTICS_PRODUCTION_MOCK_ARTIFACT_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.ts.anemic-domain-model.ast')?.then.code,
+    'HEURISTICS_ANEMIC_DOMAIN_MODEL_AST'
   );
   assert.equal(
     byId.get('heuristics.ts.debugger.ast')?.then.code,

--- a/core/rules/presets/heuristics/typescript.ts
+++ b/core/rules/presets/heuristics/typescript.ts
@@ -200,6 +200,24 @@ export const typescriptRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.ts.anemic-domain-model.ast',
+    description: 'Detects domain classes with only constructor/getters/setters and no behavior.',
+    severity: 'WARN',
+    platform: 'generic',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.ts.anemic-domain-model.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message: 'AST heuristic detected an anemic domain model.',
+      code: 'HEURISTICS_ANEMIC_DOMAIN_MODEL_AST',
+    },
+  },
+  {
     id: 'heuristics.ts.with-statement.ast',
     description: 'Detects with-statement usage in TypeScript/TSX production files.',
     severity: 'WARN',

--- a/docs/codex-skills/backend-enterprise-rules.md
+++ b/docs/codex-skills/backend-enterprise-rules.md
@@ -253,10 +253,10 @@ const { data } = await supabase
 ❌ **Magic numbers** - Usar constantes con nombres descriptivos
 ❌ **Mocks en producción** - Usar fakes/spies de test; en runtime productivo, solo adaptadores y datos reales
 ❌ **Anemic domain models** - Entidades con comportamiento, no solo getters/setters
+❌ **Lógica en controllers** - Mover lógica de negocio a casos de uso/servicios
 ❌ **Callback hell** - Usar async/await
 ❌ **Hardcoded values** - Config en variables de entorno
 ❌ **try-catch silenciosos** - Siempre loggear o propagar (AST: common.error.empty_catch)
-❌ **Lógica en controllers** - Mover a servicios/use cases
 
 ### Principio fundamental:
 ✅ **"Measure twice, cut once"** - Planificar arquitectura, dependencias y flujo de datos antes de implementar. Analizar impacto en BD, caché y performance.

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -87,6 +87,23 @@ test('normaliza mocks en producción backend al guideline foundation canonico', 
   assert.equal(rules[0]?.platform, 'backend');
 });
 
+test('normaliza anemic domain models backend al guideline foundation canonico', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'backend-guidelines',
+    sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+    sourceContent:
+      '❌ Anemic domain models - Entidades con comportamiento, no solo getters/setters',
+  });
+
+  assert.equal(rules.length, 1);
+  assert.equal(
+    rules[0]?.id,
+    'skills.backend.guideline.backend.anemic-domain-models-entidades-con-comportamiento'
+  );
+  assert.equal(rules[0]?.evaluationMode, 'AUTO');
+  assert.equal(rules[0]?.platform, 'backend');
+});
+
 test('normaliza regla frontend SOLID a id canonico', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'frontend-guidelines',

--- a/integrations/config/__tests__/skillsRuleSet.test.ts
+++ b/integrations/config/__tests__/skillsRuleSet.test.ts
@@ -785,6 +785,70 @@ test('mapea mocks en producción al heuristic AST nuevo del slice backend', asyn
   );
 });
 
+test('mapea anemic domain models al heuristic AST nuevo del slice backend', async () => {
+  await withCoreSkillsDisabled(async () =>
+    withTempDir('pumuki-skills-ruleset-backend-guideline-anemic-domain-model-', async (tempRoot) => {
+      mkdirSync(join(tempRoot, 'apps/backend'), { recursive: true });
+
+      const lock = {
+        version: '1.0',
+        compilerVersion: '1.0.0',
+        generatedAt: '2026-02-07T23:15:00.000Z',
+        bundles: [
+          {
+            name: 'backend-guidelines',
+            version: '1.0.0',
+            source: 'file:docs/codex-skills/backend-enterprise-rules.md',
+            hash: 'e'.repeat(64),
+            rules: [
+              {
+                id: 'skills.backend.guideline.backend.anemic-domain-models-entidades-con-comportamiento',
+                description: 'Avoid anemic domain models in backend runtime code.',
+                severity: 'ERROR',
+                platform: 'backend',
+                sourceSkill: 'backend-guidelines',
+                sourcePath: 'docs/codex-skills/backend-enterprise-rules.md',
+                evaluationMode: 'AUTO',
+                locked: true,
+                confidence: 'HIGH',
+              },
+            ],
+          },
+        ],
+      } as const;
+
+      writeFileSync(join(tempRoot, 'skills.lock.json'), JSON.stringify(lock, null, 2));
+
+      const result = loadSkillsRuleSetForStage('PRE_COMMIT', tempRoot);
+      assert.deepEqual(result.unsupportedAutoRuleIds, []);
+      assert.equal(result.rules.length, 1);
+      assert.equal(result.mappedHeuristicRuleIds.has('heuristics.ts.anemic-domain-model.ast'), true);
+
+      const anemicDomainRule = result.rules[0];
+      assert.ok(anemicDomainRule);
+      assert.equal(
+        anemicDomainRule.id,
+        'skills.backend.guideline.backend.anemic-domain-models-entidades-con-comportamiento'
+      );
+      assert.equal(anemicDomainRule.when.kind, 'Heuristic');
+      if (anemicDomainRule.when.kind !== 'Heuristic') {
+        assert.fail('Expected heuristic condition for backend anemic domain model guideline.');
+      }
+      assert.equal(
+        anemicDomainRule.when.where?.ruleId,
+        'heuristics.ts.anemic-domain-model.ast'
+      );
+      assert.deepEqual(collectHeuristicPrefixes(anemicDomainRule.when), ['apps/backend/']);
+      assert.equal(
+        anemicDomainRule.then.source?.includes(
+          'ast_nodes=[heuristics.ts.anemic-domain-model.ast]'
+        ),
+        true
+      );
+    })
+  );
+});
+
 test('enriquce mensaje de no-solid-violations con criterios accionables y métricas observadas', async () => {
   await withCoreSkillsDisabled(async () =>
     withTempDir('pumuki-skills-ruleset-solid-actionable-message-', async (tempRoot) => {

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -190,6 +190,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     heuristicDetector('typescript.production-mock-artifact', [
       'heuristics.ts.production-mock-artifact.ast',
     ]),
+  'skills.backend.guideline.backend.anemic-domain-models-entidades-con-comportamiento':
+    heuristicDetector('typescript.anemic-domain-model', [
+      'heuristics.ts.anemic-domain-model.ast',
+    ]),
   'skills.frontend.no-empty-catch': heuristicDetector('typescript.empty-catch', [
     'heuristics.ts.empty-catch.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -475,6 +475,14 @@ const normalizeKnownRuleTarget = (
     ) {
       return 'skills.backend.guideline.backend.mocks-en-produccion-usar-fakes-spies-de-test';
     }
+    if (
+      platform === 'backend' &&
+      (includes('anemic domain models') ||
+        includes('entidades con comportamiento') ||
+        includes('no solo getters/setters'))
+    ) {
+      return 'skills.backend.guideline.backend.anemic-domain-models-entidades-con-comportamiento';
+    }
     if (includes('solid') || includes('single responsibility') || includes('srp')) {
       return `${prefix}.no-solid-violations`;
     }


### PR DESCRIPTION
## Summary
- add the new anemic domain model heuristic foundation
- wire the backend guideline to the new AST heuristic
- extend detector, extraction, preset and config regressions

## Validation
- ./node_modules/.bin/tsx --test core/facts/detectors/typescript/index.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/typescript.test.ts integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsRuleSet.test.ts