### PR TITLE
bugfix(sdd): make expired sessions unambiguous

### DIFF
--- a/integrations/lifecycle/__tests__/status.test.ts
+++ b/integrations/lifecycle/__tests__/status.test.ts
@@ -275,7 +275,7 @@ test('readLifecycleStatus compone estado desde git + hooks + lifecycle config', 
       false
     );
 
-    assert.deepEqual(git.resolveCalls, ['/tmp/ignored-cwd']);
+    assert.deepEqual(git.resolveCalls, ['/tmp/ignored-cwd', repoRoot]);
     assert.deepEqual(git.listTrackedCalls, [repoRoot]);
     assert.deepEqual(
       git.getConfigCalls.map((call) => call.key),
@@ -285,6 +285,11 @@ test('readLifecycleStatus compone estado desde git + hooks + lifecycle config', 
         PUMUKI_CONFIG_KEYS.hooks,
         PUMUKI_CONFIG_KEYS.installedAt,
         PUMUKI_CONFIG_KEYS.openSpecManagedArtifacts,
+        'pumuki.sdd.session.active',
+        'pumuki.sdd.session.change',
+        'pumuki.sdd.session.updatedAt',
+        'pumuki.sdd.session.expiresAt',
+        'pumuki.sdd.session.ttlMinutes',
       ]
     );
     assert.ok(git.getConfigCalls.every((call) => call.cwd === repoRoot));
@@ -336,7 +341,7 @@ test('readLifecycleStatus usa process.cwd cuando no se pasa cwd explícito', asy
 
     assert.equal(status.repoRoot, repoRoot);
     assert.equal(status.version.effective, getCurrentPumukiVersion());
-    assert.deepEqual(git.resolveCalls, [process.cwd()]);
+    assert.deepEqual(git.resolveCalls, [process.cwd(), repoRoot]);
     assert.deepEqual(git.listTrackedCalls, [repoRoot]);
     assert.equal(status.trackedNodeModulesCount, 0);
     assert.equal(status.hooksDirectory, join(repoRoot, '.git', 'hooks'));
@@ -536,5 +541,29 @@ test('readLifecycleStatus devuelve lifecycle vacío y hooks ausentes cuando no h
     assert.equal(status.governanceNextAction.stage, 'PRE_WRITE');
     assert.equal(status.governanceObservation.evidence.readable, 'missing');
     assert.equal(status.governanceObservation.governance_effective, 'attention');
+  });
+});
+
+test('readLifecycleStatus proyecta sesión SDD expirada como inactiva pero mantiene atención canónica', async () => {
+  await withTempDir('pumuki-lifecycle-status-expired-sdd-', async (repoRoot) => {
+    const git = new FakeLifecycleGitService(repoRoot, [], {
+      'pumuki.sdd.session.active': 'true',
+      'pumuki.sdd.session.change': 'RGO-1750-01',
+      'pumuki.sdd.session.expiresAt': '2000-01-01T00:00:00.000Z',
+      'pumuki.sdd.session.ttlMinutes': '90',
+    });
+
+    const status = readLifecycleStatus({
+      cwd: repoRoot,
+      git,
+    });
+
+    assert.equal(status.governanceObservation.sdd_session.active, false);
+    assert.equal(status.governanceObservation.sdd_session.valid, false);
+    assert.equal(status.governanceObservation.sdd_session.remaining_seconds, 0);
+    assert.equal(
+      status.governanceObservation.attention_codes.includes('SDD_SESSION_INVALID_OR_EXPIRED'),
+      true
+    );
   });
 });

--- a/integrations/lifecycle/governanceObservationSnapshot.ts
+++ b/integrations/lifecycle/governanceObservationSnapshot.ts
@@ -89,9 +89,9 @@ const readCurrentBranch = (git: ILifecycleGitService, repoRoot: string): string 
   }
 };
 
-const readSddStatusSafe = (repoRoot: string): SddStatusPayload => {
+const readSddStatusSafe = (repoRoot: string, git: ILifecycleGitService): SddStatusPayload => {
   try {
-    return readSddStatus(repoRoot);
+    return readSddStatus(repoRoot, git);
   } catch {
     return {
       repoRoot,
@@ -222,7 +222,7 @@ export const readGovernanceObservationSnapshot = (params: {
   const git = params.git ?? new LifecycleGitService();
   const { repoRoot, experimentalFeatures, policyValidation } = params;
   const rawSdd = process.env.PUMUKI_EXPERIMENTAL_SDD?.trim();
-  const sddStatus = readSddStatusSafe(repoRoot);
+  const sddStatus = readSddStatusSafe(repoRoot, git);
   const evidence = summarizeEvidence(repoRoot);
   const branch = readCurrentBranch(git, repoRoot);
   const onProtected = typeof branch === 'string' && DEFAULT_PROTECTED_BRANCHES.has(branch.trim().toLowerCase());
@@ -243,7 +243,10 @@ export const readGovernanceObservationSnapshot = (params: {
   if (evidence.readable === 'valid' && evidence.snapshot_outcome === 'BLOCK') {
     attention.push('EVIDENCE_SNAPSHOT_BLOCK');
   }
-  if (sddStatus.session.active === true && sddStatus.session.valid !== true) {
+  if (
+    sddStatus.session.valid !== true &&
+    (sddStatus.session.active === true || !!sddStatus.session.changeId || sddStatus.session.remainingSeconds === 0)
+  ) {
     attention.push('SDD_SESSION_INVALID_OR_EXPIRED');
   }
   if (!policyValidation.stages.PRE_WRITE.strict) {

--- a/integrations/sdd/__tests__/sessionStore.test.ts
+++ b/integrations/sdd/__tests__/sessionStore.test.ts
@@ -208,9 +208,15 @@ test('readSddSession marca la sesión como inválida cuando expiresAt ya venció
     ]);
 
     const readBack = readSddSession();
-    assert.equal(readBack.active, true);
+    assert.equal(readBack.active, false);
     assert.equal(readBack.valid, false);
     assert.equal(readBack.remainingSeconds, 0);
+    assert.equal(readBack.changeId, 'add-auth-feature');
+
+    const refreshed = refreshSddSession();
+    assert.equal(refreshed.active, true);
+    assert.equal(refreshed.valid, true);
+    assert.equal(refreshed.changeId, 'add-auth-feature');
   } finally {
     process.chdir(previousCwd);
     rmSync(repo, { recursive: true, force: true });

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -12,6 +12,7 @@ import {
   readSddSession,
   refreshSddSession,
 } from './sessionStore';
+import type { ILifecycleGitService } from '../lifecycle/gitService';
 import { resolveDegradedMode } from '../gate/degradedMode';
 import { resolveSddCompletenessEnforcement } from '../policy/sddCompletenessEnforcement';
 import { resolveSddExperimentalFeature } from '../policy/experimentalFeatures';
@@ -71,10 +72,10 @@ const resolveMissingSessionGuidance = (repoRoot: string): {
   };
 };
 
-const buildStatus = (repoRoot: string): SddStatusPayload => {
+const buildStatus = (repoRoot: string, git?: ILifecycleGitService): SddStatusPayload => {
   const openspec = detectOpenSpecInstallation(repoRoot);
   const compatibility = evaluateOpenSpecCompatibility(openspec);
-  const session = readSddSession(repoRoot);
+  const session = readSddSession(repoRoot, git);
   return {
     repoRoot,
     openspec: {
@@ -164,7 +165,7 @@ const evaluateSessionRequirements = (params: {
   autoRefreshError?: string;
 }): SddDecision | undefined => {
   const { status } = params;
-  if (!status.session.active) {
+  if (!status.session.changeId) {
     const guidance = resolveMissingSessionGuidance(status.repoRoot);
     const details: Record<string, string | number | boolean | bigint | symbol | null | Date | object> = {
       command: guidance.command,
@@ -221,7 +222,6 @@ const shouldAttemptSessionAutoRefresh = (params: {
 }): boolean =>
   params.stage !== 'PRE_WRITE'
   && params.autoRefreshEnabled
-  && params.status.session.active
   && !!params.status.session.changeId
   && !params.status.session.valid;
 
@@ -545,5 +545,5 @@ export const evaluateSddPolicy = (params: {
   });
 };
 
-export const readSddStatus = (repoRoot?: string): SddStatusPayload =>
-  buildStatus(repoRoot ?? process.cwd());
+export const readSddStatus = (repoRoot?: string, git?: ILifecycleGitService): SddStatusPayload =>
+  buildStatus(repoRoot ?? process.cwd(), git);

--- a/integrations/sdd/sessionStore.ts
+++ b/integrations/sdd/sessionStore.ts
@@ -86,7 +86,7 @@ const readConfig = (
   repoRoot: string,
   git: ILifecycleGitService
 ): SddSessionState => {
-  const active = git.localConfig(repoRoot, SDD_KEYS.active) === 'true';
+  const rawActive = git.localConfig(repoRoot, SDD_KEYS.active) === 'true';
   const rawChangeId = git.localConfig(repoRoot, SDD_KEYS.change);
   const changeId =
     typeof rawChangeId === 'string' && rawChangeId.trim().length > 0
@@ -101,6 +101,7 @@ const readConfig = (
       : undefined;
 
   const validity = computeValidity(expiresAt);
+  const active = rawActive && !!changeId && validity.valid;
   return {
     repoRoot,
     active,
@@ -174,7 +175,7 @@ export const refreshSddSession = (params?: {
   const git = params?.git ?? new LifecycleGitService();
   const repoRoot = resolveRepoRoot(params?.cwd ?? process.cwd(), git);
   const current = readConfig(repoRoot, git);
-  if (!current.active || !current.changeId) {
+  if (!current.changeId) {
     throw new Error('No active SDD session to refresh. Run `pumuki sdd session --open --change=<id>` first.');
   }
   const ttlMinutes = parsePositiveMinutes(params?.ttlMinutes ?? current.ttlMinutes);


### PR DESCRIPTION
## Summary
- project expired SDD sessions as inactive while preserving canonical invalid attention
- keep expired sessions refreshable and align status/governance with the injected git source
- cover the behavior in session, policy, and lifecycle status tests

## Testing
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx --test /tmp/ast-intelligence-hooks__bugfix-inc-085-sdd-session/integrations/sdd/__tests__/sessionStore.test.ts /tmp/ast-intelligence-hooks__bugfix-inc-085-sdd-session/integrations/sdd/__tests__/policy.test.ts /tmp/ast-intelligence-hooks__bugfix-inc-085-sdd-session/integrations/lifecycle/__tests__/status.test.ts