### PR TITLE
refactor(governance): align canonical block semantics

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1032,9 +1032,9 @@ Decisión hard de cierre:
 
 Último cierre: `[✅] - Adopción útil de pumuki@6.3.98 cerrada en consumers` la release publicada ya quedó integrada en `SAAS`, `Flux` y `RuralGo` y no quedan bugs externos abiertos en los tres MDs consumidores.
 
-Último cierre operativo: `[✅] - Slice S1.a del menú Consumer cerrada` el menú `Consumer` ya muestra el bloque canónico de governance incluso sin `preflight`, reutilizando el mismo renderer compartido que usan `status` y `doctor`; la implementación quedó aislada en `refactor/s1-governance-console-v2` con tests dirigidos en verde (`8/8`) sobre `scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts` e `integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts`.
+Último cierre operativo: `[✅] - Slice S1.b alineada en status, doctor y menú` el bloque canónico compartido ya converge en orden y labels visibles entre `status`, `doctor` y el menú `Consumer`: `Contract`, `Governance`, `Platforms`, `GitFlow`, `SDD`, `Evidence` y `Pre-write` salen del mismo renderer y quedan cubiertos con tests dirigidos en verde (`8/8`) dentro de `refactor/s1-governance-console-v2`.
 
-Tarea activa única: `[🚧] - Slice S1.b — Alinear el orden/semántica visible del bloque canónico en status, doctor y menú` tras cerrar el primer corte perceptible de S1, el siguiente paso real del frente es endurecer la semántica visible del bloque compartido para que el orden y los labels canónicos converjan en las tres superficies sin abrir todavía un rediseño completo de MCP ni del menú avanzado.
+Tarea activa única: `[🚧] - Slice S1.c — Unificar next_action y prewrite_effective entre hooks, CLI y MCP con vocabulario canónico compartido` tras cerrar la convergencia visual del bloque canónico, el siguiente corte mínimo con más valor visible es unificar la narrativa accionable de bloqueo/remediación entre hooks, CLI y MCP sin abrir todavía un rediseño completo de `Advanced` ni de MCP.
 
 Barrido de consumers cerrado:
 - SAAS (`pumuki@6.3.98`): rollout ejecutado en `chore/pumuki-6-3-98-rollout`, follow-up de pin exacto (`52bb5d3`) y PR [#11](https://github.com/SwiftEnProfundidad/app-supermercados/pull/11) ya mergeada en `main` con squash `6bdd18404358319b20b594c3a2193799eabe4dab` (`2026-04-21T19:04:27Z`). `install/status/doctor` convergieron en verde y el hilo de review sobre `^6.3.98` quedó resuelto antes del merge.

--- a/integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts
+++ b/integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts
@@ -11,6 +11,13 @@ import type { LifecyclePolicyValidationSnapshot } from '../policyValidationSnaps
 
 const buildGovernanceObservation = (): GovernanceObservationSnapshot => ({
   schema_version: '1',
+  platform_bundles_effective: ['android', 'backend', 'frontend', 'ios'],
+  pre_write_effective: {
+    mode: 'off',
+    source: 'default',
+    blocking: false,
+    strict_policy: true,
+  },
   sdd: {
     experimental_raw: null,
     effective_mode: 'off',
@@ -206,8 +213,11 @@ test('buildGovernanceConsoleSummaryLines compone truth, next action, policy y ex
   });
 
   assert.match(lines[0] ?? '', /Governance truth:/);
+  assert.equal(lines.some((line) => /Contract: AGENTS=yes/.test(line)), true);
   assert.equal(lines.some((line) => /Governance: GREEN/.test(line)), true);
+  assert.equal(lines.some((line) => /Platforms: android, backend, frontend, ios/.test(line)), true);
   assert.equal(lines.some((line) => /Evidence hint: repo-clean/.test(line)), true);
+  assert.equal(lines.some((line) => /Pre-write: mode=off blocking=no strict_policy=yes source=default/.test(line)), true);
   assert.equal(lines.some((line) => /Governance next action:/.test(line)), true);
   assert.equal(lines.some((line) => /Instruction: Continúa con la implementación mínima\./.test(line)), true);
   assert.equal(lines.some((line) => /Policy-as-code: PRE_WRITE=POLICY_AS_CODE_VALID strict=yes/.test(line)), true);
@@ -234,7 +244,10 @@ test('printGovernanceConsoleHuman imprime cabecera compartida S1 y el bloque can
 
     const output = printed.join('\n');
     assert.match(output, /governance console \(S1 \/ shared status-doctor baseline\)/i);
+    assert.match(output, /Contract: AGENTS=yes/);
     assert.match(output, /Governance truth:/);
+    assert.match(output, /Platforms: android, backend, frontend, ios/);
+    assert.match(output, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
     assert.match(output, /Governance next action:/);
     assert.match(output, /Policy-as-code: PRE_WRITE=POLICY_AS_CODE_VALID strict=yes/);
     assert.match(output, /Experimental: MCP_ENTERPRISE=off/);

--- a/integrations/lifecycle/governanceObservationSnapshot.ts
+++ b/integrations/lifecycle/governanceObservationSnapshot.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readEvidenceResult } from '../evidence/readEvidence';
 import { readRepoTrackingState } from '../evidence/trackingContract';
@@ -35,6 +35,13 @@ export type GovernanceContractSurface = {
 
 export type GovernanceObservationSnapshot = {
   schema_version: '1';
+  platform_bundles_effective?: ReadonlyArray<string>;
+  pre_write_effective?: {
+    mode: 'off' | 'advisory' | 'strict';
+    source: string;
+    blocking: boolean;
+    strict_policy: boolean;
+  };
   sdd: {
     experimental_raw: string | null;
     effective_mode: 'off' | 'advisory' | 'strict';
@@ -111,6 +118,35 @@ const buildContractSurface = (repoRoot: string): GovernanceContractSurface => ({
   vendor_skills_dir: existsSync(join(repoRoot, 'vendor', 'skills')),
   pumuki_adapter_json: existsSync(join(repoRoot, '.pumuki', 'adapter.json')),
 });
+
+const PLATFORM_BUNDLE_ORDER = [
+  'android-enterprise-rules',
+  'backend-enterprise-rules',
+  'frontend-enterprise-rules',
+  'ios-enterprise-rules',
+] as const;
+
+const PLATFORM_BUNDLE_LABELS: Record<(typeof PLATFORM_BUNDLE_ORDER)[number], string> = {
+  'android-enterprise-rules': 'android',
+  'backend-enterprise-rules': 'backend',
+  'frontend-enterprise-rules': 'frontend',
+  'ios-enterprise-rules': 'ios',
+};
+
+const resolvePlatformBundlesEffective = (repoRoot: string): ReadonlyArray<string> => {
+  const vendorSkillsPath = join(repoRoot, 'vendor', 'skills');
+  if (!existsSync(vendorSkillsPath)) {
+    return [];
+  }
+  const present = new Set(
+    readdirSync(vendorSkillsPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  );
+  return PLATFORM_BUNDLE_ORDER.filter((bundle) => present.has(bundle)).map(
+    (bundle) => PLATFORM_BUNDLE_LABELS[bundle]
+  );
+};
 
 const summarizeEvidence = (repoRoot: string): GovernanceEvidenceSummary => {
   const evidenceResult = readEvidenceResult(repoRoot);
@@ -248,6 +284,13 @@ export const readGovernanceObservationSnapshot = (params: {
 
   return {
     schema_version: '1',
+    platform_bundles_effective: resolvePlatformBundlesEffective(repoRoot),
+    pre_write_effective: {
+      mode: experimentalFeatures.features.pre_write.mode,
+      source: experimentalFeatures.features.pre_write.source,
+      blocking: experimentalFeatures.features.pre_write.blocking,
+      strict_policy: policyValidation.stages.PRE_WRITE.strict,
+    },
     sdd: {
       experimental_raw: rawSdd && rawSdd.length > 0 ? rawSdd : null,
       effective_mode: experimentalFeatures.features.sdd.mode,
@@ -284,13 +327,13 @@ export const buildGovernanceObservationSummaryLines = (
   snapshot: GovernanceObservationSnapshot
 ): string[] => {
   const lines = [
-    `Governance: ${snapshot.governance_effective.toUpperCase()}`,
     `Contract: AGENTS=${snapshot.contract_surface.agents_md ? 'yes' : 'no'} skills.lock=${snapshot.contract_surface.skills_lock_json ? 'yes' : 'no'} skills.sources=${snapshot.contract_surface.skills_sources_json ? 'yes' : 'no'} vendor/skills=${snapshot.contract_surface.vendor_skills_dir ? 'yes' : 'no'} adapter=${snapshot.contract_surface.pumuki_adapter_json ? 'yes' : 'no'}`,
+    `Governance: ${snapshot.governance_effective.toUpperCase()}`,
+    `Platforms: ${snapshot.platform_bundles_effective?.join(', ') || 'none-detected'}`,
+    `GitFlow: branch=${snapshot.git.current_branch ?? 'unknown'} protected_hint=${snapshot.git.on_protected_branch_hint ? 'yes' : 'no'}`,
     `SDD: env=${snapshot.sdd.experimental_raw ?? '(unset)'} effective=${snapshot.sdd.effective_mode} session_active=${snapshot.sdd_session.active} session_valid=${snapshot.sdd_session.valid} change=${snapshot.sdd_session.change_id ?? 'none'}`,
     `Evidence: readable=${snapshot.evidence.readable} stage=${snapshot.evidence.snapshot_stage ?? 'n/a'} outcome=${snapshot.evidence.snapshot_outcome ?? 'n/a'} ai_gate=${snapshot.evidence.ai_gate_status ?? 'n/a'} findings=${snapshot.evidence.findings_count ?? 'n/a'}`,
-    `GitFlow: branch=${snapshot.git.current_branch ?? 'unknown'} protected_hint=${snapshot.git.on_protected_branch_hint ? 'yes' : 'no'}`,
-    `Tracking: enforced=${snapshot.tracking.enforced} canonical=${snapshot.tracking.canonical_path ?? 'none'} present=${snapshot.tracking.canonical_present} single_active=${snapshot.tracking.single_in_progress_valid ?? 'n/a'} count=${snapshot.tracking.in_progress_count ?? 'n/a'} conflict=${snapshot.tracking.conflict}`,
-    `Policy strict: PRE_WRITE=${snapshot.policy_strict.pre_write} PRE_COMMIT=${snapshot.policy_strict.pre_commit} PRE_PUSH=${snapshot.policy_strict.pre_push} CI=${snapshot.policy_strict.ci}`,
+    `Pre-write: mode=${snapshot.pre_write_effective?.mode ?? 'unknown'} blocking=${snapshot.pre_write_effective?.blocking ? 'yes' : 'no'} strict_policy=${snapshot.pre_write_effective?.strict_policy ? 'yes' : 'no'} source=${snapshot.pre_write_effective?.source ?? 'unknown'}`,
   ];
   if (snapshot.attention_codes.length > 0) {
     lines.push(`Attention: ${snapshot.attention_codes.join(', ')}`);

--- a/scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts
+++ b/scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts
@@ -54,6 +54,13 @@ const buildConsumerPreflightResult = (): ConsumerPreflightResult => ({
   },
   governanceObservation: {
     schema_version: '1',
+    platform_bundles_effective: ['android', 'backend', 'frontend', 'ios'],
+    pre_write_effective: {
+      mode: 'off',
+      source: 'default',
+      blocking: false,
+      strict_policy: true,
+    },
     sdd: {
       experimental_raw: null,
       effective_mode: 'off',
@@ -325,7 +332,10 @@ test('renderConsumerRuntimeModernMenu muestra bloque visible de governance cuand
   });
 
   assert.match(rendered, /Governance Console/);
+  assert.match(rendered, /Contract: AGENTS=yes/);
   assert.match(rendered, /Governance truth:/);
+  assert.match(rendered, /Platforms: android, backend, frontend, ios/);
+  assert.match(rendered, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
   assert.match(rendered, /Governance next action:/);
   assert.match(rendered, /Policy-as-code: PRE_WRITE=POLICY_AS_CODE_VALID strict=yes/);
   assert.match(rendered, /Experimental: ANALYTICS=off/);
@@ -349,6 +359,8 @@ test('renderConsumerRuntimeModernMenu muestra bloque visible de governance aunqu
 
   assert.match(rendered, /Governance Console/);
   assert.match(rendered, /Governance truth:/);
+  assert.match(rendered, /Platforms: android, backend, frontend, ios/);
+  assert.match(rendered, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
   assert.match(rendered, /Governance next action:/);
 });
 


### PR DESCRIPTION
## Resumen
- alinea el orden y los labels visibles del bloque canónico entre `status`, `doctor` y menú
- introduce `Platforms` y `Pre-write` como líneas explícitas en el renderer compartido
- mantiene el mismo frente `S1` sin abrir todavía `Advanced` ni rediseño de MCP

## Validación
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts`
- `8/8` pass

## Siguiente corte
- `S1.c — Unificar next_action y prewrite_effective entre hooks, CLI y MCP con vocabulario canónico compartido`