### PR TITLE
fix(skills): audit AST rule thresholds

### DIFF
--- a/core/facts/detectors/astRuleThresholdAudit.test.ts
+++ b/core/facts/detectors/astRuleThresholdAudit.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const detectorFiles = [
+  'core/facts/detectors/text/ios.ts',
+  'core/facts/detectors/text/android.ts',
+  'core/facts/detectors/typescript/index.ts',
+  'core/facts/detectors/security/securityCredentials.ts',
+];
+
+const forbiddenDecisionThresholds = [
+  /typeDeclarations\.length\s*<\s*\d+/,
+  /conformingTypes\.length\s*<\s*\d+/,
+  /trim\(\)\.length\s*>=\s*\d+/,
+  /relatedNodes\.length\s*<\s*\d+/,
+  /typedCaseCount\s*>=\s*\d+/,
+  /caseNodes\.length\s*<\s*\d+/,
+  /branchNodes\.length\s*<\s*\d+/,
+  /slice\(0,\s*\d+\)/,
+];
+
+test('detectores AST estructurales no usan umbrales internos para decidir skills', () => {
+  const violations = detectorFiles.flatMap((filePath) => {
+    const content = readFileSync(join(process.cwd(), filePath), 'utf8');
+    return forbiddenDecisionThresholds
+      .filter((pattern) => pattern.test(content))
+      .map((pattern) => `${filePath}: ${pattern.source}`);
+  });
+
+  assert.deepEqual(violations, []);
+});

--- a/core/facts/detectors/security/index.test.ts
+++ b/core/facts/detectors/security/index.test.ts
@@ -15,7 +15,7 @@ import {
   hasWeakTokenGenerationWithCryptoRandomUuid,
 } from './index';
 
-test('hasHardcodedSecretTokenLiteral detecta literales fuertes en identificadores sensibles', () => {
+test('hasHardcodedSecretTokenLiteral detecta literales reales en identificadores sensibles', () => {
   const ast = {
     type: 'VariableDeclarator',
     id: { type: 'Identifier', name: 'apiToken' },
@@ -24,11 +24,17 @@ test('hasHardcodedSecretTokenLiteral detecta literales fuertes en identificadore
   const safeAst = {
     type: 'VariableDeclarator',
     id: { type: 'Identifier', name: 'apiToken' },
-    init: { type: 'StringLiteral', value: 'short' },
+    init: { type: 'StringLiteral', value: 'example' },
+  };
+  const shortRealSecretAst = {
+    type: 'VariableDeclarator',
+    id: { type: 'Identifier', name: 'apiToken' },
+    init: { type: 'StringLiteral', value: 'prod' },
   };
 
   assert.equal(hasHardcodedSecretTokenLiteral(ast), true);
   assert.equal(hasHardcodedSecretTokenLiteral(safeAst), false);
+  assert.equal(hasHardcodedSecretTokenLiteral(shortRealSecretAst), true);
 });
 
 test('hasInsecureTokenGenerationWithMathRandom detecta Math.random en asignacion sensible', () => {

--- a/core/facts/detectors/security/securityCredentials.test.ts
+++ b/core/facts/detectors/security/securityCredentials.test.ts
@@ -11,16 +11,21 @@ import {
   hasWeakTokenGenerationWithCryptoRandomUuid,
 } from './securityCredentials';
 
-test('hasHardcodedSecretTokenLiteral detecta literal largo en identificador sensible', () => {
+test('hasHardcodedSecretTokenLiteral detecta literal real en identificador sensible', () => {
   const hardcodedSecretAst = {
     type: 'VariableDeclarator',
     id: { type: 'Identifier', name: 'apiKey' },
     init: { type: 'StringLiteral', value: 'super-secret-key-123' },
   };
-  const safeLengthAst = {
+  const placeholderAst = {
     type: 'VariableDeclarator',
     id: { type: 'Identifier', name: 'apiKey' },
-    init: { type: 'StringLiteral', value: 'short' },
+    init: { type: 'StringLiteral', value: 'replace-me' },
+  };
+  const shortRealSecretAst = {
+    type: 'VariableDeclarator',
+    id: { type: 'Identifier', name: 'apiKey' },
+    init: { type: 'StringLiteral', value: 'prod' },
   };
   const nonSensitiveIdentifierAst = {
     type: 'VariableDeclarator',
@@ -29,7 +34,8 @@ test('hasHardcodedSecretTokenLiteral detecta literal largo en identificador sens
   };
 
   assert.equal(hasHardcodedSecretTokenLiteral(hardcodedSecretAst), true);
-  assert.equal(hasHardcodedSecretTokenLiteral(safeLengthAst), false);
+  assert.equal(hasHardcodedSecretTokenLiteral(placeholderAst), false);
+  assert.equal(hasHardcodedSecretTokenLiteral(shortRealSecretAst), true);
   assert.equal(hasHardcodedSecretTokenLiteral(nonSensitiveIdentifierAst), false);
 });
 

--- a/core/facts/detectors/security/securityCredentials.ts
+++ b/core/facts/detectors/security/securityCredentials.ts
@@ -1,13 +1,15 @@
 import { collectNodeLineMatches, hasNode, isObject } from '../utils/astHelpers';
 
 const sensitiveIdentifierPattern = /(secret|token|password|api[_-]?key)/i;
+const placeholderSecretLiteralPattern =
+  /^(?:changeme|change-me|change_me|replace-me|replace_me|todo|tbd|example|sample|dummy|test|testing|placeholder|your[_-]?(?:secret|token|password|api[_-]?key)|xxx+)$/i;
 
-const hasStrongLiteralValue = (value: unknown): boolean => {
+const hasCredentialLiteralValue = (value: unknown): boolean => {
   if (!isObject(value)) {
     return false;
   }
   if (value.type === 'StringLiteral') {
-    return typeof value.value === 'string' && value.value.trim().length >= 12;
+    return typeof value.value === 'string' && isCredentialLiteral(value.value);
   }
   if (
     value.type === 'TemplateLiteral' &&
@@ -17,9 +19,14 @@ const hasStrongLiteralValue = (value: unknown): boolean => {
     value.quasis.length === 1
   ) {
     const cooked = value.quasis[0]?.value?.cooked;
-    return typeof cooked === 'string' && cooked.trim().length >= 12;
+    return typeof cooked === 'string' && isCredentialLiteral(cooked);
   }
   return false;
+};
+
+const isCredentialLiteral = (value: string): boolean => {
+  const normalized = value.trim();
+  return normalized.length > 0 && !placeholderSecretLiteralPattern.test(normalized);
 };
 
 const containsMathRandomCall = (candidate: unknown): boolean => {
@@ -109,7 +116,7 @@ const isHardcodedSecretTokenLiteralNode = (value: Record<string, string | number
   if (!sensitiveIdentifierPattern.test(idNode.name as string)) {
     return false;
   }
-  return hasStrongLiteralValue(value.init);
+  return hasCredentialLiteralValue(value.init);
 };
 
 const isInsecureTokenGenerationWithMathRandomNode = (value: Record<string, string | number | boolean | bigint | symbol | null | Date | object>): boolean => {

--- a/core/facts/detectors/text/android.ts
+++ b/core/facts/detectors/text/android.ts
@@ -699,9 +699,6 @@ export const findKotlinLiskovSubstitutionMatch = (
   }
 
   const typeDeclarations = parseKotlinTypeDeclarations(source);
-  if (typeDeclarations.length < 2) {
-    return undefined;
-  }
 
   const sourceLines = source.split(/\r?\n/);
 
@@ -714,9 +711,6 @@ export const findKotlinLiskovSubstitutionMatch = (
     const conformingTypes = typeDeclarations.filter((typeDeclaration) =>
       typeDeclaration.conformances.includes(interfaceDeclaration.name)
     );
-    if (conformingTypes.length < 2) {
-      continue;
-    }
 
     for (const memberName of memberNames) {
       let safeType: KotlinTypeDeclaration | undefined;

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -1435,9 +1435,6 @@ export const findSwiftLiskovSubstitutionMatch = (
   }
 
   const typeDeclarations = parseSwiftTypeDeclarations(source);
-  if (typeDeclarations.length < 2) {
-    return undefined;
-  }
 
   const sourceLines = source.split(/\r?\n/);
 
@@ -1450,9 +1447,6 @@ export const findSwiftLiskovSubstitutionMatch = (
     const conformingTypes = typeDeclarations.filter((typeDeclaration) =>
       typeDeclaration.conformances.includes(protocolDeclaration.name)
     );
-    if (conformingTypes.length < 2) {
-      continue;
-    }
 
     for (const memberName of memberNames) {
       let safeType: SwiftTypeDeclaration | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.123",
+  "version": "6.3.124",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.123",
+      "version": "6.3.124",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.123",
+  "version": "6.3.124",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Escenario\nPUMUKI-INC-117: la auditoría anterior no cubría todas las skills/reglas AST inteligentes del core y aún quedaban decisiones internas basadas en cardinalidad/longitud.\n\n## Tests\n- npx --yes tsx@4.21.0 --test core/facts/detectors/astRuleThresholdAudit.test.ts core/facts/detectors/security/securityCredentials.test.ts core/facts/detectors/security/index.test.ts core/facts/detectors/text/ios.test.ts core/facts/detectors/text/android.test.ts core/facts/detectors/typescript/index.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/securityCredentialsRules.test.ts core/rules/presets/heuristics/typescript.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts\n- rg -n "typeDeclarations\.length\s*<\s*\d+|conformingTypes\.length\s*<\s*\d+|trim\(\)\.length\s*>=\s*\d+|relatedNodes\.length < [0-9]|typedCaseCount >= [0-9]|caseNodes\.length < [0-9]|branchNodes\.length < [0-9]|slice\(0,\s*[0-9]\)" core/facts/detectors/text core/facts/detectors/typescript/index.ts core/facts/detectors/security/securityCredentials.ts\n- npm --cache /tmp/pumuki-npm-cache pack --dry-run\n\n## Evidencia\n- Suite dirigida: 140/140 pass.\n- Auditoría textual: sin resultados.\n- Pack dry-run: pumuki@6.3.124 correcto.\n- npm run -s typecheck sigue bloqueado por errores preexistentes no tocados en esta slice.\n\n## Task\nPUMUKI-INC-117\n\n---\n🐈💚 Pumuki Team® - Automated Git Flow