### PR TITLE
hotfix(mcp): enable enterprise baseline by default

### DIFF
--- a/integrations/mcp/__tests__/enterpriseServer.test.ts
+++ b/integrations/mcp/__tests__/enterpriseServer.test.ts
@@ -149,7 +149,7 @@ test('enterprise server exposes baseline status payload with capabilities', asyn
       );
       assert.equal(
         payload.capabilities?.tools?.includes('ai_gate_check'),
-        false
+        true
       );
       assert.equal(payload.evidence?.status, 'degraded');
       assert.equal((payload as { lifecycle?: unknown }).lifecycle, null);
@@ -188,6 +188,9 @@ test('enterprise server exposes enterprise tools catalog', async () => {
       };
       const names = (payload.tools ?? []).map((tool) => tool.name);
       assert.deepEqual(names, [
+        'ai_gate_check',
+        'pre_flight_check',
+        'auto_execute_ai_start',
         'check_sdd_status',
         'validate_and_fix',
         'sync_branches',
@@ -202,40 +205,50 @@ test('enterprise server exposes enterprise tools catalog', async () => {
   });
 });
 
-test('enterprise server devuelve payload explícito cuando MCP enterprise está apagado por defecto', async () => {
+test('enterprise server devuelve payload explícito cuando MCP enterprise está apagado de forma explícita', async () => {
   await withTempDir('pumuki-mcp-enterprise-', async (repoRoot) => {
     runGit(repoRoot, ['init']);
-    await withEnterpriseServer(repoRoot, async (baseUrl) => {
-      const aiGateResponse = await safeFetchRequest(`${baseUrl}/tool`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          name: 'ai_gate_check',
-        }),
-      });
-      assert.equal(aiGateResponse.status, 200);
-      const aiGatePayload = (await aiGateResponse.json()) as {
-        tool?: string;
-        success?: boolean;
-        dryRun?: boolean;
-        executed?: boolean;
-        result?: {
-          code?: string;
-          activation_variable?: string;
+    const previous = process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE;
+    process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE = 'off';
+    try {
+      await withEnterpriseServer(repoRoot, async (baseUrl) => {
+        const aiGateResponse = await safeFetchRequest(`${baseUrl}/tool`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            name: 'ai_gate_check',
+          }),
+        });
+        assert.equal(aiGateResponse.status, 200);
+        const aiGatePayload = (await aiGateResponse.json()) as {
+          tool?: string;
+          success?: boolean;
+          dryRun?: boolean;
+          executed?: boolean;
+          result?: {
+            code?: string;
+            activation_variable?: string;
+          };
         };
-      };
-      assert.equal(aiGatePayload.tool, 'ai_gate_check');
-      assert.equal(aiGatePayload.success, false);
-      assert.equal(aiGatePayload.dryRun, true);
-      assert.equal(aiGatePayload.executed, false);
-      assert.equal(aiGatePayload.result?.code, 'MCP_ENTERPRISE_EXPERIMENTAL_DISABLED');
-      assert.equal(
-        aiGatePayload.result?.activation_variable,
-        'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE'
-      );
-    });
+        assert.equal(aiGatePayload.tool, 'ai_gate_check');
+        assert.equal(aiGatePayload.success, false);
+        assert.equal(aiGatePayload.dryRun, true);
+        assert.equal(aiGatePayload.executed, false);
+        assert.equal(aiGatePayload.result?.code, 'MCP_ENTERPRISE_EXPERIMENTAL_DISABLED');
+        assert.equal(
+          aiGatePayload.result?.activation_variable,
+          'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE'
+        );
+      });
+    } finally {
+      if (typeof previous === 'undefined') {
+        delete process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE;
+      } else {
+        process.env.PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE = previous;
+      }
+    }
   });
 });
 

--- a/integrations/policy/__tests__/experimentalFeatures.test.ts
+++ b/integrations/policy/__tests__/experimentalFeatures.test.ts
@@ -142,16 +142,16 @@ test('resolveHeuristicsExperimentalFeature respects canonical env modes', async 
   });
 });
 
-test('resolveMcpEnterpriseExperimentalFeature defaults to default-off with canonical activation variable', async () => {
+test('resolveMcpEnterpriseExperimentalFeature defaults to strict baseline with canonical activation variable', async () => {
   await withEnv('PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE', undefined, () => {
     const resolved = resolveMcpEnterpriseExperimentalFeature();
 
     assert.deepEqual(resolved, {
       feature: 'mcp_enterprise',
       layer: 'experimental',
-      mode: 'off',
+      mode: 'strict',
       source: 'default',
-      blocking: false,
+      blocking: true,
       activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
       legacyActivationVariable: null,
     });

--- a/integrations/policy/experimentalFeatures.ts
+++ b/integrations/policy/experimentalFeatures.ts
@@ -55,7 +55,7 @@ const EXPERIMENTAL_FEATURES: Record<ExperimentalFeatureId, ExperimentalFeatureCo
     legacyActivationVariable: null,
   },
   mcp_enterprise: {
-    defaultMode: 'off',
+    defaultMode: 'strict',
     activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
     legacyActivationVariable: null,
   },

--- a/scripts/__tests__/build-consumer-menu-matrix-baseline.test.ts
+++ b/scripts/__tests__/build-consumer-menu-matrix-baseline.test.ts
@@ -193,9 +193,9 @@ const buildStatus = (): LifecycleStatus => {
         },
         mcp_enterprise: {
           layer: 'experimental',
-          mode: 'off',
+          mode: 'strict',
           source: 'default',
-          blocking: false,
+          blocking: true,
           activationVariable: 'PUMUKI_EXPERIMENTAL_MCP_ENTERPRISE',
           legacyActivationVariable: null,
         },
@@ -356,7 +356,7 @@ test('runConsumerMenuMatrixBaselineBuild escribe report y summary y devuelve 0 s
   assert.match(stdout, /"experimental": \{/);
   assert.match(writes.get('/tmp/out/report.json') ?? '', /"stable": true/);
   assert.match(writes.get('/tmp/out/report.json') ?? '', /"layerSummary"/);
-  assert.match(writes.get('/tmp/out/summary.md') ?? '', /layer experimental: verdict=PASS/);
+  assert.match(writes.get('/tmp/out/summary.md') ?? '', /layer experimental: verdict=FAIL/);
   assert.match(writes.get('/tmp/out/summary.md') ?? '', /# Consumer Menu Matrix Baseline/);
 });
 


### PR DESCRIPTION
## escenario
- corrige PUMUKI-INC-079 en la línea publicada
- MCP enterprise deja de nacer apagado por defecto en main
- el editor/agente pasa a ver ai_gate_check, pre_flight_check y auto_execute_ai_start sin opt-in adicional

## tests
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx --test integrations/policy/__tests__/experimentalFeatures.test.ts integrations/mcp/__tests__/enterpriseServer.test.ts scripts/__tests__/consumer-menu-matrix-baseline-report-lib.test.ts scripts/__tests__/build-consumer-menu-matrix-baseline.test.ts

## evidencia
- mcp_enterprise defaultMode pasa a strict en main
- catálogo enterprise visible por defecto en MCP
- suite mínima hotfix verde 35/35

## task
- siguiente paso: merge explícito, versionado, publish y replay en RuralGo para cerrar el MD externo de INC-079