### PR TITLE
test(governance): close s1 console convergence

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1032,9 +1032,9 @@ Decisión hard de cierre:
 
 Último cierre: `[✅] - Adopción útil de pumuki@6.3.98 cerrada en consumers` la release publicada ya quedó integrada en `SAAS`, `Flux` y `RuralGo` y no quedan bugs externos abiertos en los tres MDs consumidores.
 
-Último cierre operativo: `[✅] - Slice S1.d alineada en Advanced` `next_action` y `prewrite_effective` ya salen con el mismo bloque canónico en `Advanced`, tanto en modo UI v2 como en fallback clásico y también en frío; la superficie visible queda cubierta con tests dirigidos en verde (`14/14`) dentro de `refactor/s1-governance-console-v2`.
+Último cierre operativo: `[✅] - S1 governance console unificada cerrada` la convergencia entre `Consumer` y `Advanced` ya queda validada de extremo a extremo sobre la misma consola de governance unificada; el cierre queda cubierto con la suite dirigida en verde (`19/19`) dentro de `refactor/s1-governance-console-v2`.
 
-Tarea activa única: `[🚧] - Slice S1.e — Cerrar S1 con validación end-to-end de Consumer y Advanced sobre la consola de governance unificada` tras eliminar la última divergencia visible de `Advanced`, el siguiente corte mínimo con valor real es dejar validada de extremo a extremo la convergencia entre `Consumer` y `Advanced` sobre la misma consola unificada antes de dar S1 por cerrada.
+Tarea activa única: `[🚧] - Slice S2.a — Elevar la consola de governance unificada a smoke contractual cruzado entre menú, CLI y MCP` tras cerrar S1, el siguiente corte mínimo con valor real es convertir esta convergencia en smoke contractual cruzado entre superficies para congelar el contrato compartido.
 
 Barrido de consumers cerrado:
 - SAAS (`pumuki@6.3.98`): rollout ejecutado en `chore/pumuki-6-3-98-rollout`, follow-up de pin exacto (`52bb5d3`) y PR [#11](https://github.com/SwiftEnProfundidad/app-supermercados/pull/11) ya mergeada en `main` con squash `6bdd18404358319b20b594c3a2193799eabe4dab` (`2026-04-21T19:04:27Z`). `install/status/doctor` convergieron en verde y el hilo de review sobre `^6.3.98` quedó resuelto antes del merge.

--- a/scripts/__tests__/framework-menu-cli-runtime.test.ts
+++ b/scripts/__tests__/framework-menu-cli-runtime.test.ts
@@ -2,18 +2,38 @@ import { spawnSync } from 'node:child_process';
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
 
-const runFrameworkMenu = (env: NodeJS.ProcessEnv) =>
+const runFrameworkMenu = (params?: {
+  env?: NodeJS.ProcessEnv;
+  input?: string;
+}) =>
   spawnSync(process.execPath, ['bin/pumuki-framework.js'], {
     cwd: process.cwd(),
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...(params?.env ?? {}) },
     encoding: 'utf8',
-    input: '10\n',
+    input: params?.input ?? '10\n',
   });
+
+const assertCanonicalGovernanceConsole = (stdout: string): void => {
+  assert.match(stdout, /Governance Console/);
+  assert.match(stdout, /Governance truth:/);
+  assert.match(stdout, /Governance next action:/);
+  assert.match(
+    stdout,
+    /Pre-write: mode=.* blocking=(yes|no) strict_policy=(yes|no) source=.*/i,
+  );
+  assert.match(
+    stdout,
+    /Next action: stage=.* phase=.* action=.* confidence=.*/i,
+  );
+  assert.match(stdout, /reason=.*/i);
+};
 
 test('framework menu CLI exits cleanly in classic mode', () => {
   const result = runFrameworkMenu({
-    PUMUKI_MENU_UI_V2: '0',
-    PUMUKI_MENU_COLOR: '0',
+    env: {
+      PUMUKI_MENU_UI_V2: '0',
+      PUMUKI_MENU_COLOR: '0',
+    },
   });
 
   assert.equal(
@@ -26,8 +46,10 @@ test('framework menu CLI exits cleanly in classic mode', () => {
 
 test('framework menu CLI exits cleanly in modern mode', () => {
   const result = runFrameworkMenu({
-    PUMUKI_MENU_UI_V2: '1',
-    PUMUKI_MENU_COLOR: '0',
+    env: {
+      PUMUKI_MENU_UI_V2: '1',
+      PUMUKI_MENU_COLOR: '0',
+    },
   });
 
   assert.equal(
@@ -36,4 +58,56 @@ test('framework menu CLI exits cleanly in modern mode', () => {
     `framework menu modern mode must exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   );
   assert.ok(!result.stderr.includes('ReferenceError'));
+});
+
+test('framework menu CLI consumer renderiza la consola canónica de governance', () => {
+  const result = runFrameworkMenu({
+    env: {
+      PUMUKI_MENU_UI_V2: '1',
+      PUMUKI_MENU_COLOR: '0',
+    },
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `framework menu consumer must exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assertCanonicalGovernanceConsole(result.stdout);
+});
+
+test('framework menu CLI advanced renderiza la consola canónica de governance en frío', () => {
+  const result = runFrameworkMenu({
+    env: {
+      PUMUKI_MENU_MODE: 'advanced',
+      PUMUKI_MENU_UI_V2: '1',
+      PUMUKI_MENU_COLOR: '0',
+    },
+    input: '27\n',
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `framework menu advanced must exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assertCanonicalGovernanceConsole(result.stdout);
+});
+
+test('framework menu CLI advanced clásico renderiza la consola canónica de governance en frío', () => {
+  const result = runFrameworkMenu({
+    env: {
+      PUMUKI_MENU_MODE: 'advanced',
+      PUMUKI_MENU_UI_V2: '0',
+      PUMUKI_MENU_COLOR: '0',
+    },
+    input: '27\n',
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `framework menu advanced classic must exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assertCanonicalGovernanceConsole(result.stdout);
 });


### PR DESCRIPTION
## Summary
- cierra S1 con validación end-to-end de Consumer y Advanced
- verifica la misma consola canónica de governance desde el menú CLI real
- deja preparado el siguiente frente contractual sobre menú, CLI y MCP

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-cli-runtime.test.ts scripts/__tests__/framework-menu-advanced-view-menu.test.ts scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts`