### PR TITLE
fix(tdd): block stale baseline evidence

### DIFF
--- a/integrations/git/__tests__/tddBddEnforcement.test.ts
+++ b/integrations/git/__tests__/tddBddEnforcement.test.ts
@@ -28,6 +28,13 @@ const withEnv = async (
   }
 };
 
+const withFreshTddEvidenceWindow = async (
+  maxAgeSeconds: number,
+  callback: () => Promise<void>
+): Promise<void> => {
+  await withEnv('PUMUKI_TDD_BDD_EVIDENCE_MAX_AGE_SECONDS', String(maxAgeSeconds), callback);
+};
+
 const addedFeatureFacts = (): ReadonlyArray<Fact> => [
   {
     kind: 'FileChange',
@@ -68,6 +75,7 @@ test('enforceTddBddPolicy bloquea cuando falta contrato de evidencia en cambio i
       repoRoot,
       branch: 'feature/tdd',
       facts: addedFeatureFacts(),
+      now: () => Date.parse('2026-02-26T10:05:00.000Z'),
     });
 
     assert.equal(result.snapshot.status, 'blocked');
@@ -115,6 +123,7 @@ test('enforceTddBddPolicy pasa cuando contrato es valido y enlaza .feature exist
       repoRoot,
       branch: 'feature/tdd',
       facts: addedFeatureFacts(),
+      now: () => Date.parse('2026-02-26T10:05:00.000Z'),
     });
 
     assert.equal(result.snapshot.status, 'passed');
@@ -127,6 +136,75 @@ test('enforceTddBddPolicy pasa cuando contrato es valido y enlaza .feature exist
       failed: 0,
     });
     assert.equal(result.findings.length, 0);
+  });
+});
+
+test('enforceTddBddPolicy bloquea cuando la evidencia baseline queda caducada antes de editar', async () => {
+  await withFreshTddEvidenceWindow(300, async () => {
+    await withTempDir('pumuki-tdd-enforce-stale-baseline-', async (repoRoot) => {
+      mkdirSync(join(repoRoot, '.pumuki', 'artifacts'), { recursive: true });
+      mkdirSync(join(repoRoot, 'features'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'features', 'onboarding.feature'),
+        'Feature: Onboarding\n  Scenario: complete onboarding routes to login\n',
+        'utf8'
+      );
+      writeFileSync(
+        join(repoRoot, '.pumuki', 'artifacts', 'pumuki-evidence-v1.json'),
+        JSON.stringify(
+          {
+            version: '1',
+            generated_at: '2026-02-26T09:00:00.000Z',
+            slices: [
+              {
+                id: 'rgo-launch-flow-baseline',
+                scenario_ref: 'features/onboarding.feature:2',
+                baseline: {
+                  status: 'passed',
+                  timestamp: '2026-02-26T09:00:00.000Z',
+                  test_ref:
+                    'xcodebuild test -only-testing:RuralGoMacTests/LaunchFlowModelTests/test_completeOnboarding_marksCompletedAndRoutesToLogin',
+                },
+                red: { status: 'failed', timestamp: '2026-02-26T09:01:00.000Z' },
+                green: { status: 'passed', timestamp: '2026-02-26T09:02:00.000Z' },
+                refactor: { status: 'passed', timestamp: '2026-02-26T09:03:00.000Z' },
+              },
+            ],
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+
+      const result = enforceTddBddPolicy({
+        repoRoot,
+        branch: 'feature/rgo-1900-01-ios-buyer-core',
+        facts: [
+          {
+            kind: 'FileChange',
+            source: 'test',
+            path: 'apps/ios/Presentation/Onboarding/LaunchFlowCoordinator.swift',
+            changeType: 'modified',
+          },
+          {
+            kind: 'FileContent',
+            source: 'test',
+            path: 'apps/ios/Presentation/Onboarding/LaunchFlowCoordinator.swift',
+            content: 'public final class LaunchFlowCoordinator { public func bootstrap() {} }',
+          },
+        ],
+        now: () => Date.parse('2026-02-26T09:10:01.000Z'),
+      });
+
+      assert.equal(result.snapshot.status, 'blocked');
+      assert.equal(result.snapshot.evidence.errors.includes('TDD_BDD_EVIDENCE_STALE'), true);
+      assert.equal(
+        result.findings.some((finding) => finding.code === 'TDD_BDD_EVIDENCE_STALE'),
+        true
+      );
+      assert.equal(result.snapshot.evidence.baseline.required, true);
+    });
   });
 });
 
@@ -165,6 +243,7 @@ test('enforceTddBddPolicy bloquea cuando falta baseline verde antes del RED', as
       repoRoot,
       branch: 'feature/tdd',
       facts: addedFeatureFacts(),
+      now: () => Date.parse('2026-02-26T10:05:00.000Z'),
     });
 
     assert.equal(result.snapshot.status, 'blocked');
@@ -221,6 +300,7 @@ test('enforceTddBddPolicy bloquea cuando el baseline previo falla', async () => 
       repoRoot,
       branch: 'feature/tdd',
       facts: addedFeatureFacts(),
+      now: () => Date.parse('2026-02-26T10:05:00.000Z'),
     });
 
     assert.equal(result.snapshot.status, 'blocked');
@@ -267,6 +347,7 @@ test('enforceTddBddPolicy bloquea cuando scenario_ref no apunta a archivo .featu
       repoRoot,
       branch: 'feature/tdd',
       facts: addedFeatureFacts(),
+      now: () => Date.parse('2026-02-26T10:05:00.000Z'),
     });
 
     assert.equal(result.snapshot.status, 'blocked');

--- a/integrations/tdd/enforcement.ts
+++ b/integrations/tdd/enforcement.ts
@@ -76,10 +76,33 @@ const isTimelineOrdered = (timestamps: ReadonlyArray<string | undefined>): boole
   return true;
 };
 
+const DEFAULT_EVIDENCE_MAX_AGE_SECONDS = 900;
+
+const resolveEvidenceMaxAgeSeconds = (): number => {
+  const raw = process.env.PUMUKI_TDD_BDD_EVIDENCE_MAX_AGE_SECONDS?.trim();
+  if (!raw) {
+    return DEFAULT_EVIDENCE_MAX_AGE_SECONDS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_EVIDENCE_MAX_AGE_SECONDS;
+  }
+  return parsed;
+};
+
+const resolveEvidenceAgeSeconds = (generatedAt: string, nowMs: number): number | null => {
+  const generatedAtMs = new Date(generatedAt).getTime();
+  if (Number.isNaN(generatedAtMs)) {
+    return null;
+  }
+  return Math.max(0, Math.floor((nowMs - generatedAtMs) / 1000));
+};
+
 export const enforceTddBddPolicy = (params: {
   facts: ReadonlyArray<Fact>;
   repoRoot: string;
   branch: string | null;
+  now?: () => number;
 }): TddBddEnforcementResult => {
   const scope = classifyTddBddScope(params.facts);
   const baseSnapshot: TddBddSnapshot = {
@@ -205,6 +228,46 @@ export const enforceTddBddPolicy = (params: {
           version: evidenceRead.version,
           integrity_ok: false,
           errors: [evidenceRead.reason],
+        },
+      },
+    };
+  }
+
+  const maxAgeSeconds = resolveEvidenceMaxAgeSeconds();
+  const ageSeconds = resolveEvidenceAgeSeconds(
+    evidenceRead.evidence.generated_at,
+    params.now?.() ?? Date.now()
+  );
+  if (ageSeconds === null || ageSeconds > maxAgeSeconds) {
+    const messageAge =
+      ageSeconds === null ? 'unknown' : `${ageSeconds}s`;
+    const finding = buildFinding({
+      ruleId: 'generic_tdd_baseline_required',
+      code: 'TDD_BDD_EVIDENCE_STALE',
+      message:
+        `TDD/BDD evidence is stale for this PRE_WRITE baseline: age=${messageAge}, max=${maxAgeSeconds}s. Re-run the baseline tests for the touched component and refresh evidence before editing related code.`,
+      filePath: evidenceRead.path,
+    });
+    return {
+      findings: [finding],
+      snapshot: {
+        ...baseSnapshot,
+        status: 'blocked',
+        evidence: {
+          ...baseSnapshot.evidence,
+          state: 'valid',
+          version: evidenceRead.evidence.version,
+          slices_total: evidenceRead.evidence.slices.length,
+          slices_valid: 0,
+          slices_invalid: evidenceRead.evidence.slices.length,
+          integrity_ok: evidenceRead.integrity.valid,
+          errors: ['TDD_BDD_EVIDENCE_STALE'],
+          baseline: {
+            required: true,
+            passed: 0,
+            missing: 0,
+            failed: 0,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary\n- Blocks in-scope TDD/BDD changes when baseline evidence is stale.\n- Adds configurable freshness window via PUMUKI_TDD_BDD_EVIDENCE_MAX_AGE_SECONDS, default 900s.\n- Covers RuralGo INC-060 shape: editing LaunchFlowCoordinator requires fresh baseline evidence before continuing.\n\n## Validation\n- node --import tsx --test integrations/git/__tests__/tddBddEnforcement.test.ts integrations/policy/__tests__/tddBddEnforcement.test.ts integrations/gate/__tests__/evaluateAiGate.test.ts\n- node --import tsx --test integrations/evidence/writeEvidence.test.ts integrations/evidence/__tests__/buildEvidence.test.ts integrations/lifecycle/__tests__/saasIngestionContract.test.ts integrations/lifecycle/__tests__/saasIngestionBuilder.test.ts\n- git diff --check\n- managed pre-write/pre-commit hooks passed on commit