### PR TITLE
hotfix(release): fix blocked remediation runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.3.101] - 2026-04-22
+
+### Fixed
+
+- **`gate.blocked` sin `ReferenceError` en consumers:** `resolveBlockedRemediation` recupera su contrato con variantes (`banner`/`dialog`) y deja de romper la ruta bloqueante de `PRE_WRITE` por un `options is not defined`.
+- **Cobertura de regresión del módulo de remediación:** la suite de `framework-menu-system-notifications-remediation` fija el caso de copy legacy en inglés y la compactación de banners sin truncados rotos.
+
 ## [6.3.100] - 2026-04-22
 
 ### Fixed

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ This file keeps only the operational highlights and rollout notes that matter wh
 
 ## 2026-04 (CLI stability and macOS notifications)
 
+### 2026-04-22 (v6.3.101)
+
+- **Hotfix de ruta bloqueante:** `gate.blocked` deja de lanzar `ReferenceError: options is not defined` al construir la remediación visible en `PRE_WRITE`.
+- **Rollout recomendado:** publicar `pumuki@6.3.101`, repin inmediato en `RuralGo` y revalidar que el bloqueo de `PRE_WRITE` termina limpio, sin error residual tras el panel.
+
 ### 2026-04-22 (v6.3.100)
 
 - **Hotfix de activación efectiva:** la línea publicada deja de resolver `PRE_WRITE` a `off/default` en ausencia de override explícito; el default vuelve a ser coercitivo para el flujo real del agente/editor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.100",
+  "version": "6.3.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.100",
+      "version": "6.3.101",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.100",
+  "version": "6.3.101",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/__tests__/framework-menu-system-notifications-remediation.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-remediation.test.ts
@@ -14,6 +14,7 @@ test('resolveBlockedRemediation usa remediation explícita cuando viene traducib
     'PRE_PUSH_UPSTREAM_MISSING'
   );
 
+  assert.match(result, /configura upstream/i);
   assert.match(result, /set-upstream/);
   assert.match(result, /PRE_PUSH/i);
 });
@@ -45,18 +46,33 @@ test('resolveBlockedRemediation cae a fallback genérico cuando no conoce el blo
   assert.match(result, /corrige/i);
 });
 
-test('resolveBlockedRemediation cae a fallback en español ante remediación inglesa no mapeada', () => {
+test('resolveBlockedRemediation traduce remediaciones legacy en inglés a una salida accionable en español', () => {
   const result = resolveBlockedRemediation(
     {
       kind: 'gate.blocked',
-      stage: 'PRE_COMMIT',
+      stage: 'PRE_PUSH',
       totalViolations: 1,
-      remediation: 'Fix the blocking rule and rerun the gate.',
+      remediation: 'Split the change into smaller commits.',
     },
-    'UNKNOWN_AST_RULE'
+    'GIT_ATOMICITY_TOO_MANY_SCOPES'
   );
 
-  assert.match(result, /corrige/i);
-  assert.match(result, /vuelve a ejecutar/i);
-  assert.doesNotMatch(result, /fix the blocking rule/i);
+  assert.match(result, /divide el cambio/i);
+  assert.doesNotMatch(result, /split the change/i);
+});
+
+test('resolveBlockedRemediation compacta el banner sin cortar palabras por la mitad', () => {
+  const result = resolveBlockedRemediation(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_WRITE',
+      totalViolations: 1,
+      remediation: 'Cómo solucionarlo: Refresca la evidencia del repositorio y vuelve a validar PRE_WRITE y PRE_PUSH con la sesión SDD correcta para esta rama.',
+    },
+    'EVIDENCE_STALE',
+    { variant: 'banner' }
+  );
+
+  assert.ok(result.length <= 120);
+  assert.doesNotMatch(result, /sesió…|correc…|ram…/i);
 });

--- a/scripts/framework-menu-system-notifications-remediation.ts
+++ b/scripts/framework-menu-system-notifications-remediation.ts
@@ -5,21 +5,26 @@ import {
 } from './framework-menu-system-notifications-text';
 
 const BLOCKED_REMEDIATION_BY_CODE: Readonly<Record<string, string>> = {
-  EVIDENCE_MISSING: 'Genera evidencia del slice actual y vuelve a validar el gate de esta fase.',
-  EVIDENCE_INVALID: 'Regenera la evidencia de la iteración y repite la validación en el mismo stage.',
+  EVIDENCE_MISSING: 'Genera la evidencia del slice actual y vuelve a validar esta fase.',
+  EVIDENCE_INVALID: 'Regenera la evidencia de esta iteración y repite la validación.',
   EVIDENCE_CHAIN_INVALID: 'Regenera la evidencia para restaurar la cadena de integridad y vuelve a validar.',
-  EVIDENCE_STALE: 'Ejecuta una auditoría completa de evidencia y vuelve a validar PRE_WRITE/PRE_PUSH. Si persiste, refresca la sesión SDD y reintenta.',
-  EVIDENCE_BRANCH_MISMATCH: 'Regenera evidencia en esta rama y vuelve a ejecutar la validación para sincronizar branch y snapshot.',
-  EVIDENCE_REPO_ROOT_MISMATCH: 'Regenera evidencia desde este repositorio y relanza la validación del gate.',
-  PRE_PUSH_UPSTREAM_MISSING: 'Configura upstream con `git push --set-upstream origin <branch>` y vuelve a ejecutar PRE_PUSH.',
-  SDD_SESSION_MISSING: 'Abre sesión SDD del change activo y repite la validación de la fase actual.',
-  SDD_SESSION_INVALID: 'Refresca la sesión SDD (open/refresh) y vuelve a validar en el mismo stage.',
-  OPENSPEC_MISSING: 'Instala OpenSpec en el repositorio y relanza la validación del gate.',
-  MCP_ENTERPRISE_RECEIPT_MISSING: 'Genera el receipt enterprise de MCP y vuelve a ejecutar la validación.',
-  BACKEND_AVOID_EXPLICIT_ANY: 'Reemplaza `any` por tipos concretos en backend y vuelve a lanzar el gate para confirmar el fix.',
+  EVIDENCE_STALE: 'Refresca la evidencia y vuelve a validar PRE_WRITE/PRE_PUSH.',
+  EVIDENCE_BRANCH_MISMATCH: 'La evidencia no corresponde a esta rama. Regenera el receipt/evidencia y vuelve a validar.',
+  EVIDENCE_REPO_ROOT_MISMATCH: 'Regenera la evidencia desde este repositorio y vuelve a validar.',
+  PRE_PUSH_UPSTREAM_MISSING: 'Configura upstream con `git push --set-upstream origin <branch>` y repite PRE_PUSH.',
+  SDD_SESSION_MISSING: 'Abre la sesión SDD del change activo y repite la validación.',
+  SDD_SESSION_INVALID: 'Refresca la sesión SDD activa y vuelve a validar esta fase.',
+  OPENSPEC_MISSING: 'Instala OpenSpec en este repositorio y vuelve a validar el gate.',
+  MCP_ENTERPRISE_RECEIPT_MISSING: 'Genera el receipt enterprise de MCP y vuelve a validar.',
+  BACKEND_AVOID_EXPLICIT_ANY: 'Sustituye `any` por tipos concretos en backend y relanza el gate.',
+  GIT_ATOMICITY_TOO_MANY_SCOPES: 'Divide el cambio por scope o en commits más pequeños y vuelve a ejecutar el gate.',
+  SOLID_HEURISTIC: 'Corrige la violación detectada y vuelve a ejecutar el gate.',
 };
 
-const BLOCKED_REMEDIATION_MAX_LENGTH = 220;
+const BLOCKED_REMEDIATION_MAX_LENGTH_BY_VARIANT: Readonly<Record<BlockedRemediationVariant, number>> = {
+  banner: 120,
+  dialog: 220,
+};
 
 const GENERIC_BLOCKED_REMEDIATION =
   'Corrige el bloqueo indicado y vuelve a ejecutar el comando.';
@@ -37,7 +42,6 @@ const resolveFallbackRemediation = (causeCode: string): string =>
 const hasEnglishHints = (message: string): boolean => {
   const normalized = message.toLowerCase();
   return [
-    'detected',
     'avoid explicit any',
     'set-upstream',
     'refresh evidence',
@@ -48,16 +52,6 @@ const hasEnglishHints = (message: string): boolean => {
     'rerun',
     'retry',
     'to continue',
-    'protected branch',
-    'open spec',
-    'openspec',
-    'session',
-    'missing',
-    'invalid',
-    'failed',
-    'worktree',
-    'callback usage',
-    'usage.',
     'run ',
   ].some((hint) => normalized.includes(hint));
 };
@@ -73,9 +67,6 @@ const toKnownSpanishRemediationFromMessage = (message: string, causeCode: string
   if (normalized.includes('refresh evidence') || normalized.includes('evidence is stale')) {
     return BLOCKED_REMEDIATION_BY_CODE.EVIDENCE_STALE;
   }
-  if (normalized.includes('evidence ai gate status is blocked')) {
-    return BLOCKED_REMEDIATION_BY_CODE.EVIDENCE_GATE_BLOCKED;
-  }
   if (normalized.includes('split the change')) {
     return BLOCKED_REMEDIATION_BY_CODE.GIT_ATOMICITY_TOO_MANY_SCOPES;
   }
@@ -87,7 +78,10 @@ const toKnownSpanishRemediationFromMessage = (message: string, causeCode: string
 
 export const resolveBlockedRemediation = (
   event: Extract<PumukiCriticalNotificationEvent, { kind: 'gate.blocked' }>,
-  causeCode: string
+  causeCode: string,
+  options?: {
+    variant?: BlockedRemediationVariant;
+  }
 ): string => {
   const variant = options?.variant ?? 'dialog';
   const maxLength = BLOCKED_REMEDIATION_MAX_LENGTH_BY_VARIANT[variant];


### PR DESCRIPTION
## Summary
- restore the blocked remediation variant contract in system notifications
- remove the PRE_WRITE blocked-path ReferenceError seen in RuralGo
- bump release metadata to 6.3.101

## Validation
- npx --yes tsx@4.21.0 --test scripts/__tests__/framework-menu-system-notifications-remediation.test.ts scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts
- npx --yes tsx@4.21.0 --test scripts/__tests__/release-metadata-alignment.test.ts
- npx --yes tsx@4.21.0 scripts/check-package-manifest.ts