### PR TITLE
test(governance): add cross-surface contract smoke

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1032,9 +1032,9 @@ Decisión hard de cierre:
 
 Último cierre: `[✅] - Adopción útil de pumuki@6.3.98 cerrada en consumers` la release publicada ya quedó integrada en `SAAS`, `Flux` y `RuralGo` y no quedan bugs externos abiertos en los tres MDs consumidores.
 
-Último cierre operativo: `[✅] - S1 governance console unificada cerrada` la convergencia entre `Consumer` y `Advanced` ya queda validada de extremo a extremo sobre la misma consola de governance unificada; el cierre queda cubierto con la suite dirigida en verde (`19/19`) dentro de `refactor/s1-governance-console-v2`.
+Último cierre operativo: `[✅] - Slice S2.a smoke contractual cruzado entre menú, CLI y MCP` la consola de governance unificada ya queda congelada con un smoke contractual que cruza menú real, CLI real y MCP sobre el mismo contrato visible de `Pre-write` y `Next action`; el cierre queda cubierto con la suite dirigida en verde (`6/6`) dentro de `refactor/s1-governance-console-v2`.
 
-Tarea activa única: `[🚧] - Slice S2.a — Elevar la consola de governance unificada a smoke contractual cruzado entre menú, CLI y MCP` tras cerrar S1, el siguiente corte mínimo con valor real es convertir esta convergencia en smoke contractual cruzado entre superficies para congelar el contrato compartido.
+Tarea activa única: `[🚧] - Slice S2.b — Extender el smoke contractual de governance a status, doctor y ai_gate_check` tras congelar el contrato entre menú, CLI y MCP, el siguiente corte mínimo con valor real es cubrir también `status`, `doctor` y `ai_gate_check` para cerrar el perímetro contractual principal de governance.
 
 Barrido de consumers cerrado:
 - SAAS (`pumuki@6.3.98`): rollout ejecutado en `chore/pumuki-6-3-98-rollout`, follow-up de pin exacto (`52bb5d3`) y PR [#11](https://github.com/SwiftEnProfundidad/app-supermercados/pull/11) ya mergeada en `main` con squash `6bdd18404358319b20b594c3a2193799eabe4dab` (`2026-04-21T19:04:27Z`). `install/status/doctor` convergieron en verde y el hilo de review sobre `^6.3.98` quedó resuelto antes del merge.

--- a/scripts/__tests__/governance-console-cross-surface-smoke.test.ts
+++ b/scripts/__tests__/governance-console-cross-surface-smoke.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { readLifecycleStatus } from '../../integrations/lifecycle/status';
+import { runEnterprisePreFlightCheck } from '../../integrations/mcp/preFlightCheck';
+
+const runFrameworkMenuCli = () =>
+  spawnSync(process.execPath, ['bin/pumuki-framework.js'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PUMUKI_MENU_MODE: 'advanced',
+      PUMUKI_MENU_UI_V2: '1',
+      PUMUKI_MENU_COLOR: '0',
+    },
+    encoding: 'utf8',
+    input: '27\n',
+  });
+
+const runLifecycleStatusCli = () =>
+  spawnSync(process.execPath, ['bin/pumuki.js', 'status'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PUMUKI_MENU_COLOR: '0',
+    },
+    encoding: 'utf8',
+  });
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const toYesNo = (value: boolean): 'yes' | 'no' => (value ? 'yes' : 'no');
+
+test('governance console mantiene contrato cruzado entre menu, cli y mcp', () => {
+  const lifecycleStatus = readLifecycleStatus({ cwd: process.cwd() });
+  const preWriteEffective = lifecycleStatus.governanceObservation.pre_write_effective;
+  assert.ok(preWriteEffective);
+
+  const preFlight = runEnterprisePreFlightCheck({
+    repoRoot: process.cwd(),
+    stage: 'PRE_WRITE',
+  });
+
+  assert.equal(preFlight.result.prewrite_effective.mode, preWriteEffective.mode);
+  assert.equal(preFlight.result.prewrite_effective.source, preWriteEffective.source);
+  assert.equal(preFlight.result.prewrite_effective.blocking, preWriteEffective.blocking);
+  assert.equal(preFlight.result.prewrite_effective.strict_policy, preWriteEffective.strict_policy);
+  assert.equal(typeof preFlight.result.reason_code, 'string');
+  assert.equal(preFlight.result.reason_code.length > 0, true);
+  assert.equal(typeof preFlight.result.instruction, 'string');
+  assert.equal(preFlight.result.instruction.length > 0, true);
+  assert.equal(typeof preFlight.result.next_action.kind, 'string');
+  assert.equal(typeof preFlight.result.next_action.message, 'string');
+  assert.equal(preFlight.result.next_action.message.length > 0, true);
+
+  const expectedPreWriteLine =
+    `Pre-write: mode=${preWriteEffective.mode} ` +
+    `blocking=${toYesNo(preWriteEffective.blocking)} ` +
+    `strict_policy=${toYesNo(preWriteEffective.strict_policy)} ` +
+    `source=${preWriteEffective.source}`;
+  const expectedReason = `reason=${lifecycleStatus.governanceNextAction.reason_code}`;
+  const expectedInstruction = `Instruction: ${lifecycleStatus.governanceNextAction.instruction}`;
+
+  const menuCli = runFrameworkMenuCli();
+  assert.equal(
+    menuCli.status,
+    0,
+    `framework menu smoke must exit 0\nstdout:\n${menuCli.stdout}\nstderr:\n${menuCli.stderr}`,
+  );
+  assert.match(menuCli.stdout, new RegExp(escapeRegExp(expectedPreWriteLine)));
+  assert.match(menuCli.stdout, new RegExp(escapeRegExp(expectedReason)));
+  assert.match(menuCli.stdout, new RegExp(escapeRegExp(expectedInstruction)));
+
+  const statusCli = runLifecycleStatusCli();
+  assert.equal(
+    statusCli.status,
+    0,
+    `lifecycle status smoke must exit 0\nstdout:\n${statusCli.stdout}\nstderr:\n${statusCli.stderr}`,
+  );
+  assert.match(statusCli.stdout, new RegExp(escapeRegExp(expectedPreWriteLine)));
+  assert.match(statusCli.stdout, new RegExp(escapeRegExp(expectedReason)));
+  assert.match(statusCli.stdout, new RegExp(escapeRegExp(expectedInstruction)));
+});


### PR DESCRIPTION
## Summary
- añade smoke contractual cruzado entre menú, CLI y MCP para la consola de governance
- congela el contrato visible de `Pre-write` y `Next action`
- deja preparado el siguiente perímetro contractual sobre `status`, `doctor` y `ai_gate_check`

## Validation
- `npx --yes tsx@4.21.0 --test scripts/__tests__/governance-console-cross-surface-smoke.test.ts scripts/__tests__/framework-menu-cli-runtime.test.ts`