### PR TITLE
fix(pre-write): enforce coercive agent start contract

### DIFF
--- a/integrations/lifecycle/__tests__/governanceNextAction.test.ts
+++ b/integrations/lifecycle/__tests__/governanceNextAction.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readGovernanceNextAction } from '../governanceNextAction';
+import type { GovernanceObservationSnapshot } from '../governanceObservationSnapshot';
+
+const buildSnapshot = (
+  attentionCodes: ReadonlyArray<string>
+): GovernanceObservationSnapshot => {
+  return {
+    governance_effective: 'attention',
+    attention_codes: attentionCodes,
+    enterprise_warn_as_block_env: false,
+    contract_surface: {
+      skills_lock_json: true,
+      skills_sources_json: true,
+      pumuki_adapter_json: true,
+    },
+  } as GovernanceObservationSnapshot;
+};
+
+test('readGovernanceNextAction no degrada PRE_WRITE por policy gaps de otros stages', () => {
+  const snapshot = buildSnapshot(['POLICY_PRE_COMMIT_NOT_STRICT']);
+
+  const result = readGovernanceNextAction({
+    repoRoot: process.cwd(),
+    stage: 'PRE_WRITE',
+    governanceObservation: snapshot,
+  });
+
+  assert.notEqual(result.reason_code, 'POLICY_STAGE_NOT_STRICT');
+});
+
+test('readGovernanceNextAction mantiene POLICY_STAGE_NOT_STRICT cuando PRE_WRITE no es estricto', () => {
+  const snapshot = buildSnapshot(['POLICY_PRE_WRITE_NOT_STRICT']);
+
+  const result = readGovernanceNextAction({
+    repoRoot: process.cwd(),
+    stage: 'PRE_WRITE',
+    governanceObservation: snapshot,
+  });
+
+  assert.equal(result.reason_code, 'POLICY_STAGE_NOT_STRICT');
+});

--- a/integrations/lifecycle/__tests__/policyValidationSnapshot.test.ts
+++ b/integrations/lifecycle/__tests__/policyValidationSnapshot.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { readLifecyclePolicyValidationSnapshot } from '../policyValidationSnapshot';
+
+const withPreWriteMode = async <T>(
+  value: string | undefined,
+  callback: () => Promise<T> | T
+): Promise<T> => {
+  const previous = process.env.PUMUKI_EXPERIMENTAL_PRE_WRITE;
+  if (typeof value === 'undefined') {
+    delete process.env.PUMUKI_EXPERIMENTAL_PRE_WRITE;
+  } else {
+    process.env.PUMUKI_EXPERIMENTAL_PRE_WRITE = value;
+  }
+  try {
+    return await callback();
+  } finally {
+    if (typeof previous === 'undefined') {
+      delete process.env.PUMUKI_EXPERIMENTAL_PRE_WRITE;
+    } else {
+      process.env.PUMUKI_EXPERIMENTAL_PRE_WRITE = previous;
+    }
+  }
+};
+
+test('readLifecyclePolicyValidationSnapshot trata PRE_WRITE como estricto cuando el enforcement efectivo está en strict', async () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'pumuki-policy-validation-prewrite-'));
+  try {
+    await withPreWriteMode(undefined, () => {
+      const snapshot = readLifecyclePolicyValidationSnapshot(repoRoot);
+      assert.equal(snapshot.stages.PRE_WRITE.strict, true);
+    });
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('readLifecyclePolicyValidationSnapshot refleja PRE_WRITE no estricto cuando el enforcement efectivo está en advisory', async () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'pumuki-policy-validation-prewrite-advisory-'));
+  try {
+    await withPreWriteMode('advisory', () => {
+      const snapshot = readLifecyclePolicyValidationSnapshot(repoRoot);
+      assert.equal(snapshot.stages.PRE_WRITE.strict, false);
+    });
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/integrations/lifecycle/governanceNextAction.ts
+++ b/integrations/lifecycle/governanceNextAction.ts
@@ -24,6 +24,13 @@ export type GovernanceNextActionReader = (params: {
   governanceObservation: GovernanceObservationSnapshot;
 }) => GovernanceNextActionSummary;
 
+const POLICY_ATTENTION_CODE_BY_STAGE: Record<AiGateStage, string> = {
+  PRE_WRITE: 'POLICY_PRE_WRITE_NOT_STRICT',
+  PRE_COMMIT: 'POLICY_PRE_COMMIT_NOT_STRICT',
+  PRE_PUSH: 'POLICY_PRE_PUSH_NOT_STRICT',
+  CI: 'POLICY_CI_NOT_STRICT',
+};
+
 const resolveBlockedAction = (
   snapshot: GovernanceObservationSnapshot,
   stage: AiGateStage
@@ -72,7 +79,7 @@ const resolveBlockedAction = (
     };
   }
   if (
-    snapshot.attention_codes.some((code) => code.startsWith('POLICY_'))
+    snapshot.attention_codes.includes(POLICY_ATTENTION_CODE_BY_STAGE[stage])
     || snapshot.enterprise_warn_as_block_env
   ) {
     return {

--- a/integrations/lifecycle/policyValidationSnapshot.ts
+++ b/integrations/lifecycle/policyValidationSnapshot.ts
@@ -3,6 +3,7 @@ import {
   resolvePolicyForStage,
   type ResolvedStagePolicy,
 } from '../gate/stagePolicies';
+import { resolvePreWriteEnforcement } from '../policy/preWriteEnforcement';
 
 export type LifecyclePolicyValidationStageSnapshot = {
   source: ResolvedStagePolicy['trace']['source'];
@@ -23,8 +24,13 @@ export type LifecyclePolicyValidationSnapshot = {
 const POLICY_STAGES: ReadonlyArray<SkillsStage> = ['PRE_WRITE', 'PRE_COMMIT', 'PRE_PUSH', 'CI'];
 
 const toStageSnapshot = (
+  stage: SkillsStage,
   resolved: ResolvedStagePolicy
 ): LifecyclePolicyValidationStageSnapshot => {
+  const strictFromPolicy = resolved.trace.validation?.strict ?? false;
+  const strict = stage === 'PRE_WRITE'
+    ? strictFromPolicy || resolvePreWriteEnforcement().blocking
+    : strictFromPolicy;
   return {
     source: resolved.trace.source,
     bundle: resolved.trace.bundle,
@@ -34,7 +40,7 @@ const toStageSnapshot = (
     policySource: resolved.trace.policySource ?? null,
     validationStatus: resolved.trace.validation?.status ?? null,
     validationCode: resolved.trace.validation?.code ?? null,
-    strict: resolved.trace.validation?.strict ?? false,
+    strict,
   };
 };
 
@@ -42,7 +48,7 @@ export const readLifecyclePolicyValidationSnapshot = (
   repoRoot: string
 ): LifecyclePolicyValidationSnapshot => {
   const resolvedByStage = Object.fromEntries(
-    POLICY_STAGES.map((stage) => [stage, toStageSnapshot(resolvePolicyForStage(stage, repoRoot))])
+    POLICY_STAGES.map((stage) => [stage, toStageSnapshot(stage, resolvePolicyForStage(stage, repoRoot))])
   ) as Record<SkillsStage, LifecyclePolicyValidationStageSnapshot>;
 
   return {

--- a/integrations/mcp/__tests__/autoExecuteAiStart.test.ts
+++ b/integrations/mcp/__tests__/autoExecuteAiStart.test.ts
@@ -107,11 +107,12 @@ test('auto_execute_ai_start devuelve contrato accionable en bloqueo (confidence_
     });
 
     assert.equal(result.tool, 'auto_execute_ai_start');
+    assert.equal(result.success, false);
     assert.equal(result.result.action, 'ask');
     assert.equal(result.result.phase, 'RED');
     assert.equal(result.result.message.length > 0, true);
     assert.equal(result.result.instruction.length > 0, true);
-    assert.equal(typeof result.result.platforms.force, 'boolean');
+    assert.equal(result.result.platforms.force, true);
     assert.equal(typeof result.result.confidence_pct, 'number');
     assert.equal(result.result.confidence_pct >= 0, true);
     assert.equal(result.result.reason_code.length > 0, true);
@@ -227,6 +228,7 @@ test('auto_execute_ai_start devuelve proceed cuando gate está en verde', () => 
     });
 
     assert.equal(result.tool, 'auto_execute_ai_start');
+    assert.equal(result.success, true);
     assert.equal(result.result.action, 'proceed');
     assert.equal(result.result.phase, 'GREEN');
     assert.equal(result.result.message.includes('Confianza alta'), true);

--- a/integrations/mcp/__tests__/enterpriseServer.test.ts
+++ b/integrations/mcp/__tests__/enterpriseServer.test.ts
@@ -367,7 +367,7 @@ test('enterprise server ejecuta tools enterprise en safe mode cuando MCP enterpr
           };
         };
         assert.equal(autoExecutePayload.tool, 'auto_execute_ai_start');
-        assert.equal(autoExecutePayload.success, true);
+        assert.equal(autoExecutePayload.success, false);
         assert.equal(typeof autoExecutePayload.result?.confidence_pct, 'number');
         assert.equal(typeof autoExecutePayload.result?.reason_code, 'string');
         assert.equal((autoExecutePayload.result?.next_action?.message ?? '').length > 0, true);

--- a/integrations/mcp/autoExecuteAiStart.ts
+++ b/integrations/mcp/autoExecuteAiStart.ts
@@ -214,13 +214,13 @@ export const runEnterpriseAutoExecuteAiStart = (params: {
     message = `${message} Learning: ${learningContext.recommended_actions[0]}`;
     instruction = `${instruction} Learning: ${learningContext.recommended_actions[0]}`;
   }
-  const force = action === 'ask' && confidencePct < 50;
+  const force = action === 'ask';
 
   return {
     tool: 'auto_execute_ai_start',
     dryRun: true,
     executed: true,
-    success: true,
+    success: evaluation.allowed,
     result: {
       action,
       phase,


### PR DESCRIPTION
## Summary
- align PRE_WRITE strict policy visibility with effective pre-write enforcement
- stop reporting POLICY_STAGE_NOT_STRICT for PRE_WRITE when only other stages drift
- make auto_execute_ai_start return failure semantics when the gate blocks

## Validation
- npx --yes tsx@4.21.0 --test integrations/lifecycle/__tests__/policyValidationSnapshot.test.ts integrations/lifecycle/__tests__/governanceNextAction.test.ts integrations/mcp/__tests__/autoExecuteAiStart.test.ts
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules npx --yes tsx@4.21.0 --test integrations/mcp/__tests__/enterpriseServer.test.ts