### PR TITLE
chore: release pumuki 6.3.131

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.130",
+  "version": "6.3.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.130",
+      "version": "6.3.131",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.130",
+  "version": "6.3.131",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package version to `6.3.131` for the iOS critical testing skill coverage fix merged in #845

## Validation
- `node --import tsx --test integrations/config/__tests__/iosAvdleeParity.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/skillsRuleSet.test.ts integrations/gate/__tests__/evaluateAiGate.test.ts integrations/git/__tests__/runPlatformGate.test.ts` -> 172/172 pass
- `node --import tsx scripts/compile-skills-lock.ts --check` -> FRESH
- `git diff --check` -> clean
- `npm pack --dry-run` -> `pumuki@6.3.131`, 1120 files, 3.9 MB
