### PR TITLE
fix(mcp): make enterprise baseline visible by default

### DIFF
--- a/integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts
+++ b/integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts
@@ -163,9 +163,9 @@ const buildExperimentalFeatures = (): LifecycleExperimentalFeaturesSnapshot => (
     },
     mcp_enterprise: {
       layer: 'experimental',
-      mode: 'off',
+      mode: 'strict',
       source: 'default',
-      blocking: false,
+      blocking: true,
       activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
       legacyActivationVariable: null,
     },
@@ -250,7 +250,7 @@ test('printGovernanceConsoleHuman imprime cabecera compartida S1 y el bloque can
     assert.match(output, /Pre-write: mode=off blocking=no strict_policy=yes source=default/);
     assert.match(output, /Governance next action:/);
     assert.match(output, /Policy-as-code: PRE_WRITE=POLICY_AS_CODE_VALID strict=yes/);
-    assert.match(output, /Experimental: MCP_ENTERPRISE=off/);
+    assert.match(output, /Experimental: MCP_ENTERPRISE=strict/);
   } finally {
     process.stdout.write = originalStdoutWrite;
   }

--- a/integrations/mcp/__tests__/enterpriseServer.test.ts
+++ b/integrations/mcp/__tests__/enterpriseServer.test.ts
@@ -52,6 +52,20 @@ const withMcpEnterpriseEnabled = async (callback: () => Promise<void>): Promise<
   }
 };
 
+const withMcpEnterpriseDisabled = async (callback: () => Promise<void>): Promise<void> => {
+  const previous = process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE;
+  process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE = 'off';
+  try {
+    await callback();
+  } finally {
+    if (typeof previous === 'undefined') {
+      delete process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE;
+    } else {
+      process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE = previous;
+    }
+  }
+};
+
 type AiEvidencePayload = Parameters<typeof computeEvidencePayloadHash>[0];
 
 const withEvidenceChain = (evidence: AiEvidencePayload): AiEvidencePayload => {
@@ -106,7 +120,7 @@ test('enterprise server exposes health endpoint', async () => {
       };
       assert.equal(payload.status, 'ok');
       assert.equal(payload.repoRoot, repoRoot);
-      assert.equal(payload.experimentalFeatures?.mcp_enterprise?.mode, 'off');
+      assert.equal(payload.experimentalFeatures?.mcp_enterprise?.mode, 'strict');
     });
   });
 });
@@ -159,7 +173,15 @@ test('enterprise server exposes baseline status payload with capabilities', asyn
       );
       assert.equal(
         payload.capabilities?.tools?.includes('ai_gate_check'),
-        false
+        true
+      );
+      assert.equal(
+        payload.capabilities?.tools?.includes('pre_flight_check'),
+        true
+      );
+      assert.equal(
+        payload.capabilities?.tools?.includes('auto_execute_ai_start'),
+        true
       );
       assert.equal(payload.evidence?.status, 'degraded');
       assert.equal((payload as { lifecycle?: unknown }).lifecycle, null);
@@ -198,6 +220,9 @@ test('enterprise server exposes enterprise tools catalog', async () => {
       };
       const names = (payload.tools ?? []).map((tool) => tool.name);
       assert.deepEqual(names, [
+        'ai_gate_check',
+        'pre_flight_check',
+        'auto_execute_ai_start',
         'check_sdd_status',
         'validate_and_fix',
         'sync_branches',
@@ -212,39 +237,41 @@ test('enterprise server exposes enterprise tools catalog', async () => {
   });
 });
 
-test('enterprise server devuelve payload explícito cuando MCP enterprise está apagado por defecto', async () => {
-  await withTempDir('pumuki-mcp-enterprise-', async (repoRoot) => {
-    runGit(repoRoot, ['init']);
-    await withEnterpriseServer(repoRoot, async (baseUrl) => {
-      const aiGateResponse = await safeFetchRequest(`${baseUrl}/tool`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          name: 'ai_gate_check',
-        }),
-      });
-      assert.equal(aiGateResponse.status, 200);
-      const aiGatePayload = (await aiGateResponse.json()) as {
-        tool?: string;
-        success?: boolean;
-        dryRun?: boolean;
-        executed?: boolean;
-        result?: {
-          code?: string;
-          activation_variable?: string;
+test('enterprise server devuelve payload explícito cuando MCP enterprise está desactivado de forma explícita', async () => {
+  await withMcpEnterpriseDisabled(async () => {
+    await withTempDir('pumuki-mcp-enterprise-', async (repoRoot) => {
+      runGit(repoRoot, ['init']);
+      await withEnterpriseServer(repoRoot, async (baseUrl) => {
+        const aiGateResponse = await safeFetchRequest(`${baseUrl}/tool`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            name: 'ai_gate_check',
+          }),
+        });
+        assert.equal(aiGateResponse.status, 200);
+        const aiGatePayload = (await aiGateResponse.json()) as {
+          tool?: string;
+          success?: boolean;
+          dryRun?: boolean;
+          executed?: boolean;
+          result?: {
+            code?: string;
+            activation_variable?: string;
+          };
         };
-      };
-      assert.equal(aiGatePayload.tool, 'ai_gate_check');
-      assert.equal(aiGatePayload.success, false);
-      assert.equal(aiGatePayload.dryRun, true);
-      assert.equal(aiGatePayload.executed, false);
-      assert.equal(aiGatePayload.result?.code, 'MCP_ENTERPRISE_EXPERIMENTAL_DISABLED');
-      assert.equal(
-        aiGatePayload.result?.activation_variable,
-        'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE'
-      );
+        assert.equal(aiGatePayload.tool, 'ai_gate_check');
+        assert.equal(aiGatePayload.success, false);
+        assert.equal(aiGatePayload.dryRun, true);
+        assert.equal(aiGatePayload.executed, false);
+        assert.equal(aiGatePayload.result?.code, 'MCP_ENTERPRISE_EXPERIMENTAL_DISABLED');
+        assert.equal(
+          aiGatePayload.result?.activation_variable,
+          'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE'
+        );
+      });
     });
   });
 });

--- a/integrations/policy/__tests__/experimentalFeatures.test.ts
+++ b/integrations/policy/__tests__/experimentalFeatures.test.ts
@@ -142,16 +142,16 @@ test('resolveHeuristicsExperimentalFeature respects canonical env modes', async 
   });
 });
 
-test('resolveMcpEnterpriseExperimentalFeature defaults to default-off with canonical activation variable', async () => {
+test('resolveMcpEnterpriseExperimentalFeature defaults to strict baseline with canonical activation variable', async () => {
   await withEnv('PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE', undefined, () => {
     const resolved = resolveMcpEnterpriseExperimentalFeature();
 
     assert.deepEqual(resolved, {
       feature: 'mcp_enterprise',
       layer: 'experimental',
-      mode: 'off',
+      mode: 'strict',
       source: 'default',
-      blocking: false,
+      blocking: true,
       activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
       legacyActivationVariable: null,
     });

--- a/integrations/policy/experimentalFeatures.ts
+++ b/integrations/policy/experimentalFeatures.ts
@@ -55,7 +55,7 @@ const EXPERIMENTAL_FEATURES: Record<ExperimentalFeatureId, ExperimentalFeatureCo
     legacyActivationVariable: null,
   },
   mcp_enterprise: {
-    defaultMode: 'off',
+    defaultMode: 'strict',
     activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
     legacyActivationVariable: null,
   },

--- a/scripts/__tests__/build-consumer-menu-matrix-baseline.test.ts
+++ b/scripts/__tests__/build-consumer-menu-matrix-baseline.test.ts
@@ -203,9 +203,9 @@ const buildStatus = (): LifecycleStatus => {
         },
         mcp_enterprise: {
           layer: 'experimental',
-          mode: 'off',
+          mode: 'strict',
           source: 'default',
-          blocking: false,
+          blocking: true,
           activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
           legacyActivationVariable: null,
         },
@@ -368,7 +368,7 @@ test('runConsumerMenuMatrixBaselineBuild escribe report y summary y devuelve 0 s
   assert.match(stdout, /"experimental": \{/);
   assert.match(writes.get('/tmp/out/report.json') ?? '', /"stable": true/);
   assert.match(writes.get('/tmp/out/report.json') ?? '', /"layerSummary"/);
-  assert.match(writes.get('/tmp/out/summary.md') ?? '', /layer experimental: verdict=PASS/);
+  assert.match(writes.get('/tmp/out/summary.md') ?? '', /layer experimental: verdict=FAIL/);
   assert.match(writes.get('/tmp/out/summary.md') ?? '', /# Consumer Menu Matrix Baseline/);
 });
 

--- a/scripts/__tests__/consumer-menu-matrix-baseline-report-lib.test.ts
+++ b/scripts/__tests__/consumer-menu-matrix-baseline-report-lib.test.ts
@@ -206,9 +206,9 @@ const buildStatus = (): LifecycleStatus => {
         },
         mcp_enterprise: {
           layer: 'experimental',
-          mode: 'off',
+          mode: 'strict',
           source: 'default',
-          blocking: false,
+          blocking: true,
           activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
           legacyActivationVariable: null,
         },
@@ -344,7 +344,7 @@ test('buildConsumerMenuMatrixBaselineSnapshot conserva contrato útil para accep
   assert.equal(snapshot.latestRound.byOption['1'].totalViolations, 3);
   assert.equal(snapshot.doctor.layerSummary.core.verdict, 'PASS');
   assert.equal(snapshot.doctor.layerSummary.operational.verdict, 'WARN');
-  assert.equal(snapshot.doctor.layerSummary.experimental.verdict, 'PASS');
+  assert.equal(snapshot.doctor.layerSummary.experimental.verdict, 'FAIL');
 });
 
 test('renderConsumerMenuMatrixBaselineSummary publica drift, capas y latest round', () => {
@@ -364,7 +364,7 @@ test('renderConsumerMenuMatrixBaselineSummary publica drift, capas y latest roun
   assert.match(summary, /- stable: YES/);
   assert.match(summary, /- layer core: verdict=PASS/);
   assert.match(summary, /- layer policy-pack: verdict=WARN/);
-  assert.match(summary, /- layer experimental: verdict=PASS/);
+  assert.match(summary, /- layer experimental: verdict=FAIL/);
   assert.match(summary, /- option 1: stable=YES drift=none/);
   assert.match(
     summary,

--- a/scripts/__tests__/framework-menu-advanced-view-menu.test.ts
+++ b/scripts/__tests__/framework-menu-advanced-view-menu.test.ts
@@ -198,7 +198,7 @@ const buildConsumerPreflightResult = (): ConsumerPreflightResult => ({
       analytics: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_ANALYTICS', legacyActivationVariable: null },
       heuristics: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_HEURISTICS', legacyActivationVariable: null },
       learning_context: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_LEARNING_CONTEXT', legacyActivationVariable: null },
-      mcp_enterprise: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE', legacyActivationVariable: null },
+      mcp_enterprise: { layer: 'experimental', mode: 'strict', source: 'default', blocking: true, activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE', legacyActivationVariable: null },
       operational_memory: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_OPERATIONAL_MEMORY', legacyActivationVariable: null },
       pre_write: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_PRE_WRITE', legacyActivationVariable: null },
       saas_ingestion: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_SAAS_INGESTION', legacyActivationVariable: null },

--- a/scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts
+++ b/scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts
@@ -180,7 +180,7 @@ const buildConsumerPreflightResult = (): ConsumerPreflightResult => ({
       analytics: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_ANALYTICS', legacyActivationVariable: null },
       heuristics: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_HEURISTICS', legacyActivationVariable: null },
       learning_context: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_LEARNING_CONTEXT', legacyActivationVariable: null },
-      mcp_enterprise: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE', legacyActivationVariable: null },
+      mcp_enterprise: { layer: 'experimental', mode: 'strict', source: 'default', blocking: true, activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE', legacyActivationVariable: null },
       operational_memory: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_OPERATIONAL_MEMORY', legacyActivationVariable: null },
       pre_write: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_PRE_WRITE', legacyActivationVariable: null },
       saas_ingestion: { layer: 'experimental', mode: 'off', source: 'default', blocking: false, activationVariable: 'PUMUKI_EXPERIMENTAL_SAAS_INGESTION', legacyActivationVariable: null },


### PR DESCRIPTION
## escenario
- corrige PUMUKI-INC-079 en la capa MCP de la línea develop
- MCP enterprise deja de nacer apagado por defecto
- el editor/agente pasa a ver ai_gate_check, pre_flight_check y auto_execute_ai_start sin opt-in adicional

## tests
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx --test integrations/policy/__tests__/experimentalFeatures.test.ts integrations/mcp/__tests__/enterpriseServer.test.ts integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts scripts/__tests__/framework-menu-advanced-view-menu.test.ts scripts/__tests__/framework-menu-consumer-runtime-menu.test.ts scripts/__tests__/consumer-menu-matrix-baseline-report-lib.test.ts scripts/__tests__/build-consumer-menu-matrix-baseline.test.ts

## evidencia
- mcp_enterprise defaultMode pasa a strict
- snapshots de consola y menús alineadas con la nueva baseline
- suite dirigida verde 51/51

## task
- si esta PR entra, el siguiente paso es hotfix sobre main, release útil y replay en RuralGo para cerrar el MD externo de INC-079