### PR TITLE
refactor(governance): unify next action and prewrite fields

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1032,9 +1032,9 @@ Decisión hard de cierre:
 
 Último cierre: `[✅] - Adopción útil de pumuki@6.3.98 cerrada en consumers` la release publicada ya quedó integrada en `SAAS`, `Flux` y `RuralGo` y no quedan bugs externos abiertos en los tres MDs consumidores.
 
-Último cierre operativo: `[✅] - Slice S1.b alineada en status, doctor y menú` el bloque canónico compartido ya converge en orden y labels visibles entre `status`, `doctor` y el menú `Consumer`: `Contract`, `Governance`, `Platforms`, `GitFlow`, `SDD`, `Evidence` y `Pre-write` salen del mismo renderer y quedan cubiertos con tests dirigidos en verde (`8/8`) dentro de `refactor/s1-governance-console-v2`.
+Último cierre operativo: `[✅] - Slice S1.c unificada entre hooks, CLI y MCP` `next_action` y `prewrite_effective` ya salen con vocabulario canónico compartido entre hooks, CLI y MCP; el contrato queda cubierto con la suite dirigida en verde (`91/91`) dentro de `refactor/s1-governance-console-v2`.
 
-Tarea activa única: `[🚧] - Slice S1.c — Unificar next_action y prewrite_effective entre hooks, CLI y MCP con vocabulario canónico compartido` tras cerrar la convergencia visual del bloque canónico, el siguiente corte mínimo con más valor visible es unificar la narrativa accionable de bloqueo/remediación entre hooks, CLI y MCP sin abrir todavía un rediseño completo de `Advanced` ni de MCP.
+Tarea activa única: `[🚧] - Slice S1.d — Llevar next_action y prewrite_effective canónicos a Advanced sin divergencias de orden, labels ni estados efectivos` tras cerrar la convergencia de hooks, CLI y MCP, el siguiente corte mínimo con más valor visible es llevar ese mismo vocabulario canónico a `Advanced` para eliminar la última divergencia relevante del frente S1.
 
 Barrido de consumers cerrado:
 - SAAS (`pumuki@6.3.98`): rollout ejecutado en `chore/pumuki-6-3-98-rollout`, follow-up de pin exacto (`52bb5d3`) y PR [#11](https://github.com/SwiftEnProfundidad/app-supermercados/pull/11) ya mergeada en `main` con squash `6bdd18404358319b20b594c3a2193799eabe4dab` (`2026-04-21T19:04:27Z`). `install/status/doctor` convergieron en verde y el hilo de review sobre `^6.3.98` quedó resuelto antes del merge.

--- a/integrations/lifecycle/__tests__/cli.test.ts
+++ b/integrations/lifecycle/__tests__/cli.test.ts
@@ -2170,6 +2170,12 @@ test('runLifecycleCli sdd validate PRE_WRITE con auto-bootstrap deshabilitado ex
     const payload = JSON.parse(printed[printed.length - 1] ?? '{}') as {
       sdd?: { decision?: { code?: string; allowed?: boolean } };
       pre_write_enforcement?: { mode?: string; blocking?: boolean };
+      prewrite_effective?: {
+        mode?: string;
+        source?: string;
+        blocking?: boolean;
+        strict_policy?: boolean;
+      };
       bootstrap?: { enabled?: boolean; attempted?: boolean; status?: string; details?: string };
       reason_code?: string;
       instruction?: string;
@@ -2179,6 +2185,10 @@ test('runLifecycleCli sdd validate PRE_WRITE con auto-bootstrap deshabilitado ex
     assert.equal(payload.sdd?.decision?.code, 'OPENSPEC_MISSING');
     assert.equal(payload.pre_write_enforcement?.mode, 'advisory');
     assert.equal(payload.pre_write_enforcement?.blocking, false);
+    assert.equal(payload.prewrite_effective?.mode, 'advisory');
+    assert.equal(payload.prewrite_effective?.source, 'env');
+    assert.equal(payload.prewrite_effective?.blocking, false);
+    assert.equal(payload.prewrite_effective?.strict_policy, false);
     assert.equal(payload.bootstrap?.enabled, false);
     assert.equal(payload.bootstrap?.attempted, false);
     assert.equal(payload.bootstrap?.status, 'SKIPPED');

--- a/integrations/lifecycle/__tests__/lifecycle.test.ts
+++ b/integrations/lifecycle/__tests__/lifecycle.test.ts
@@ -159,6 +159,7 @@ test('runLifecycleCli PRE_WRITE en modo texto anuncia que el gate fue desactivad
       assert.match(rendered, /PRE_WRITE_EXPERIMENTAL_DISABLED/);
       assert.match(rendered, /está desactivado explícitamente/i);
       assert.match(rendered, /pre-write enforcement: mode=off source=env blocking=no/i);
+      assert.match(rendered, /\[pumuki\]\[sdd\] prewrite_effective: mode=off source=env blocking=no strict_policy=no/i);
       assert.match(rendered, /\[pumuki\]\[sdd\] reason_code=PRE_WRITE_EXPERIMENTAL_DISABLED/);
       assert.match(rendered, /\[pumuki\]\[sdd\] instruction=Activa PRE_WRITE en modo estricto/);
       assert.doesNotMatch(rendered, /\[pumuki\]\[ai-gate\]/);
@@ -197,6 +198,12 @@ test('runLifecycleCli PRE_WRITE --json expone payload determinista cuando el gat
         blocking?: boolean;
         activationVariable?: string;
       };
+      prewrite_effective?: {
+        mode?: string;
+        source?: string;
+        blocking?: boolean;
+        strict_policy?: boolean;
+      };
       experimental_features?: {
         features?: {
           pre_write?: {
@@ -224,6 +231,10 @@ test('runLifecycleCli PRE_WRITE --json expone payload determinista cuando el gat
       assert.equal(payload.pre_write_enforcement?.mode, 'off');
       assert.equal(payload.pre_write_enforcement?.blocking, false);
       assert.equal(payload.pre_write_enforcement?.activationVariable, 'PUMUKI_EXPERIMENTAL_PRE_WRITE');
+      assert.equal(payload.prewrite_effective?.mode, 'off');
+      assert.equal(payload.prewrite_effective?.source, 'env');
+      assert.equal(payload.prewrite_effective?.blocking, false);
+      assert.equal(payload.prewrite_effective?.strict_policy, false);
       assert.equal(payload.experimental_features?.features?.pre_write?.mode, 'off');
       assert.equal(payload.experimental_features?.features?.pre_write?.source, 'env');
       assert.equal(payload.experimental_features?.features?.sdd?.mode, 'off');

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -1588,6 +1588,12 @@ type PreWriteValidationEnvelope = {
   sdd: SddEvaluateResult;
   ai_gate: ReturnType<typeof evaluateAiGate>;
   pre_write_enforcement: PreWriteEnforcementResolution;
+  prewrite_effective: {
+    mode: PreWriteEnforcementResolution['mode'];
+    source: PreWriteEnforcementResolution['source'];
+    blocking: boolean;
+    strict_policy: boolean;
+  };
   experimental_features: LifecycleExperimentalFeaturesSnapshot;
   policy_validation: LifecyclePolicyValidationSnapshot;
   automation: PreWriteAutomationTrace;
@@ -2014,6 +2020,12 @@ export const buildPreWriteValidationEnvelope = (
   sdd: result,
   ai_gate: aiGate,
   pre_write_enforcement: preWriteEnforcement,
+  prewrite_effective: {
+    mode: preWriteEnforcement.mode,
+    source: preWriteEnforcement.source,
+    blocking: preWriteEnforcement.blocking,
+    strict_policy: policyValidation.stages.PRE_WRITE.strict,
+  },
   experimental_features: experimentalFeatures,
   policy_validation: policyValidation,
   automation: {

--- a/integrations/lifecycle/cliSdd.ts
+++ b/integrations/lifecycle/cliSdd.ts
@@ -92,6 +92,12 @@ export const runSddCommand = async (parsed: ParsedArgs, activeDependencies: Life
                   {
                     sdd: disabledResult,
                     pre_write_enforcement: preWriteEnforcement,
+                    prewrite_effective: {
+                      mode: preWriteEnforcement.mode,
+                      source: preWriteEnforcement.source,
+                      blocking: false,
+                      strict_policy: policyValidation.stages.PRE_WRITE.strict,
+                    },
                     experimental_features: experimentalFeatures,
                     policy_validation: policyValidation,
                     automation: {
@@ -129,6 +135,9 @@ export const runSddCommand = async (parsed: ParsedArgs, activeDependencies: Life
               );
               writeInfo(
                 `[pumuki][sdd] pre-write enforcement: mode=${preWriteEnforcement.mode} source=${preWriteEnforcement.source} blocking=no`
+              );
+              writeInfo(
+                `[pumuki][sdd] prewrite_effective: mode=${preWriteEnforcement.mode} source=${preWriteEnforcement.source} blocking=no strict_policy=${policyValidation.stages.PRE_WRITE.strict ? 'yes' : 'no'}`
               );
               writeInfo('[pumuki][sdd] reason_code=PRE_WRITE_EXPERIMENTAL_DISABLED');
               writeInfo(
@@ -273,6 +282,9 @@ export const runSddCommand = async (parsed: ParsedArgs, activeDependencies: Life
               );
               writeInfo(
                 `[pumuki][sdd] pre-write enforcement: mode=${preWriteEnforcement.mode} source=${preWriteEnforcement.source} blocking=${preWriteEnforcement.blocking ? 'yes' : 'no'}`
+              );
+              writeInfo(
+                `[pumuki][sdd] prewrite_effective: mode=${preWriteEnforcement.mode} source=${preWriteEnforcement.source} blocking=${preWriteEnforcement.blocking ? 'yes' : 'no'} strict_policy=${policyValidation.stages.PRE_WRITE.strict ? 'yes' : 'no'}`
               );
               if (preWriteBootstrapTrace.details) {
                 writeInfo(

--- a/integrations/mcp/__tests__/aiGateCheck.test.ts
+++ b/integrations/mcp/__tests__/aiGateCheck.test.ts
@@ -116,6 +116,10 @@ test('runEnterpriseAiGateCheck aplica contrato de tool ai_gate_check en PRE_WRIT
     assert.equal(result.result.message.length > 0, true);
     assert.equal(result.result.reason_code, 'AI_GATE_ALLOWED');
     assert.equal(result.result.instruction.length > 0, true);
+    assert.equal(typeof result.result.prewrite_effective.mode, 'string');
+    assert.equal(typeof result.result.prewrite_effective.source, 'string');
+    assert.equal(typeof result.result.prewrite_effective.blocking, 'boolean');
+    assert.equal(typeof result.result.prewrite_effective.strict_policy, 'boolean');
     assert.equal(result.result.next_action.reason, 'AI_GATE_ALLOWED');
     assert.equal(result.result.next_action.kind, 'info');
     assert.equal(result.result.next_action.message.length > 0, true);

--- a/integrations/mcp/__tests__/enterpriseServer.test.ts
+++ b/integrations/mcp/__tests__/enterpriseServer.test.ts
@@ -272,6 +272,12 @@ test('enterprise server ejecuta tools enterprise en safe mode cuando MCP enterpr
           result?: {
             reason_code?: string;
             instruction?: string;
+            prewrite_effective?: {
+              mode?: string;
+              source?: string;
+              blocking?: boolean;
+              strict_policy?: boolean;
+            };
             next_action?: {
               reason?: string;
               kind?: string;
@@ -285,6 +291,10 @@ test('enterprise server ejecuta tools enterprise en safe mode cuando MCP enterpr
         assert.equal(aiGatePayload.executed, true);
         assert.equal(typeof aiGatePayload.result?.reason_code, 'string');
         assert.equal((aiGatePayload.result?.instruction ?? '').length > 0, true);
+        assert.equal(typeof aiGatePayload.result?.prewrite_effective?.mode, 'string');
+        assert.equal(typeof aiGatePayload.result?.prewrite_effective?.source, 'string');
+        assert.equal(typeof aiGatePayload.result?.prewrite_effective?.blocking, 'boolean');
+        assert.equal(typeof aiGatePayload.result?.prewrite_effective?.strict_policy, 'boolean');
         assert.equal(typeof aiGatePayload.result?.next_action?.reason, 'string');
         assert.equal(aiGatePayload.result?.next_action?.kind, 'info');
         assert.equal((aiGatePayload.result?.next_action?.message ?? '').length > 0, true);
@@ -307,11 +317,29 @@ test('enterprise server ejecuta tools enterprise en safe mode cuando MCP enterpr
           success?: boolean;
           dryRun?: boolean;
           executed?: boolean;
+          result?: {
+            prewrite_effective?: {
+              mode?: string;
+              source?: string;
+              blocking?: boolean;
+              strict_policy?: boolean;
+            };
+            next_action?: {
+              kind?: string;
+              message?: string;
+            };
+          };
         };
         assert.equal(preFlightPayload.tool, 'pre_flight_check');
         assert.equal(preFlightPayload.success, false);
         assert.equal(preFlightPayload.dryRun, true);
         assert.equal(preFlightPayload.executed, true);
+        assert.equal(typeof preFlightPayload.result?.prewrite_effective?.mode, 'string');
+        assert.equal(typeof preFlightPayload.result?.prewrite_effective?.source, 'string');
+        assert.equal(typeof preFlightPayload.result?.prewrite_effective?.blocking, 'boolean');
+        assert.equal(typeof preFlightPayload.result?.prewrite_effective?.strict_policy, 'boolean');
+        assert.equal(typeof preFlightPayload.result?.next_action?.kind, 'string');
+        assert.equal((preFlightPayload.result?.next_action?.message ?? '').length > 0, true);
 
         const autoExecuteResponse = await safeFetchRequest(`${baseUrl}/tool`, {
           method: 'POST',

--- a/integrations/mcp/aiGateCheck.ts
+++ b/integrations/mcp/aiGateCheck.ts
@@ -1,6 +1,8 @@
 import { evaluateAiGate, type AiGateStage } from '../gate/evaluateAiGate';
 import { resolveRemediationHintForViolationCode } from '../gate/remediationCatalog';
+import { readLifecyclePolicyValidationSnapshot } from '../lifecycle/policyValidationSnapshot';
 import { resolveLearningContextExperimentalFeature } from '../policy/experimentalFeatures';
+import { resolvePreWriteEnforcement } from '../policy/preWriteEnforcement';
 import { readSddLearningContext, type SddLearningContext } from '../sdd/learningInsights';
 import { runMcpAlignedPlatformGate } from './alignedPlatformGate';
 
@@ -26,6 +28,12 @@ export type EnterpriseAiGateCheckResult = {
     message: string;
     reason_code: string;
     instruction: string;
+    prewrite_effective: {
+      mode: ReturnType<typeof resolvePreWriteEnforcement>['mode'];
+      source: ReturnType<typeof resolvePreWriteEnforcement>['source'];
+      blocking: boolean;
+      strict_policy: boolean;
+    };
     next_action: {
       kind: 'info';
       reason: string;
@@ -224,6 +232,8 @@ export const runEnterpriseAiGateCheck = (params: {
     : readSddLearningContext({
       repoRoot: params.repoRoot,
     });
+  const preWriteEnforcement = resolvePreWriteEnforcement();
+  const policyValidation = readLifecyclePolicyValidationSnapshot(params.repoRoot);
   const warnings = buildWarnings(evaluation);
   const autoFixes = buildAutoFixes(evaluation, learningContext);
   const message = buildMessage(evaluation);
@@ -241,6 +251,12 @@ export const runEnterpriseAiGateCheck = (params: {
       message,
       reason_code: buildReasonCode(evaluation),
       instruction: buildInstruction(evaluation),
+      prewrite_effective: {
+        mode: preWriteEnforcement.mode,
+        source: preWriteEnforcement.source,
+        blocking: preWriteEnforcement.blocking,
+        strict_policy: policyValidation.stages.PRE_WRITE.strict,
+      },
       next_action: buildNextAction(evaluation, autoFixes),
       stage: evaluation.stage,
       policy: evaluation.policy,
@@ -310,6 +326,8 @@ export const runEnterpriseAiGateCheckAsync = async (params: {
   const warnings = buildWarnings(evaluationForHints);
   const autoFixes = buildAutoFixes(evaluationForHints, learningContext);
   const message = buildMessage(evaluationForHints, platform);
+  const preWriteEnforcement = resolvePreWriteEnforcement();
+  const policyValidation = readLifecyclePolicyValidationSnapshot(params.repoRoot);
 
   return {
     tool: 'ai_gate_check',
@@ -324,6 +342,12 @@ export const runEnterpriseAiGateCheckAsync = async (params: {
       message,
       reason_code: buildReasonCode(evaluationForHints),
       instruction: buildInstruction(evaluationForHints),
+      prewrite_effective: {
+        mode: preWriteEnforcement.mode,
+        source: preWriteEnforcement.source,
+        blocking: preWriteEnforcement.blocking,
+        strict_policy: policyValidation.stages.PRE_WRITE.strict,
+      },
       next_action: buildNextAction(evaluationForHints, autoFixes),
       stage: evaluation.stage,
       policy: evaluation.policy,

--- a/integrations/mcp/preFlightCheck.ts
+++ b/integrations/mcp/preFlightCheck.ts
@@ -4,7 +4,9 @@ import {
 } from '../gate/governanceActionCatalog';
 import { evaluateAiGate, type AiGateStage, type AiGateViolation } from '../gate/evaluateAiGate';
 import { collectWorktreeAtomicSlices } from '../git/worktreeAtomicSlices';
+import { readLifecyclePolicyValidationSnapshot } from '../lifecycle/policyValidationSnapshot';
 import { resolveLearningContextExperimentalFeature } from '../policy/experimentalFeatures';
+import { resolvePreWriteEnforcement } from '../policy/preWriteEnforcement';
 import { readSddLearningContext, type SddLearningContext } from '../sdd/learningInsights';
 
 const ACTIONABLE_HINTS_BY_CODE: Readonly<Record<string, string>> = {
@@ -141,6 +143,12 @@ export type EnterprisePreFlightCheckResult = {
     message: string;
     instruction: string;
     reason_code: string;
+    prewrite_effective: {
+      mode: ReturnType<typeof resolvePreWriteEnforcement>['mode'];
+      source: ReturnType<typeof resolvePreWriteEnforcement>['source'];
+      blocking: boolean;
+      strict_policy: boolean;
+    };
     next_action: GovernanceCatalogNextAction;
     stage: ReturnType<typeof evaluateAiGate>['stage'];
     policy: ReturnType<typeof evaluateAiGate>['policy'];
@@ -172,6 +180,8 @@ export const runEnterprisePreFlightCheck = (params: {
     : readSddLearningContext({
       repoRoot: params.repoRoot,
     });
+  const preWriteEnforcement = resolvePreWriteEnforcement();
+  const policyValidation = readLifecyclePolicyValidationSnapshot(params.repoRoot);
 
   const hints = buildPreFlightHints({
     repoRoot: params.repoRoot,
@@ -218,6 +228,12 @@ export const runEnterprisePreFlightCheck = (params: {
       message,
       instruction,
       reason_code: reasonCode,
+      prewrite_effective: {
+        mode: preWriteEnforcement.mode,
+        source: preWriteEnforcement.source,
+        blocking: preWriteEnforcement.blocking,
+        strict_policy: policyValidation.stages.PRE_WRITE.strict,
+      },
       next_action: nextAction,
       stage: evaluation.stage,
       policy: evaluation.policy,


### PR DESCRIPTION
## Summary
- unifica `prewrite_effective` entre hooks, CLI y MCP
- alinea `next_action` y la narrativa canónica de PRE_WRITE en los contratos visibles
- deja `S1.c` cubierto con regresión dirigida en lifecycle y enterprise MCP

## Validation
- `npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/cli.test.ts integrations/lifecycle/__tests__/lifecycle.test.ts integrations/mcp/__tests__/aiGateCheck.test.ts integrations/mcp/__tests__/enterpriseServer.test.ts`