### PR TITLE
fix(lifecycle): materialize strict policy contract on install

### DIFF
--- a/integrations/lifecycle/__tests__/install.test.ts
+++ b/integrations/lifecycle/__tests__/install.test.ts
@@ -47,6 +47,60 @@ const createGitRepo = (): string => {
   return repo;
 };
 
+const writeValidPolicyReconcileInputs = (repoRoot: string): void => {
+  writeFileSync(
+    join(repoRoot, 'AGENTS.md'),
+    [
+      '# AGENTS',
+      'ios-enterprise-rules',
+      'swift-concurrency',
+      'swiftui-expert-skill',
+      'frontend-enterprise-rules',
+      'backend-enterprise-rules',
+      'android-enterprise-rules',
+      '',
+    ].join('\n'),
+    'utf8'
+  );
+  writeFileSync(
+    join(repoRoot, 'skills.lock.json'),
+    JSON.stringify(
+      {
+        version: '1.0',
+        bundles: [
+          {
+            name: 'ios-enterprise-rules',
+            source: 'docs/codex-skills/ios-enterprise-rules.md',
+          },
+          {
+            name: 'swift-concurrency',
+            source: 'docs/codex-skills/swift-concurrency.md',
+          },
+          {
+            name: 'swiftui-expert-skill',
+            source: 'docs/codex-skills/swiftui-expert-skill.md',
+          },
+          {
+            name: 'frontend-enterprise-rules',
+            source: 'docs/codex-skills/frontend-enterprise-rules.md',
+          },
+          {
+            name: 'backend-enterprise-rules',
+            source: 'docs/codex-skills/backend-enterprise-rules.md',
+          },
+          {
+            name: 'android-enterprise-rules',
+            source: 'docs/codex-skills/android-enterprise-rules.md',
+          },
+        ],
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+};
+
 test('runLifecycleInstall instala hooks y persiste estado lifecycle', () => {
   const repo = createGitRepo();
   try {
@@ -255,6 +309,33 @@ test('runLifecycleInstall es idempotente en segunda ejecución sobre repo ya ins
     assert.equal(typeof firstInstalledAt, 'string');
     assert.equal(typeof secondInstalledAt, 'string');
     assert.equal(existsSync(join(repo, '.ai_evidence.json')), true);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('runLifecycleInstall materializa policy-as-code estricta cuando el repo declara insumos mínimos', () => {
+  const repo = createGitRepo();
+  try {
+    writeValidPolicyReconcileInputs(repo);
+
+    runLifecycleInstall({ cwd: repo });
+
+    const contract = JSON.parse(
+      readFileSync(join(repo, '.pumuki', 'policy-as-code.json'), 'utf8')
+    ) as {
+      strict?: Partial<Record<'PRE_WRITE' | 'PRE_COMMIT' | 'PRE_PUSH' | 'CI', boolean>>;
+      signatures?: Partial<Record<'PRE_WRITE' | 'PRE_COMMIT' | 'PRE_PUSH' | 'CI', string>>;
+    };
+
+    assert.equal(contract.strict?.PRE_WRITE, true);
+    assert.equal(contract.strict?.PRE_COMMIT, true);
+    assert.equal(contract.strict?.PRE_PUSH, true);
+    assert.equal(contract.strict?.CI, true);
+    assert.equal(typeof contract.signatures?.PRE_WRITE, 'string');
+    assert.equal(typeof contract.signatures?.PRE_COMMIT, 'string');
+    assert.equal(typeof contract.signatures?.PRE_PUSH, 'string');
+    assert.equal(typeof contract.signatures?.CI, 'string');
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/integrations/lifecycle/install.ts
+++ b/integrations/lifecycle/install.ts
@@ -14,6 +14,7 @@ import { readOpenSpecManagedArtifacts, writeLifecycleState } from './state';
 import { ensureRuntimeArtifactsIgnored } from './artifacts';
 import { runLifecycleAdapterInstall } from './adapter';
 import { writeLifecycleBootstrapManifest } from './bootstrapManifest';
+import { runPolicyReconcile } from './policyReconcile';
 
 export type LifecycleInstallResult = {
   repoRoot: string;
@@ -82,6 +83,26 @@ const ensureRepoBaselineAdapter = (repoRoot: string): void => {
   }
 };
 
+const materializeStrictPolicyAsCode = (repoRoot: string): void => {
+  try {
+    const report = runPolicyReconcile({
+      repoRoot,
+      strict: true,
+      apply: true,
+    });
+    if (report.summary.status === 'PASS') {
+      return;
+    }
+    if (process.env.PUMUKI_VERBOSE_INSTALL === '1') {
+      console.debug('[pumuki] strict policy reconcile skipped', report.summary.status);
+    }
+  } catch (cause: unknown) {
+    if (process.env.PUMUKI_VERBOSE_INSTALL === '1') {
+      console.debug('[pumuki] strict policy reconcile skipped', cause);
+    }
+  }
+};
+
 export const runLifecycleInstall = (params?: {
   cwd?: string;
   git?: ILifecycleGitService;
@@ -108,6 +129,7 @@ export const runLifecycleInstall = (params?: {
         openSpecManagedArtifacts: priorArtifacts.length > 0 ? priorArtifacts : undefined,
       });
       ensureRepoBaselineAdapter(report.repoRoot);
+      materializeStrictPolicyAsCode(report.repoRoot);
       const bootstrapManifest = writeLifecycleBootstrapManifest({
         git,
         repoRoot: report.repoRoot,
@@ -155,6 +177,7 @@ export const runLifecycleInstall = (params?: {
     openSpecManagedArtifacts: Array.from(mergedOpenSpecArtifacts),
   });
   ensureRepoBaselineAdapter(report.repoRoot);
+  materializeStrictPolicyAsCode(report.repoRoot);
   const bootstrapManifest = writeLifecycleBootstrapManifest({
     git,
     repoRoot: report.repoRoot,


### PR DESCRIPTION
## Summary
- materialize strict policy-as-code during install when the repo exposes minimum reconcile inputs
- keep install best-effort when reconcile cannot converge
- add install regression coverage for strict contract materialization

## Testing
- env NODE_PATH=/Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules /Users/juancarlosmerlosalbarracin/Developer/Projects/ast-intelligence-hooks/node_modules/.bin/tsx --test integrations/policy/__tests__/policyAsCode.test.ts integrations/gate/__tests__/stagePolicies.test.ts integrations/lifecycle/__tests__/policyReconcile.test.ts integrations/lifecycle/__tests__/install.test.ts