### PR TITLE
refactor(governance): align advanced menu canonical console

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1032,9 +1032,9 @@ Decisión hard de cierre:
 
 Último cierre: `[✅] - Adopción útil de pumuki@6.3.98 cerrada en consumers` la release publicada ya quedó integrada en `SAAS`, `Flux` y `RuralGo` y no quedan bugs externos abiertos en los tres MDs consumidores.
 
-Último cierre operativo: `[✅] - Slice S1.c unificada entre hooks, CLI y MCP` `next_action` y `prewrite_effective` ya salen con vocabulario canónico compartido entre hooks, CLI y MCP; el contrato queda cubierto con la suite dirigida en verde (`91/91`) dentro de `refactor/s1-governance-console-v2`.
+Último cierre operativo: `[✅] - Slice S1.d alineada en Advanced` `next_action` y `prewrite_effective` ya salen con el mismo bloque canónico en `Advanced`, tanto en modo UI v2 como en fallback clásico y también en frío; la superficie visible queda cubierta con tests dirigidos en verde (`14/14`) dentro de `refactor/s1-governance-console-v2`.
 
-Tarea activa única: `[🚧] - Slice S1.d — Llevar next_action y prewrite_effective canónicos a Advanced sin divergencias de orden, labels ni estados efectivos` tras cerrar la convergencia de hooks, CLI y MCP, el siguiente corte mínimo con más valor visible es llevar ese mismo vocabulario canónico a `Advanced` para eliminar la última divergencia relevante del frente S1.
+Tarea activa única: `[🚧] - Slice S1.e — Cerrar S1 con validación end-to-end de Consumer y Advanced sobre la consola de governance unificada` tras eliminar la última divergencia visible de `Advanced`, el siguiente corte mínimo con valor real es dejar validada de extremo a extremo la convergencia entre `Consumer` y `Advanced` sobre la misma consola unificada antes de dar S1 por cerrada.
 
 Barrido de consumers cerrado:
 - SAAS (`pumuki@6.3.98`): rollout ejecutado en `chore/pumuki-6-3-98-rollout`, follow-up de pin exacto (`52bb5d3`) y PR [#11](https://github.com/SwiftEnProfundidad/app-supermercados/pull/11) ya mergeada en `main` con squash `6bdd18404358319b20b594c3a2193799eabe4dab` (`2026-04-21T19:04:27Z`). `install/status/doctor` convergieron en verde y el hilo de review sobre `^6.3.98` quedó resuelto antes del merge.

--- a/scripts/__tests__/framework-menu-advanced-view-menu.test.ts
+++ b/scripts/__tests__/framework-menu-advanced-view-menu.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../framework-menu-advanced-view-lib';
 import { createFrameworkMenuPrompts } from '../framework-menu-prompts';
 import type { ConsumerPreflightResult } from '../framework-menu-consumer-preflight-types';
+import type { GovernanceConsoleSnapshot } from '../../integrations/lifecycle/cliGovernanceConsole';
 
 const noop = async (): Promise<void> => {};
 
@@ -72,6 +73,12 @@ const buildConsumerPreflightResult = (): ConsumerPreflightResult => ({
   },
   governanceObservation: {
     schema_version: '1',
+    pre_write_effective: {
+      mode: 'off',
+      source: 'default',
+      blocking: false,
+      strict_policy: true,
+    },
     sdd: {
       experimental_raw: null,
       effective_mode: 'off',
@@ -202,6 +209,16 @@ const buildConsumerPreflightResult = (): ConsumerPreflightResult => ({
   notificationResults: [],
 });
 
+const buildGovernanceConsoleSnapshot = (): GovernanceConsoleSnapshot => {
+  const preflight = buildConsumerPreflightResult();
+  return {
+    governanceObservation: preflight.governanceObservation,
+    governanceNextAction: preflight.governanceNextAction,
+    policyValidation: preflight.policyValidation,
+    experimentalFeatures: preflight.experimentalFeatures,
+  };
+};
+
 test('formatAdvancedMenuView renderiza secciones por dominio y ayuda contextual corta', () => {
   const rendered = formatAdvancedMenuView(buildAdvancedActions(), {
     evidenceSummary: {
@@ -278,6 +295,9 @@ test('formatAdvancedMenuView muestra bloque visible de governance cuando existe 
   assert.match(rendered, /Governance Console/);
   assert.match(rendered, /Governance truth:/);
   assert.match(rendered, /Governance next action:/);
+  assert.match(rendered, /Next action: stage=PRE_COMMIT phase=GREEN action=proceed confidence=90%/);
+  assert.match(rendered, /reason=READY/);
+  assert.match(rendered, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
   assert.match(rendered, /Policy-as-code: PRE_WRITE=POLICY_AS_CODE_VALID strict=yes/);
   assert.match(rendered, /Experimental: ANALYTICS=off/);
 });
@@ -298,4 +318,64 @@ test('formatAdvancedMenuClassicView conserva formato legacy sin panel agrupado',
   assert.match(rendered, /C\. Switch to consumer menu/);
   assert.match(rendered, /1\.\s+Evaluate staged changes/);
   assert.match(rendered, /27\.\s+Exit/);
+});
+
+test('formatAdvancedMenuView muestra bloque canónico de governance también en frío', () => {
+  const rendered = formatAdvancedMenuView(buildAdvancedActions(), {
+    evidenceSummary: {
+      status: 'ok',
+      stage: 'PRE_COMMIT',
+      outcome: 'PASS',
+      totalFindings: 0,
+      bySeverity: { CRITICAL: 0, ERROR: 0, WARN: 0, INFO: 0 },
+      topFiles: [],
+    },
+    governanceConsole: buildGovernanceConsoleSnapshot(),
+  });
+
+  assert.match(rendered, /Governance Console/);
+  assert.match(rendered, /Governance truth:/);
+  assert.match(rendered, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
+  assert.match(rendered, /Next action: stage=PRE_COMMIT phase=GREEN action=proceed confidence=90%/);
+  assert.match(rendered, /reason=READY/);
+});
+
+test('formatAdvancedMenuClassicView muestra bloque canónico de governance cuando existe preflight', () => {
+  const rendered = formatAdvancedMenuClassicView(buildAdvancedActions(), {
+    evidenceSummary: {
+      status: 'ok',
+      stage: 'PRE_COMMIT',
+      outcome: 'PASS',
+      totalFindings: 0,
+      bySeverity: { CRITICAL: 0, ERROR: 0, WARN: 0, INFO: 0 },
+      topFiles: [],
+    },
+    preflight: buildConsumerPreflightResult(),
+  });
+
+  assert.match(rendered, /Governance Console/);
+  assert.match(rendered, /Governance truth:/);
+  assert.match(rendered, /Governance next action:/);
+  assert.match(rendered, /Next action: stage=PRE_COMMIT phase=GREEN action=proceed confidence=90% reason=READY/);
+  assert.match(rendered, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
+  assert.match(rendered, /C\. Switch to consumer menu/);
+});
+
+test('formatAdvancedMenuClassicView muestra bloque canónico de governance también en frío', () => {
+  const rendered = formatAdvancedMenuClassicView(buildAdvancedActions(), {
+    evidenceSummary: {
+      status: 'ok',
+      stage: 'PRE_COMMIT',
+      outcome: 'PASS',
+      totalFindings: 0,
+      bySeverity: { CRITICAL: 0, ERROR: 0, WARN: 0, INFO: 0 },
+      topFiles: [],
+    },
+    governanceConsole: buildGovernanceConsoleSnapshot(),
+  });
+
+  assert.match(rendered, /Governance Console/);
+  assert.match(rendered, /Governance truth:/);
+  assert.match(rendered, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
+  assert.match(rendered, /Next action: stage=PRE_COMMIT phase=GREEN action=proceed confidence=90% reason=READY/);
 });

--- a/scripts/framework-menu-advanced-view-lib.ts
+++ b/scripts/framework-menu-advanced-view-lib.ts
@@ -19,7 +19,10 @@ import {
   renderActionRow,
   renderBadge,
 } from './framework-menu-ui-components-lib';
-import { buildGovernanceConsoleSummaryLines } from '../integrations/lifecycle/cliGovernanceConsole';
+import {
+  buildGovernanceConsoleSummaryLines,
+  type GovernanceConsoleSnapshot,
+} from '../integrations/lifecycle/cliGovernanceConsole';
 import type { ConsumerPreflightResult } from './framework-menu-consumer-preflight-types';
 
 export const formatAdvancedMenuView = (
@@ -27,23 +30,32 @@ export const formatAdvancedMenuView = (
   options?: {
     evidenceSummary?: FrameworkMenuEvidenceSummary;
     preflight?: ConsumerPreflightResult | null;
+    governanceConsole?: GovernanceConsoleSnapshot | null;
   }
 ): string => {
   const evidenceSummary = options?.evidenceSummary ?? readEvidenceSummaryForMenu(process.cwd());
   const tokens = buildCliDesignTokens();
   const statusBadge = resolveAdvancedStatusBadge(evidenceSummary, tokens);
   const groupedActions = resolveAdvancedMenuLayout(actions);
+  const governanceConsole = options?.preflight
+    ? {
+      governanceObservation: options.preflight.governanceObservation,
+      governanceNextAction: options.preflight.governanceNextAction,
+      policyValidation: options.preflight.policyValidation,
+      experimentalFeatures: options.preflight.experimentalFeatures,
+    }
+    : (options?.governanceConsole ?? null);
   const lines = [
     'Pumuki Framework Menu (Advanced)',
     `Status: ${statusBadge}`,
-    ...(options?.preflight
+    ...(governanceConsole
       ? [
         'Governance Console',
         ...buildGovernanceConsoleSummaryLines({
-          governanceObservation: options.preflight.governanceObservation,
-          governanceNextAction: options.preflight.governanceNextAction,
-          policyValidation: options.preflight.policyValidation,
-          experimentalFeatures: options.preflight.experimentalFeatures,
+          governanceObservation: governanceConsole.governanceObservation,
+          governanceNextAction: governanceConsole.governanceNextAction,
+          policyValidation: governanceConsole.policyValidation,
+          experimentalFeatures: governanceConsole.experimentalFeatures,
         }).map((line) => `  ${line}`),
         '',
       ]
@@ -75,11 +87,33 @@ export const formatAdvancedMenuClassicView = (
   actions: ReadonlyArray<MenuAction>,
   options?: {
     evidenceSummary?: FrameworkMenuEvidenceSummary;
+    preflight?: ConsumerPreflightResult | null;
+    governanceConsole?: GovernanceConsoleSnapshot | null;
   }
 ): string => {
   const evidenceSummary = options?.evidenceSummary ?? readEvidenceSummaryForMenu(process.cwd());
+  const governanceConsole = options?.preflight
+    ? {
+      governanceObservation: options.preflight.governanceObservation,
+      governanceNextAction: options.preflight.governanceNextAction,
+      policyValidation: options.preflight.policyValidation,
+      experimentalFeatures: options.preflight.experimentalFeatures,
+    }
+    : (options?.governanceConsole ?? null);
   const lines = [
     'Pumuki Framework Menu (Advanced)',
+    ...(governanceConsole
+      ? [
+        'Governance Console',
+        ...buildGovernanceConsoleSummaryLines({
+          governanceObservation: governanceConsole.governanceObservation,
+          governanceNextAction: governanceConsole.governanceNextAction,
+          policyValidation: governanceConsole.policyValidation,
+          experimentalFeatures: governanceConsole.experimentalFeatures,
+        }).map((line) => `  ${line}`),
+        '',
+      ]
+      : []),
     'C. Switch to consumer menu',
     ...actions.map((action) => {
       const help = ADVANCED_MENU_HELP[action.id];

--- a/scripts/framework-menu.ts
+++ b/scripts/framework-menu.ts
@@ -24,6 +24,8 @@ import {
   loadAndFormatActiveSkillsBundles,
 } from './framework-menu-skills-lib';
 import { isMenuUiV2Enabled } from './framework-menu-ui-version-lib';
+import { readLifecycleStatus } from '../integrations/lifecycle/status';
+import type { GovernanceConsoleSnapshot } from '../integrations/lifecycle/cliGovernanceConsole';
 export * from './framework-menu-builders';
 export { formatAdvancedMenuView } from './framework-menu-advanced-view-lib';
 export { buildMenuGateParams } from './framework-menu-gate-lib';
@@ -40,6 +42,20 @@ const resolveInitialMenuMode = (): MenuMode => {
     return 'advanced';
   }
   return 'consumer';
+};
+
+const readAdvancedGovernanceConsoleSnapshot = (): GovernanceConsoleSnapshot | null => {
+  try {
+    const status = readLifecycleStatus({ cwd: process.cwd() });
+    return {
+      governanceObservation: status.governanceObservation,
+      governanceNextAction: status.governanceNextAction,
+      policyValidation: status.policyValidation,
+      experimentalFeatures: status.experimentalFeatures,
+    };
+  } catch {
+    return null;
+  }
 };
 
 const menu = async (): Promise<void> => {
@@ -74,10 +90,13 @@ const menu = async (): Promise<void> => {
       } else {
         const currentSummary = consumerRuntime.readCurrentSummary();
         const lastPreflight = consumerRuntime.readLastPreflight();
+        const governanceConsole = lastPreflight ? null : readAdvancedGovernanceConsoleSnapshot();
         if (!isMenuUiV2Enabled()) {
           output.write(
             `\n${formatAdvancedMenuClassicView(advancedActions, {
               evidenceSummary: currentSummary ?? undefined,
+              preflight: lastPreflight ?? undefined,
+              governanceConsole: governanceConsole ?? undefined,
             })}\n`
           );
         } else {
@@ -86,6 +105,7 @@ const menu = async (): Promise<void> => {
               `\n${formatAdvancedMenuView(advancedActions, {
                 evidenceSummary: currentSummary ?? undefined,
                 preflight: lastPreflight ?? undefined,
+                governanceConsole: governanceConsole ?? undefined,
               })}\n`
             );
           } catch {
@@ -93,6 +113,8 @@ const menu = async (): Promise<void> => {
             output.write(
               `\n${formatAdvancedMenuClassicView(advancedActions, {
                 evidenceSummary: currentSummary ?? undefined,
+                preflight: lastPreflight ?? undefined,
+                governanceConsole: governanceConsole ?? undefined,
               })}\n`
             );
           }


### PR DESCRIPTION
## Summary
- alinea el menú Advanced con el bloque canónico de governance
- lleva `next_action` y `prewrite_effective` a la vista Advanced también en frío
- mantiene convergencia entre UI v2 y fallback clásico

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-advanced-view-menu.test.ts scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts`