### PR TITLE
fix(prewrite): canonicalize blocked contract and remediation

### DIFF
--- a/integrations/lifecycle/__tests__/cli.prewrite-heavy.test.ts
+++ b/integrations/lifecycle/__tests__/cli.prewrite-heavy.test.ts
@@ -772,7 +772,7 @@ test('runLifecycleCli sdd validate PRE_WRITE expone next_action de reconcile cua
     assert.equal(payload.next_action?.reason, 'EVIDENCE_ACTIVE_RULE_IDS_EMPTY_FOR_CODE_CHANGES');
     assert.equal(
       payload.next_action?.command,
-      'npx --yes --package pumuki@latest pumuki policy reconcile --strict --json && npx --yes --package pumuki@latest pumuki sdd validate --stage=PRE_WRITE --json'
+      `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot: repo })} pumuki policy reconcile --strict --json && npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot: repo })} pumuki sdd validate --stage=PRE_WRITE --json`
     );
   } finally {
     process.stdout.write = originalStdoutWrite;

--- a/integrations/lifecycle/__tests__/doctor.test.ts
+++ b/integrations/lifecycle/__tests__/doctor.test.ts
@@ -465,6 +465,78 @@ test('runLifecycleDoctor --deep marca evidence stale como fallo bloqueante', asy
   });
 });
 
+test('runLifecycleDoctor añade issue canónico y alinea stage cuando governance está bloqueado por evidencia', async () => {
+  await withTempDir('pumuki-doctor-governance-blocked-', async (repoRoot) => {
+    mkdirSync(join(repoRoot, '.git', 'hooks'), { recursive: true });
+    installPumukiHooks(repoRoot);
+    const branch = 'feature/doctor-governance-blocked';
+    const blockedEvidence = {
+      ...sampleEvidence({
+        repoRoot,
+        branch,
+        upstream: null,
+      }),
+      snapshot: {
+        stage: 'PRE_PUSH' as const,
+        outcome: 'BLOCK' as const,
+        findings: [],
+      },
+      ai_gate: {
+        status: 'BLOCKED' as const,
+        violations: [],
+        human_intent: null,
+      },
+      severity_metrics: {
+        gate_status: 'BLOCKED' as const,
+        total_violations: 0,
+        by_severity: {
+          CRITICAL: 0,
+          ERROR: 0,
+          WARN: 0,
+          INFO: 0,
+        },
+      },
+    };
+    const payloadHash = computeEvidencePayloadHash(blockedEvidence);
+    writeFileSync(
+      join(repoRoot, '.ai_evidence.json'),
+      JSON.stringify(
+        {
+          ...blockedEvidence,
+          evidence_chain: {
+            algorithm: 'sha256' as const,
+            previous_payload_hash: null,
+            payload_hash: payloadHash,
+            sequence: 1,
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const git = new FakeLifecycleGitService(repoRoot, [], {
+      [PUMUKI_CONFIG_KEYS.installed]: 'true',
+      [PUMUKI_CONFIG_KEYS.version]: getCurrentPumukiVersion(),
+      [PUMUKI_CONFIG_KEYS.hooks]: 'pre-commit,pre-push',
+    });
+
+    const report = runLifecycleDoctor({
+      cwd: repoRoot,
+      git,
+    });
+
+    assert.equal(report.governanceObservation.evidence.snapshot_stage, 'PRE_PUSH');
+    assert.equal(report.governanceNextAction.stage, 'PRE_PUSH');
+    assert.equal(report.issues.some((issue) => issue.severity === 'error'), true);
+    assert.equal(
+      report.issues.some((issue) => issue.message.includes('Governance is blocked')),
+      true
+    );
+  });
+});
+
 test('runLifecycleDoctor --deep marca policy-drift por fallback default como fail no bloqueante', async () => {
   await withTempDir('pumuki-doctor-deep-policy-drift-advisory-', async (repoRoot) => {
     mkdirSync(join(repoRoot, '.git', 'hooks'), { recursive: true });

--- a/integrations/lifecycle/__tests__/status.test.ts
+++ b/integrations/lifecycle/__tests__/status.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
+import { computeEvidencePayloadHash } from '../../evidence/evidenceChain';
 import { withTempDir } from '../../__tests__/helpers/tempDir';
 import { PUMUKI_CONFIG_KEYS } from '../constants';
 import type { ILifecycleGitService } from '../gitService';
@@ -51,6 +52,82 @@ class FakeLifecycleGitService implements ILifecycleGitService {
     return this.config[key];
   }
 }
+
+const writeAllowedEvidence = (params: {
+  repoRoot: string;
+  branch: string;
+  stage: 'PRE_WRITE' | 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+}): void => {
+  const evidence = {
+    version: '2.1' as const,
+    timestamp: new Date().toISOString(),
+    snapshot: {
+      stage: params.stage,
+      outcome: 'PASS' as const,
+      findings: [],
+    },
+    ledger: [],
+    platforms: {},
+    rulesets: [],
+    human_intent: null,
+    ai_gate: {
+      status: 'ALLOWED' as const,
+      violations: [],
+      human_intent: null,
+    },
+    severity_metrics: {
+      gate_status: 'ALLOWED' as const,
+      total_violations: 0,
+      by_severity: {
+        CRITICAL: 0,
+        ERROR: 0,
+        WARN: 0,
+        INFO: 0,
+      },
+    },
+    repo_state: {
+      repo_root: params.repoRoot,
+      git: {
+        available: true,
+        branch: params.branch,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        dirty: false,
+        staged: 0,
+        unstaged: 0,
+      },
+      lifecycle: {
+        installed: true,
+        package_version: getCurrentPumukiVersion(),
+        lifecycle_version: getCurrentPumukiVersion(),
+        hooks: {
+          pre_commit: 'managed' as const,
+          pre_push: 'managed' as const,
+        },
+      },
+    },
+  };
+
+  const payloadHash = computeEvidencePayloadHash(evidence);
+  writeFileSync(
+    join(params.repoRoot, '.ai_evidence.json'),
+    JSON.stringify(
+      {
+        ...evidence,
+        evidence_chain: {
+          algorithm: 'sha256' as const,
+          previous_payload_hash: null,
+          payload_hash: payloadHash,
+          sequence: 1,
+        },
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+};
 
 test('readLifecycleStatus compone estado desde git + hooks + lifecycle config', async () => {
   await withTempDir('pumuki-lifecycle-status-', async (repoRoot) => {
@@ -357,6 +434,25 @@ test('readLifecycleStatus no marca tracking inválido cuando la board canónica 
       status.governanceObservation.attention_codes.includes('TRACKING_CANONICAL_IN_PROGRESS_INVALID'),
       false
     );
+  });
+});
+
+test('readLifecycleStatus alinea governanceNextAction.stage con evidence.snapshot_stage cuando existe evidencia', async () => {
+  await withTempDir('pumuki-lifecycle-status-evidence-stage-', async (repoRoot) => {
+    writeAllowedEvidence({
+      repoRoot,
+      branch: 'feature/status-evidence-stage',
+      stage: 'PRE_PUSH',
+    });
+
+    const git = new FakeLifecycleGitService(repoRoot, [], {});
+    const status = readLifecycleStatus({
+      cwd: repoRoot,
+      git,
+    });
+
+    assert.equal(status.governanceObservation.evidence.snapshot_stage, 'PRE_PUSH');
+    assert.equal(status.governanceNextAction.stage, 'PRE_PUSH');
   });
 });
 

--- a/integrations/lifecycle/cli.ts
+++ b/integrations/lifecycle/cli.ts
@@ -16,6 +16,7 @@ import { printGovernanceConsoleHuman } from './cliGovernanceConsole';
 import { runLifecycleInstall } from './install';
 import { runLifecycleRemove } from './remove';
 import { readLifecycleStatus } from './status';
+import { getCurrentPumukiVersion } from './packageInfo';
 import {
   readLifecycleExperimentalFeaturesSnapshot,
   type LifecycleExperimentalFeaturesSnapshot,
@@ -1579,10 +1580,26 @@ const printDoctorReport = (
 };
 
 const PRE_WRITE_TELEMETRY_CHAIN = 'pumuki->mcp->ai_gate->ai_evidence';
-const PRE_WRITE_INSTALL_REMEDIATION_COMMAND =
-  'npx --yes --package pumuki@latest pumuki install';
-const PRE_WRITE_POLICY_RECONCILE_COMMAND =
-  'npx --yes --package pumuki@latest pumuki policy reconcile --strict --json && npx --yes --package pumuki@latest pumuki sdd validate --stage=PRE_WRITE --json';
+const buildPinnedPumukiNpxCommand = (params: {
+  repoRoot?: string;
+  executableAndArgs: string;
+}): string =>
+  `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot: params.repoRoot })} ${params.executableAndArgs}`;
+const buildPreWriteInstallRemediationCommand = (repoRoot?: string): string =>
+  buildPinnedPumukiNpxCommand({ repoRoot, executableAndArgs: 'pumuki install' });
+const buildPreWriteValidateCommand = (params: {
+  repoRoot?: string;
+  stage: SddStage;
+}): string =>
+  buildPinnedPumukiNpxCommand({
+    repoRoot: params.repoRoot,
+    executableAndArgs: `pumuki sdd validate --stage=${params.stage} --json`,
+  });
+const buildPreWritePolicyReconcileCommand = (repoRoot?: string): string =>
+  `${buildPinnedPumukiNpxCommand({
+    repoRoot,
+    executableAndArgs: 'pumuki policy reconcile --strict --json',
+  })} && ${buildPreWriteValidateCommand({ repoRoot, stage: 'PRE_WRITE' })}`;
 
 type PreWriteValidationEnvelope = {
   sdd: SddEvaluateResult;
@@ -1626,9 +1643,9 @@ export type PreWriteOpenSpecBootstrapTrace = {
 };
 
 export const PRE_WRITE_ENABLE_STRICT_COMMAND =
-  'PUMUKI_EXPERIMENTAL_PRE_WRITE=strict npx --yes --package pumuki@latest pumuki sdd validate --stage=PRE_WRITE --json';
+  `PUMUKI_EXPERIMENTAL_PRE_WRITE=strict ${buildPreWriteValidateCommand({ stage: 'PRE_WRITE' })}`;
 export const buildSddExperimentalEnableAdvisoryCommand = (stage: SddStage): string =>
-  `PUMUKI_EXPERIMENTAL_SDD=advisory npx --yes --package pumuki@latest pumuki sdd validate --stage=${stage} --json`;
+  `PUMUKI_EXPERIMENTAL_SDD=advisory ${buildPreWriteValidateCommand({ stage })}`;
 const buildAnalyticsExperimentalEnableCommand = (action: AnalyticsHotspotsCommand): string =>
   `PUMUKI_EXPERIMENTAL_ANALYTICS=advisory npx --yes --package pumuki@latest pumuki analytics hotspots ${action} --json`;
 const SAAS_INGESTION_ENABLE_ADVISORY_COMMAND =
@@ -1788,8 +1805,11 @@ const PRE_WRITE_HINTS_BY_CODE: Readonly<Record<string, string>> = {
   MCP_ENTERPRISE_RECEIPT_REPO_ROOT_MISMATCH: 'Genera el recibo MCP en este mismo repositorio.',
 };
 
-const PRE_WRITE_DEFAULT_REMEDIATION =
-  'Corrige la causa bloqueante y vuelve a ejecutar: npx --yes --package pumuki@latest pumuki-pre-write';
+const buildPreWriteDefaultRemediation = (repoRoot?: string): string =>
+  `Corrige la causa bloqueante y vuelve a ejecutar: ${buildPinnedPumukiNpxCommand({
+    repoRoot,
+    executableAndArgs: 'pumuki-pre-write',
+  })}`;
 
 export const PRE_WRITE_OPENSPEC_AUTOREMEDIABLE_CODES = new Set<string>([
   'OPENSPEC_MISSING',
@@ -1813,7 +1833,7 @@ export const resolvePreWriteNextAction = (params: {
   if (!params.sdd.decision.allowed && PRE_WRITE_OPENSPEC_AUTOREMEDIABLE_CODES.has(params.sdd.decision.code)) {
     return {
       reason: params.sdd.decision.code,
-      command: PRE_WRITE_INSTALL_REMEDIATION_COMMAND,
+      command: buildPreWriteInstallRemediationCommand(params.aiGate?.repo_state.repo_root),
     };
   }
   if (!params.aiGate || params.aiGate.allowed) {
@@ -1825,7 +1845,7 @@ export const resolvePreWriteNextAction = (params: {
   if (policyReconcileViolation) {
     return {
       reason: policyReconcileViolation.code,
-      command: PRE_WRITE_POLICY_RECONCILE_COMMAND,
+      command: buildPreWritePolicyReconcileCommand(params.aiGate.repo_state.repo_root),
     };
   }
   const atomicSliceViolation = params.aiGate.violations.find((violation) =>
@@ -1841,7 +1861,10 @@ export const resolvePreWriteNextAction = (params: {
     return {
       reason: atomicSliceViolation.code,
       command:
-        `${firstSliceCommand} && npx --yes --package pumuki@latest pumuki sdd validate --stage=PRE_WRITE --json`,
+        `${firstSliceCommand} && ${buildPreWriteValidateCommand({
+          repoRoot: params.aiGate.repo_state.repo_root,
+          stage: 'PRE_WRITE',
+        })}`,
     };
   }
   const hasMcpViolation = params.aiGate.violations.some((violation) =>
@@ -1852,7 +1875,10 @@ export const resolvePreWriteNextAction = (params: {
   }
   return {
     reason: 'MCP_ENTERPRISE_RECEIPT',
-    command: 'npx --yes --package pumuki@latest pumuki-pre-write',
+    command: buildPinnedPumukiNpxCommand({
+      repoRoot: params.aiGate.repo_state.repo_root,
+      executableAndArgs: 'pumuki-pre-write',
+    }),
   };
 };
 
@@ -1863,7 +1889,7 @@ export const resolvePreWriteBlockedRemediation = (params: {
   if (params.nextAction?.command) {
     return params.nextAction.command;
   }
-  return PRE_WRITE_HINTS_BY_CODE[params.causeCode] ?? PRE_WRITE_DEFAULT_REMEDIATION;
+  return PRE_WRITE_HINTS_BY_CODE[params.causeCode] ?? buildPreWriteDefaultRemediation();
 };
 
 export const buildPreWriteReasonCode = (params: {

--- a/integrations/lifecycle/doctor.ts
+++ b/integrations/lifecycle/doctor.ts
@@ -191,6 +191,28 @@ const buildDoctorIssues = (params: {
   return issues;
 };
 
+const appendGovernanceBlockingIssue = (params: {
+  issues: ReadonlyArray<DoctorIssue>;
+  governanceObservation: GovernanceObservationSnapshot;
+  governanceNextAction: GovernanceNextActionSummary;
+}): ReadonlyArray<DoctorIssue> => {
+  if (!doctorGovernanceIsBlocking(params.governanceObservation)) {
+    return params.issues;
+  }
+  if (params.issues.some((issue) => issue.severity === 'error')) {
+    return params.issues;
+  }
+  return [
+    ...params.issues,
+    {
+      severity: 'error',
+      message:
+        `Governance is blocked (${params.governanceNextAction.reason_code}). ` +
+        params.governanceNextAction.instruction,
+    },
+  ];
+};
+
 const DEEP_EVIDENCE_MAX_AGE_SECONDS = 1800;
 
 const toCanonicalPath = (value: string): string => {
@@ -878,10 +900,16 @@ export const runLifecycleDoctor = (params?: {
     policyValidation,
     git,
   });
+  const governanceStage = governanceObservation.evidence.snapshot_stage ?? 'PRE_WRITE';
   const governanceNextAction = (params?.governanceNextActionReader ?? readGovernanceNextAction)({
     repoRoot,
-    stage: 'PRE_WRITE',
+    stage: governanceStage,
     governanceObservation,
+  });
+  const canonicalIssues = appendGovernanceBlockingIssue({
+    issues,
+    governanceObservation,
+    governanceNextAction,
   });
 
   const parity_profile =
@@ -910,7 +938,7 @@ export const runLifecycleDoctor = (params?: {
     governanceNextAction,
     governanceObservation,
     tracking,
-    issues,
+    issues: canonicalIssues,
     deep,
     parity_profile,
     parity_comparison,

--- a/integrations/lifecycle/status.ts
+++ b/integrations/lifecycle/status.ts
@@ -60,9 +60,10 @@ export const readLifecycleStatus = (params?: {
     policyValidation,
     git,
   });
+  const governanceStage = governanceObservation.evidence.snapshot_stage ?? 'PRE_WRITE';
   const governanceNextAction = (params?.governanceNextActionReader ?? readGovernanceNextAction)({
     repoRoot,
-    stage: 'PRE_WRITE',
+    stage: governanceStage,
     governanceObservation,
   });
   const tracking = resolveRepoTrackingState(repoRoot);


### PR DESCRIPTION
## Summary
- canonicaliza el stage de governance desde evidence.snapshot_stage en status y doctor
- añade issue canónico cuando doctor queda bloqueado por governance sin errores explícitos
- fija las remediaciones PRE_WRITE al runtime diagnosticado en vez de pumuki@latest

## Validation
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx --test /tmp/ast-intelligence-hooks__bugfix-inc-084-086-089/integrations/lifecycle/__tests__/status.test.ts /tmp/ast-intelligence-hooks__bugfix-inc-084-086-089/integrations/lifecycle/__tests__/doctor.test.ts /tmp/ast-intelligence-hooks__bugfix-inc-084-086-089/integrations/lifecycle/__tests__/cli.prewrite-heavy.test.ts