### PR TITLE
chore: release pumuki 6.3.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.3.140] - 2026-05-05
+
+### Fixed
+
+- **PRE_PUSH atomicity por commit:** el guard de atomicidad evalúa cada commit del rango de push de forma independiente, evitando que una rama formada por commits atómicos quede bloqueada por el diff agregado.
+- **Falsos positivos de metadata:** `hardcoded-values` y `magic-numbers` dejan de bloquear literales internos de policy/evidence/analytics y constantes estándar, manteniendo la detección real de configuración hardcoded.
+
 ## [6.3.139] - 2026-05-05
 
 ### Fixed

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This file tracks the active deterministic framework line used in this repository
 Canonical release chronology lives in `CHANGELOG.md`.
 This file keeps only the operational highlights and rollout notes that matter while running the framework.
 
+### 2026-05-05 (v6.3.140)
+
+- **PRE_PUSH compatible con ramas largas:** la atomicidad se valida por commit individual, no por diff agregado de rama.
+- **Skills sin falsos positivos de metadata:** el diff de release queda con `hardcoded-values`/`magic-numbers` a `0` para ficheros cambiados.
+- **Rollout:** publicar `pumuki@6.3.140`, repinear primero RuralGo y repetir validaciones `status`, `doctor` y hooks gestionados.
+
 ### 2026-05-05 (v6.3.139)
 
 - **Baseline tests antes de editar:** Pumuki bloquea cambios TDD/BDD in-scope si cada slice no registra un baseline test pasado antes de RED.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.139",
+  "version": "6.3.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.139",
+      "version": "6.3.140",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.139",
+  "version": "6.3.140",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps package metadata to pumuki@6.3.140.
- Documents the PRE_PUSH per-commit atomicity fix and metadata false-positive reduction.

## Validation
- npm publish --dry-run --access public
- npm publish --access public -> + pumuki@6.3.140
- npm view pumuki version -> 6.3.140
- release branch push ran managed PRE_WRITE + PRE_PUSH hooks and returned ALLOW
- RuralGo first repin branch chore/pumuki-6-3-140-rollout pushed after status alignment.