### PR TITLE
hotfix(sdd): make expired sessions unambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.3.107] - 2026-04-22
+
+### Fixed
+
+- **Semántica inequívoca para sesión SDD expirada:** una sesión vencida deja de proyectarse como `active=true` y pasa a exponerse como inactiva (`active=false`) manteniendo `valid=false` y `remainingSeconds=0`.
+- **Refresh de sesión expiradas todavía permitido:** `refreshSddSession` ya no exige `active=true`; basta con conservar el `changeId` para poder renovar una sesión caducada sin reabrirla manualmente.
+- **Policy SDD alineada con esa semántica:** `evaluateSddPolicy` trata la sesión como `missing` solo cuando falta `changeId`, y conserva `SDD_SESSION_INVALID` para sesiones expiradas con contexto recuperable.
+
 ## [6.3.106] - 2026-04-22
 
 ### Fixed

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -6,6 +6,12 @@ This file keeps only the operational highlights and rollout notes that matter wh
 
 ## 2026-04 (CLI stability and macOS notifications)
 
+### 2026-04-22 (v6.3.107)
+
+- **Sesión SDD expirada sin semántica ambigua:** la línea publicada deja de diagnosticar sesiones vencidas como `active=true` con `valid=false`; ahora las proyecta como inactivas y mantiene la señal de expiración con `remainingSeconds=0`.
+- **Refresh reproducible de sesiones caducadas:** si el `changeId` sigue siendo válido, `session --refresh` vuelve a servir para recuperar la sesión sin exigir un `session --open` innecesario.
+- **Rollout recomendado:** publicar `pumuki@6.3.107`, repin inmediato en `RuralGo` y revalidar `sdd validate --stage=PRE_WRITE --json` comprobando que `status.session.active=false`, `valid=false` y que la remediación siga permitiendo refresh sobre el mismo `changeId`.
+
 ### 2026-04-22 (v6.3.106)
 
 - **Cierre útil del literal residual en RuralGo:** `sdd validate --stage=PRE_WRITE --json` ya no recomienda activar SDD con `pumuki@latest`; devuelve el mismo runtime versionado que está diagnosticando.

--- a/integrations/sdd/__tests__/policy.test.ts
+++ b/integrations/sdd/__tests__/policy.test.ts
@@ -193,11 +193,11 @@ test('evaluateSddPolicy bloquea con SDD_SESSION_MISSING cuando no existe sesión
     assert.match(result.decision.message, /session --open --change=/i);
     assert.equal(
       result.decision.details?.command,
-      'npx --yes --package pumuki@latest pumuki sdd session --open --change=add-auth-feature'
+      `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot })} pumuki sdd session --open --change=add-auth-feature`
     );
     assert.equal(
       result.decision.details?.fallbackCommand,
-      'npx --yes --package pumuki@latest pumuki sdd session --open --change=auto'
+      `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot })} pumuki sdd session --open --change=auto`
     );
   });
 });
@@ -216,11 +216,11 @@ test('evaluateSddPolicy con múltiples changes activos no recomienda --change=au
     assert.doesNotMatch(result.decision.message, /change=auto/i);
     assert.equal(
       result.decision.details?.command,
-      'npx --yes --package pumuki@latest pumuki sdd session --open --change=<id>'
+      `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot })} pumuki sdd session --open --change=<id>`
     );
     assert.equal(
       result.decision.details?.fallbackCommand,
-      'npx --yes --package pumuki@latest pumuki sdd session --open --change=<id>'
+      `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot })} pumuki sdd session --open --change=<id>`
     );
     assert.deepEqual(result.decision.details?.availableChangeIds, ['add-auth-feature', 'rgo-2000-01']);
     assert.equal(result.decision.details?.suggestedChangeId, undefined);
@@ -255,7 +255,7 @@ test('evaluateSddPolicy bloquea con SDD_SESSION_INVALID cuando la sesión está 
       assert.equal(result.decision.code, 'SDD_SESSION_INVALID');
       assert.equal(
         result.decision.details?.command,
-        'npx --yes --package pumuki@latest pumuki sdd session --refresh --ttl-minutes=90'
+        `npx --yes --package pumuki@${getCurrentPumukiVersion({ repoRoot })} pumuki sdd session --refresh --ttl-minutes=90`
       );
     } finally {
       if (typeof previous === 'undefined') {

--- a/integrations/sdd/__tests__/sessionStore.test.ts
+++ b/integrations/sdd/__tests__/sessionStore.test.ts
@@ -208,9 +208,15 @@ test('readSddSession marca la sesión como inválida cuando expiresAt ya venció
     ]);
 
     const readBack = readSddSession();
-    assert.equal(readBack.active, true);
+    assert.equal(readBack.active, false);
     assert.equal(readBack.valid, false);
     assert.equal(readBack.remainingSeconds, 0);
+    assert.equal(readBack.changeId, 'add-auth-feature');
+
+    const refreshed = refreshSddSession();
+    assert.equal(refreshed.active, true);
+    assert.equal(refreshed.valid, true);
+    assert.equal(refreshed.changeId, 'add-auth-feature');
   } finally {
     process.chdir(previousCwd);
     rmSync(repo, { recursive: true, force: true });

--- a/integrations/sdd/policy.ts
+++ b/integrations/sdd/policy.ts
@@ -12,6 +12,7 @@ import {
   readSddSession,
   refreshSddSession,
 } from './sessionStore';
+import type { ILifecycleGitService } from '../lifecycle/gitService';
 import { resolveDegradedMode } from '../gate/degradedMode';
 import { getCurrentPumukiVersion } from '../lifecycle/packageInfo';
 import { resolveSddCompletenessEnforcement } from '../policy/sddCompletenessEnforcement';
@@ -78,10 +79,10 @@ const resolveMissingSessionGuidance = (repoRoot: string): {
   };
 };
 
-const buildStatus = (repoRoot: string): SddStatusPayload => {
+const buildStatus = (repoRoot: string, git?: ILifecycleGitService): SddStatusPayload => {
   const openspec = detectOpenSpecInstallation(repoRoot);
   const compatibility = evaluateOpenSpecCompatibility(openspec);
-  const session = readSddSession(repoRoot);
+  const session = readSddSession(repoRoot, git);
   return {
     repoRoot,
     openspec: {
@@ -171,7 +172,7 @@ const evaluateSessionRequirements = (params: {
   autoRefreshError?: string;
 }): SddDecision | undefined => {
   const { status } = params;
-  if (!status.session.active) {
+  if (!status.session.changeId) {
     const guidance = resolveMissingSessionGuidance(status.repoRoot);
     const details: Record<string, string | number | boolean | bigint | symbol | null | Date | object> = {
       command: guidance.command,
@@ -229,7 +230,6 @@ const shouldAttemptSessionAutoRefresh = (params: {
 }): boolean =>
   params.stage !== 'PRE_WRITE'
   && params.autoRefreshEnabled
-  && params.status.session.active
   && !!params.status.session.changeId
   && !params.status.session.valid;
 
@@ -553,5 +553,5 @@ export const evaluateSddPolicy = (params: {
   });
 };
 
-export const readSddStatus = (repoRoot?: string): SddStatusPayload =>
-  buildStatus(repoRoot ?? process.cwd());
+export const readSddStatus = (repoRoot?: string, git?: ILifecycleGitService): SddStatusPayload =>
+  buildStatus(repoRoot ?? process.cwd(), git);

--- a/integrations/sdd/sessionStore.ts
+++ b/integrations/sdd/sessionStore.ts
@@ -86,7 +86,7 @@ const readConfig = (
   repoRoot: string,
   git: ILifecycleGitService
 ): SddSessionState => {
-  const active = git.localConfig(repoRoot, SDD_KEYS.active) === 'true';
+  const rawActive = git.localConfig(repoRoot, SDD_KEYS.active) === 'true';
   const rawChangeId = git.localConfig(repoRoot, SDD_KEYS.change);
   const changeId =
     typeof rawChangeId === 'string' && rawChangeId.trim().length > 0
@@ -101,6 +101,7 @@ const readConfig = (
       : undefined;
 
   const validity = computeValidity(expiresAt);
+  const active = rawActive && !!changeId && validity.valid;
   return {
     repoRoot,
     active,
@@ -174,7 +175,7 @@ export const refreshSddSession = (params?: {
   const git = params?.git ?? new LifecycleGitService();
   const repoRoot = resolveRepoRoot(params?.cwd ?? process.cwd(), git);
   const current = readConfig(repoRoot, git);
-  if (!current.active || !current.changeId) {
+  if (!current.changeId) {
     throw new Error('No active SDD session to refresh. Run `pumuki sdd session --open --change=<id>` first.');
   }
   const ttlMinutes = parsePositiveMinutes(params?.ttlMinutes ?? current.ttlMinutes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.106",
+  "version": "6.3.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.106",
+      "version": "6.3.107",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.106",
+  "version": "6.3.107",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- project expired SDD sessions as inactive while preserving refreshability via changeId
- align SDD policy so expired sessions stay invalid instead of becoming missing
- publish release metadata for 6.3.107 and cover the behavior in session/policy tests

## Testing
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx --test /tmp/ast-intelligence-hooks__hotfix-inc-085-sdd-session/integrations/sdd/__tests__/sessionStore.test.ts /tmp/ast-intelligence-hooks__hotfix-inc-085-sdd-session/integrations/sdd/__tests__/policy.test.ts
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx scripts/check-package-manifest.ts