### PR TITLE
chore: release pumuki 6.3.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.3.141] - 2026-05-05
+
+### Fixed
+
+- **PRE_PUSH en ramas actualizadas desde base:** el guard de atomicidad ignora commits heredados de `main`/`develop` y commits merge al validar trazabilidad y límites por commit, evitando bloqueos falsos en rollouts que solo resolvieron conflictos con la rama base.
+
 ## [6.3.140] - 2026-05-05
 
 ### Fixed

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This file tracks the active deterministic framework line used in this repository
 Canonical release chronology lives in `CHANGELOG.md`.
 This file keeps only the operational highlights and rollout notes that matter while running the framework.
 
+### 2026-05-05 (v6.3.141)
+
+- **PRE_PUSH sin falso bloqueo por historial base:** ramas de rollout que integran `main`/`develop` dejan de fallar por commits merge heredados como `Merge pull request ...`.
+- **Flux/SAAS follow-up:** esta patch desbloquea el push de las resoluciones de conflicto de los PRs de repin abiertos tras `6.3.140`.
+- **Rollout:** publicar `pumuki@6.3.141`, repinear primero RuralGo y repetir Flux/SAAS sin bypass.
+
 ### 2026-05-05 (v6.3.140)
 
 - **PRE_PUSH compatible con ramas largas:** la atomicidad se valida por commit individual, no por diff agregado de rama.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.140",
+  "version": "6.3.141",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.140",
+      "version": "6.3.141",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.140",
+  "version": "6.3.141",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary\n- Release pumuki@6.3.141 after PRE_PUSH base-history fix.\n- Document rollout notes for RuralGo, Flux and SAAS.\n\n## Evidence\n- PUMUKI_DISABLE_SYSTEM_NOTIFICATIONS=1 node --import tsx --test integrations/git/__tests__/gitAtomicity.test.ts\n- npm publish --dry-run --access public\n- npm publish --access public -> + pumuki@6.3.141\n- npm view pumuki version -> 6.3.141