### PR TITLE
feat(lifecycle): adapt alignment commands to consumer runtime

### DIFF
--- a/PUMUKI.md
+++ b/PUMUKI.md
@@ -59,7 +59,7 @@ Version drift contract:
   - `version.pathExecutionHazard`
   - `version.pathExecutionWarning`
   - `version.pathExecutionWorkaroundCommand`
-- If `driftWarning` appears, align the consumer package and lifecycle state with `version.alignmentCommand`.
+- If `driftWarning` appears, align the consumer package and lifecycle state with `version.alignmentCommand`. When the consumer declares a Node runtime via `volta`, `.nvmrc`, or `package.json.engines.node`, the remediation command prepends the matching runtime switch before the Pumuki install step.
 - If `pathExecutionHazard=true`, the safe workaround is the local node invocation printed by Pumuki, for example:
 
 ```bash

--- a/docs/product/API_REFERENCE.md
+++ b/docs/product/API_REFERENCE.md
@@ -174,7 +174,7 @@ Interpretation contract:
 - `consumerInstalled`: version installed in the consumer repository.
 - `lifecycleInstalled`: version recorded in managed lifecycle metadata.
 - `driftWarning`: compact human-readable explanation when those values diverge.
-- `alignmentCommand`: exact remediation command to align dependency and lifecycle state with the current runtime version.
+- `alignmentCommand`: exact remediation command to align dependency and lifecycle state with the current runtime version. When the consumer repo declares a Node runtime via `volta`, `.nvmrc`, or `package.json.engines.node`, this command prepends the matching runtime switch before the Pumuki install step.
 - `pathExecutionHazard`: boolean flag raised when the repo root contains the platform `PATH` delimiter and `npx/npm exec` can fail to resolve `pumuki`.
 - `pathExecutionWarning`: compact warning explaining why `PATH` resolution is unsafe in that repo.
 - `pathExecutionWorkaroundCommand`: safe local-node entrypoint to use when `pathExecutionHazard=true`.

--- a/docs/product/USAGE.md
+++ b/docs/product/USAGE.md
@@ -403,7 +403,7 @@ How to read it:
 - `lifecycleInstalled`: version persisted in managed lifecycle state.
 - `source`: source chosen to compute `effective`.
 - `driftWarning`: compact explanation when those values diverge.
-- `alignmentCommand`: exact command to align consumer dependency and lifecycle state with the current runtime.
+- `alignmentCommand`: exact command to align consumer dependency and lifecycle state with the current runtime. If the consumer declares Node via `volta`, `.nvmrc`, or `package.json.engines.node`, the command prepends the matching runtime switch before the Pumuki install step.
 - `pathExecutionHazard`: tells you whether the repo root itself can break `PATH`-based execution.
 - `pathExecutionWarning`: compact explanation of that hazard.
 - `pathExecutionWorkaroundCommand`: safe local-node entrypoint to use when `PATH` execution is unsafe.

--- a/integrations/lifecycle/__tests__/packageInfo.test.ts
+++ b/integrations/lifecycle/__tests__/packageInfo.test.ts
@@ -142,6 +142,21 @@ test('buildLifecycleVersionReport expone drift entre runtime, consumer y lifecyc
       JSON.stringify({ name: getCurrentPumukiPackageName(), version: '8.8.8' }, null, 2),
       'utf8'
     );
+    writeFileSync(
+      join(repoRoot, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'consumer-fixture',
+          version: '1.0.0',
+          volta: {
+            node: '18.20.4',
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
 
     const report = buildLifecycleVersionReport({
       repoRoot,
@@ -157,14 +172,40 @@ test('buildLifecycleVersionReport expone drift entre runtime, consumer y lifecyc
     assert.equal(report.driftFromLifecycleInstalled, true);
     assert.match(report.driftWarning ?? '', /effective=8\.8\.8/i);
     assert.match(report.driftWarning ?? '', /runtime=/i);
+    assert.match(report.driftWarning ?? '', /node=18\.20\.4/i);
     assert.match(report.driftWarning ?? '', /lifecycle=7\.7\.7/i);
     assert.equal(
       report.alignmentCommand,
-      `npm install --save-exact pumuki@${getCurrentPumukiVersion()} && npx --yes --package pumuki@${getCurrentPumukiVersion()} pumuki install`
+      `volta install node@18.20.4 && volta pin node@18.20.4 && npm install --save-exact pumuki@${getCurrentPumukiVersion()} && npx --yes --package pumuki@${getCurrentPumukiVersion()} pumuki install`
     );
     assert.equal(report.pathExecutionHazard, false);
     assert.equal(report.pathExecutionWarning, null);
     assert.equal(report.pathExecutionWorkaroundCommand, null);
+  });
+});
+
+test('buildLifecycleVersionReport usa .nvmrc cuando el consumer no declara volta', async () => {
+  await withTempDir('pumuki-package-info-report-nvmrc-', async (repoRoot) => {
+    const packageRoot = join(repoRoot, 'node_modules', getCurrentPumukiPackageName());
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({ name: getCurrentPumukiPackageName(), version: '8.8.8' }, null, 2),
+      'utf8'
+    );
+    writeFileSync(join(repoRoot, '.nvmrc'), '18.20.4\n', 'utf8');
+
+    const report = buildLifecycleVersionReport({
+      repoRoot,
+      lifecycleVersion: '7.7.7',
+    });
+
+    assert.equal(report.driftFromRuntime, true);
+    assert.match(report.driftWarning ?? '', /node=18\.20\.4/i);
+    assert.equal(
+      report.alignmentCommand,
+      `nvm install 18.20.4 && nvm use 18.20.4 && npm install --save-exact pumuki@${getCurrentPumukiVersion()} && npx --yes --package pumuki@${getCurrentPumukiVersion()} pumuki install`
+    );
   });
 });
 

--- a/integrations/lifecycle/packageInfo.ts
+++ b/integrations/lifecycle/packageInfo.ts
@@ -49,15 +49,126 @@ const hasPathExecutionHazard = (repoRoot?: string): boolean =>
   repoRoot.trim().length > 0 &&
   repoRoot.includes(delimiter);
 
+type ConsumerNodeRuntimeSpec = {
+  version: string;
+  source: 'volta' | '.nvmrc' | 'package.engines';
+  commandPrefix: 'volta' | 'nvm';
+};
+
+const normalizeNodeVersionToken = (value: string): string =>
+  value.trim().replace(/^node@/i, '').replace(/^v/i, '');
+
+const extractNodeVersionToken = (value: string): string | null => {
+  const normalized = normalizeNodeVersionToken(value);
+  const exactVersion = normalized.match(/\d+\.\d+\.\d+/)?.[0];
+  if (exactVersion) {
+    return exactVersion;
+  }
+  const majorOnly = normalized.match(/^\d+$/)?.[0];
+  return majorOnly ?? null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readNestedString = (
+  source: Record<string, unknown>,
+  path: ReadonlyArray<string>
+): string | undefined => {
+  let cursor: unknown = source;
+  for (const segment of path) {
+    if (!isRecord(cursor)) {
+      return undefined;
+    }
+    cursor = cursor[segment];
+  }
+  return typeof cursor === 'string' && cursor.trim().length > 0 ? cursor.trim() : undefined;
+};
+
+const readConsumerNodeRuntimeSpec = (repoRoot?: string): ConsumerNodeRuntimeSpec | null => {
+  if (typeof repoRoot !== 'string' || repoRoot.trim().length === 0) {
+    return null;
+  }
+
+  const packageJsonPath = join(repoRoot, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as unknown;
+      if (isRecord(parsed)) {
+        const voltaNode = readNestedString(parsed, ['volta', 'node']);
+        const voltaVersion = voltaNode ? extractNodeVersionToken(voltaNode) : null;
+        if (voltaVersion) {
+          return {
+            version: voltaVersion,
+            source: 'volta',
+            commandPrefix: 'volta',
+          };
+        }
+
+        const enginesNode = readNestedString(parsed, ['engines', 'node']);
+        const enginesVersion = enginesNode ? extractNodeVersionToken(enginesNode) : null;
+        if (enginesVersion) {
+          return {
+            version: enginesVersion,
+            source: 'package.engines',
+            commandPrefix: 'nvm',
+          };
+        }
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  const nvmrcPath = join(repoRoot, '.nvmrc');
+  if (existsSync(nvmrcPath)) {
+    try {
+      const nvmrcVersion = extractNodeVersionToken(readFileSync(nvmrcPath, 'utf8'));
+      if (nvmrcVersion) {
+        return {
+          version: nvmrcVersion,
+          source: '.nvmrc',
+          commandPrefix: 'nvm',
+        };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+const buildConsumerNodeAlignmentCommand = (repoRoot?: string): string | null => {
+  const runtimeSpec = readConsumerNodeRuntimeSpec(repoRoot);
+  if (!runtimeSpec) {
+    return null;
+  }
+
+  const currentNodeVersion = normalizeNodeVersionToken(process.version);
+  if (currentNodeVersion === runtimeSpec.version) {
+    return null;
+  }
+
+  if (runtimeSpec.commandPrefix === 'volta') {
+    return `volta install node@${runtimeSpec.version} && volta pin node@${runtimeSpec.version}`;
+  }
+
+  return `nvm install ${runtimeSpec.version} && nvm use ${runtimeSpec.version}`;
+};
+
 export const buildLifecycleAlignmentCommand = (
   runtimeVersion: string,
   repoRoot?: string
 ): string => {
+  const consumerNodeAlignmentCommand = buildConsumerNodeAlignmentCommand(repoRoot);
   const installStep = `npm install --save-exact pumuki@${runtimeVersion}`;
   const runStep = hasPathExecutionHazard(repoRoot)
     ? `${buildLocalPumukiCommand()} install`
     : `npx --yes --package pumuki@${runtimeVersion} pumuki install`;
-  return `${installStep} && ${runStep}`;
+  return [consumerNodeAlignmentCommand, installStep, runStep]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join(' && ');
 };
 
 export const resolvePumukiVersionMetadata = (params?: { repoRoot?: string }): PumukiVersionMetadata => {
@@ -114,11 +225,17 @@ export const buildLifecycleVersionReport = (params?: {
   const driftFromConsumerInstalled =
     metadata.consumerInstalledVersion !== null &&
     metadata.consumerInstalledVersion !== metadata.runtimeVersion;
+  const consumerNodeSpec = readConsumerNodeRuntimeSpec(params?.repoRoot);
+  const consumerNodeVersion = consumerNodeSpec?.version ?? null;
+  const currentNodeVersion = normalizeNodeVersionToken(process.version);
+  const driftFromConsumerNode =
+    consumerNodeVersion !== null && currentNodeVersion !== consumerNodeVersion;
   const driftFromLifecycleInstalled =
     lifecycleInstalled !== null && metadata.resolvedVersion !== lifecycleInstalled;
   const driftTargets = [
     driftFromRuntime ? `runtime=${metadata.runtimeVersion}` : null,
     driftFromConsumerInstalled ? `consumer=${metadata.consumerInstalledVersion}` : null,
+    driftFromConsumerNode ? `node=${consumerNodeVersion}` : null,
     driftFromLifecycleInstalled ? `lifecycle=${lifecycleInstalled}` : null,
   ].filter((value): value is string => value !== null);
   const pathExecutionHazard = hasPathExecutionHazard(params?.repoRoot);

--- a/integrations/lifecycle/watch.ts
+++ b/integrations/lifecycle/watch.ts
@@ -736,7 +736,7 @@ export const runLifecycleWatch = async (
           driftFromRuntime,
           driftWarning,
           alignmentCommand: driftFromRuntime
-            ? buildLifecycleAlignmentCommand(versionMetadata.runtimeVersion)
+            ? buildLifecycleAlignmentCommand(versionMetadata.runtimeVersion, repoRoot)
             : null,
         },
         stage,


### PR DESCRIPTION
Consumer-repo runtime selection now respects volta, .nvmrc, or package.json.engines.node when building version remediation commands. This keeps alignment instructions reproducible in the repo that installs Pumuki.