### PR TITLE
fix(lifecycle): surface actionable tracking context

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1034,7 +1034,7 @@ Decisión hard de cierre:
 
 Último cierre operativo: `[✅] - PUMUKI-INC-080 — Convergencia de policy efectiva y wiring de hooks en instalación limpia` el fix quedó integrado en `develop` vía PR [#808](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/808) (merge `5460677930494c0c966120ea9e72b10ee43d26b0`), backporteado a `main` vía PR [#809](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/809) (merge `0ed2b81ed10bac6fca4386cfcfcc5997f76d8486`) y publicado como `pumuki@6.3.109` tras la PR de release [#810](https://github.com/SwiftEnProfundidad/ast-intelligence-hooks/pull/810) (merge `24d3a546678c006e4e6b7e5495b11267a49aabdf`). El replay útil en RuralGo confirma `version.effective=6.3.109`, `.pumuki/policy-as-code.json` materializado por `install`, `policyValidation.stages.{PRE_WRITE,PRE_COMMIT,PRE_PUSH,CI}.strict=true`, `policySource=file:.pumuki/policy-as-code.json` y `doctor.issues=[]`.
 
-Tarea activa única: `[🚧] - PUMUKI-INC-081 — Separar blocker real de warning PRE_WRITE y hacer accionable el tracking canónico` tras cerrar `INC-080`, el backlog externo de RuralGo sigue abierto y la prioridad hard pasa al siguiente bug externo vivo de mayor severidad. Mientras `PUMUKI-INC-081` siga reportado en el MD externo, no se permite activar una task interna distinta ni saltar a incidencias de menor severidad.
+Tarea activa única: `[🚧] - PUMUKI-INC-083 — Hacer accionable el tracking canónico en la salida visible del runtime` tras cerrar `INC-082`, el backlog externo de RuralGo sigue abierto y la prioridad hard pasa al siguiente bug externo vivo de mayor severidad. Mientras `PUMUKI-INC-083` siga reportado en el MD externo, no se permite activar una task interna distinta ni saltar a incidencias de menor severidad.
 
 Regla operativa persistente: este repositorio no dispone de cuota útil de GitHub Actions en el ciclo actual; durante rollout y release se crean las PR necesarias y se mergean igualmente sin esperar CI remoto. La validación contractual pasa a ser local y dirigida y cualquier bloqueo de branch policy por checks remotos debe resolverse por merge administrativo, no reabriendo el debate sobre esperar Actions.
 
@@ -1049,7 +1049,7 @@ Snapshot de adopción vigente:
 | Consumer | Versión/estado actual | Estado backlog externo | Lectura operativa |
 |----------|------------------------|------------------------|-------------------|
 | `SAAS` | `6.3.102` mergeada vía [#12](https://github.com/SwiftEnProfundidad/app-supermercados/pull/12) | `0` incidencias activas | Adopción cerrada en `main`. |
-| `RuralGo` | `6.3.109` en rollout útil para cierre de `INC-080` | `27` incidencias activas | `PUMUKI-INC-080` ya cerrado; siguiente bug vivo prioritario `PUMUKI-INC-081`. |
+| `RuralGo` | `6.3.109` en rollout útil para cierre de `INC-080` | `27` incidencias activas | `PUMUKI-INC-080` ya cerrado; siguiente bug vivo prioritario `PUMUKI-INC-083`. |
 | `Flux` | `6.3.102` mergeada vía [#9](https://github.com/SwiftEnProfundidad/flux-training/pull/9) | sin bug nuevo abierto en backlog Pumuki | Adopción cerrada en `develop`. |
 
 *(Sustituir la fila anterior al cerrar/abrir la tarea en curso: una sola 🚧 en todo el plan.)*

--- a/integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts
+++ b/integrations/lifecycle/__tests__/cliGovernanceConsole.test.ts
@@ -255,3 +255,39 @@ test('printGovernanceConsoleHuman imprime cabecera compartida S1 y el bloque can
     process.stdout.write = originalStdoutWrite;
   }
 });
+
+test('buildGovernanceConsoleSummaryLines itemiza el tracking canónico cuando está inconsistente', () => {
+  const observation = buildGovernanceObservation();
+  observation.tracking = {
+    ...observation.tracking,
+    single_in_progress_valid: false,
+    in_progress_count: 2,
+    in_progress_entries: [
+      { line_number: 10, task_id: 'PUMUKI-INC-078' },
+      { line_number: 11, task_id: 'PUMUKI-INC-079' },
+    ],
+    last_run_status: 'IN_PROGRESS',
+  };
+  observation.attention_codes = ['TRACKING_CANONICAL_IN_PROGRESS_INVALID'];
+
+  const lines = buildGovernanceConsoleSummaryLines({
+    governanceObservation: observation,
+    governanceNextAction: buildGovernanceNextAction(),
+    policyValidation: buildPolicyValidation(),
+    experimentalFeatures: buildExperimentalFeatures(),
+  });
+
+  const output = lines.join('\n');
+  assert.equal(
+    output.includes(
+      'Tracking: canonical=PUMUKI-RESET-MASTER-PLAN.md in_progress_count=2 active_entries=PUMUKI-INC-078@L10, PUMUKI-INC-079@L11 last_run_status=IN_PROGRESS'
+    ),
+    true
+  );
+  assert.equal(
+    output.includes(
+      'Attention: TRACKING_CANONICAL_IN_PROGRESS_INVALID'
+    ),
+    true
+  );
+});

--- a/integrations/lifecycle/__tests__/doctor.test.ts
+++ b/integrations/lifecycle/__tests__/doctor.test.ts
@@ -281,6 +281,10 @@ test('runLifecycleDoctor marca warning cuando el tracking canónico tiene más d
     assert.equal(report.issues.length, 1);
     assert.equal(report.issues[0]?.severity, 'warning');
     assert.match(report.issues[0]?.message ?? '', /Canonical tracking is inconsistent/i);
+    assert.match(
+      report.issues[0]?.message ?? '',
+      /active_entries=PUMUKI-INC-078@L3, PUMUKI-INC-079@L4/i
+    );
     assert.equal(doctorHasBlockingIssues(report), false);
   });
 });

--- a/integrations/lifecycle/__tests__/status.test.ts
+++ b/integrations/lifecycle/__tests__/status.test.ts
@@ -217,7 +217,7 @@ test('readLifecycleStatus compone estado desde git + hooks + lifecycle config', 
     );
     assert.equal(status.experimentalFeatures.features.heuristics.legacyActivationVariable, null);
     assert.equal(status.experimentalFeatures.features.mcp_enterprise.layer, 'experimental');
-    assert.equal(status.experimentalFeatures.features.mcp_enterprise.mode, 'off');
+    assert.equal(status.experimentalFeatures.features.mcp_enterprise.mode, 'strict');
     assert.equal(status.experimentalFeatures.features.mcp_enterprise.source, 'default');
     assert.equal(
       status.experimentalFeatures.features.mcp_enterprise.activationVariable,
@@ -352,7 +352,7 @@ test('readLifecycleStatus usa process.cwd cuando no se pasa cwd explícito', asy
     assert.equal(status.experimentalFeatures.features.saas_ingestion.mode, 'off');
     assert.equal(status.experimentalFeatures.features.heuristics.mode, 'off');
     assert.equal(status.experimentalFeatures.features.learning_context.mode, 'off');
-    assert.equal(status.experimentalFeatures.features.mcp_enterprise.mode, 'off');
+    assert.equal(status.experimentalFeatures.features.mcp_enterprise.mode, 'strict');
     assert.equal(status.experimentalFeatures.features.sdd.mode, 'off');
     assert.equal(status.governanceNextAction.stage, 'PRE_WRITE');
     assert.equal(status.governanceObservation.governance_effective, 'attention');
@@ -536,7 +536,7 @@ test('readLifecycleStatus devuelve lifecycle vacío y hooks ausentes cuando no h
     assert.equal(status.experimentalFeatures.features.saas_ingestion.mode, 'off');
     assert.equal(status.experimentalFeatures.features.heuristics.mode, 'off');
     assert.equal(status.experimentalFeatures.features.learning_context.mode, 'off');
-    assert.equal(status.experimentalFeatures.features.mcp_enterprise.mode, 'off');
+    assert.equal(status.experimentalFeatures.features.mcp_enterprise.mode, 'strict');
     assert.equal(status.experimentalFeatures.features.sdd.mode, 'off');
     assert.equal(status.governanceNextAction.stage, 'PRE_WRITE');
     assert.equal(status.governanceObservation.evidence.readable, 'missing');

--- a/integrations/lifecycle/doctor.ts
+++ b/integrations/lifecycle/doctor.ts
@@ -180,10 +180,16 @@ const buildDoctorIssues = (params: {
           `Tracking contract has conflicting canonical declarations (${params.tracking.declarations.map((declaration) => declaration.resolved_path).join(', ')}).`,
       });
     } else if (!params.tracking.single_in_progress_valid) {
+      const activeEntries = (params.tracking.in_progress_entries ?? [])
+        .map((entry) => `${entry.task_id ?? 'UNKNOWN'}@L${entry.line_number}`)
+        .join(', ');
+      const actionableContext = activeEntries.length > 0
+        ? ` active_entries=${activeEntries} last_run_status=${params.tracking.last_run_status ?? 'absent'}`
+        : '';
       issues.push({
         severity: 'warning',
         message:
-          `Canonical tracking is inconsistent for ${params.tracking.canonical_path} (in_progress_count=${params.tracking.in_progress_count}, active_task=${params.tracking.active_task_id ?? 'unknown'}, last_run_status=${params.tracking.last_run_status ?? 'absent'}).`,
+          `Canonical tracking is inconsistent for ${params.tracking.canonical_path} (in_progress_count=${params.tracking.in_progress_count}, active_task=${params.tracking.active_task_id ?? 'unknown'}, last_run_status=${params.tracking.last_run_status ?? 'absent'}).${actionableContext}`,
       });
     }
   }

--- a/integrations/lifecycle/governanceObservationSnapshot.ts
+++ b/integrations/lifecycle/governanceObservationSnapshot.ts
@@ -119,6 +119,17 @@ const buildContractSurface = (repoRoot: string): GovernanceContractSurface => ({
   pumuki_adapter_json: existsSync(join(repoRoot, '.pumuki', 'adapter.json')),
 });
 
+const formatTrackingActionableContext = (tracking: RepoTrackingState): string | null => {
+  const activeEntries = (tracking.in_progress_entries ?? [])
+    .map((entry) => `${entry.task_id ?? 'UNKNOWN'}@L${entry.line_number}`)
+    .join(', ');
+  if (!activeEntries) {
+    return null;
+  }
+  const lastRunStatus = tracking.last_run_status ?? 'absent';
+  return `active_entries=${activeEntries} last_run_status=${lastRunStatus}`;
+};
+
 const PLATFORM_BUNDLE_ORDER = [
   'android-enterprise-rules',
   'backend-enterprise-rules',
@@ -204,8 +215,9 @@ const buildHints = (
     hints.push(`Falta el tracking canónico declarado (${tracking.canonical_path ?? 'sin resolver'}).`);
   }
   if (tracking.enforced && tracking.single_in_progress_valid === false) {
+    const actionableContext = formatTrackingActionableContext(tracking);
     hints.push(
-      `El tracking canónico debe dejar exactamente una 🚧 (actual=${tracking.in_progress_count ?? 'n/a'}).`
+      `El tracking canónico debe dejar exactamente una 🚧 (actual=${tracking.in_progress_count ?? 'n/a'}${actionableContext ? `, ${actionableContext}` : ''}).`
     );
   }
   hints.push('SDD/OpenSpec: usa PUMUKI_EXPERIMENTAL_SDD=advisory|strict cuando el loop SDD esté activo.');
@@ -340,6 +352,12 @@ export const buildGovernanceObservationSummaryLines = (
   ];
   if (snapshot.attention_codes.length > 0) {
     lines.push(`Attention: ${snapshot.attention_codes.join(', ')}`);
+  }
+  if (snapshot.tracking.enforced && snapshot.tracking.single_in_progress_valid === false) {
+    const actionableContext = formatTrackingActionableContext(snapshot.tracking);
+    lines.push(
+      `Tracking: canonical=${snapshot.tracking.canonical_path ?? 'unknown'} in_progress_count=${snapshot.tracking.in_progress_count ?? 'n/a'}${actionableContext ? ` ${actionableContext}` : ''}`
+    );
   }
   return lines;
 };


### PR DESCRIPTION
## Resumen\n\n- Añade contexto accionable al tracking canónico en /.\n- Itemiza las entradas  que disparan .\n- Alinea el tracking interno con .\n\n## Validación\n\n- \n\n