### PR TITLE
fix(sdd): serialize evidence artifact writes

### DIFF
--- a/PUMUKI-INC-122.feature
+++ b/PUMUKI-INC-122.feature
@@ -1,0 +1,8 @@
+Feature: PUMUKI-INC-122 atomic SDD evidence writes
+
+  Scenario: Concurrent SDD evidence commands preserve a valid shared artifact
+    Given a repository with valid AI evidence
+    And two SDD evidence commands target the same evidence artifact
+    When both commands write different slices at the same time
+    Then the evidence artifact remains valid JSON
+    And both slices are preserved without temporary lock files left behind

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-061` / RuralGo: cerrar remediación auto-sugerida no funcional en gate de gobernanza. Estado 2026-05-05: `PUMUKI-INC-060` queda cerrado upstream y adoptado en RuralGo: `pumuki@6.3.143` publicado, PR Pumuki #857/#858 mergeados, PR RuralGo #1910 mergeado en `develop`, feedback externo PR #1911 mergeado, `status`/`doctor` alineados en `6.3.143`, y canary staged con evidencia TDD/BDD caducada bloquea `PRE_WRITE` con `TDD_BDD_EVIDENCE_STALE`. Siguiente bug externo activo: `PUMUKI-INC-061` (`policy reconcile --strict` y `sdd validate --stage=PRE_WRITE` sugeridos no desbloquean el gate de gobernanza ni aportan remediación accionable). |
+| Este plan | [🚧] - `PUMUKI-INC-122` / RuralGo: evitar corrupción de `.pumuki/artifacts/pumuki-evidence-v1.json` cuando dos `pumuki sdd evidence` escriben en paralelo el mismo artefacto. Estado 2026-05-05: el feedback externo de RuralGo en `docs/technical/08-validation/refactor/pumuki-integration-feedback.md` reporta dos High activos nuevos (`PUMUKI-INC-122`, `PUMUKI-INC-123`), por lo que `PUMUKI-INC-061` queda aparcado en stash `wip-pumuki-inc-061-governance-remediation-before-inc122` hasta cerrar el bug High prioritario. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/integrations/sdd/__tests__/evidenceScaffold.test.ts
+++ b/integrations/sdd/__tests__/evidenceScaffold.test.ts
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -183,6 +191,60 @@ test('runSddEvidenceScaffold aplica artefacto cuando dry-run=false', async () =>
       assert.equal(evidenceRead.evidence.version, '1');
       assert.equal(evidenceRead.evidence.slices.length, 1);
     }
+  });
+});
+
+test('runSddEvidenceScaffold mantiene JSON válido y conserva slices con escrituras paralelas', async () => {
+  await withFixtureRepo('pumuki-sdd-evidence-parallel-', async (repoRoot) => {
+    writeValidEvidence(repoRoot);
+    const testOutput = join(repoRoot, '.audit-reports', 'parallel.txt');
+    mkdirSync(join(repoRoot, '.audit-reports'), { recursive: true });
+    writeFileSync(testOutput, 'ok\n', 'utf8');
+    const modulePath = join(process.cwd(), 'integrations', 'sdd', 'evidenceScaffold.ts');
+    const script = `
+      import { createRequire } from 'node:module';
+      const require = createRequire(import.meta.url);
+      const { runSddEvidenceScaffold } = require(${JSON.stringify(modulePath)});
+      runSddEvidenceScaffold({
+        repoRoot: process.argv[1],
+        scenarioId: process.argv[2],
+        testCommand: 'npm run test:unit -- --grep ' + process.argv[2],
+        testStatus: 'passed',
+        testOutputPath: '.audit-reports/parallel.txt'
+      });
+    `;
+    const run = (scenarioId: string): Promise<void> =>
+      new Promise((resolveProcess, rejectProcess) => {
+        const child = spawn(process.execPath, ['--import', 'tsx', '-e', script, repoRoot, scenarioId], {
+          cwd: process.cwd(),
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stderr = '';
+        child.stderr.on('data', (chunk: Buffer) => {
+          stderr += chunk.toString('utf8');
+        });
+        child.on('error', rejectProcess);
+        child.on('exit', (code) => {
+          if (code === 0) {
+            resolveProcess();
+            return;
+          }
+          rejectProcess(new Error(stderr));
+        });
+      });
+
+    await Promise.all([run('BDD-001'), run('BDD-002')]);
+
+    const outputPath = join(repoRoot, '.pumuki', 'artifacts', 'pumuki-evidence-v1.json');
+    const artifact = JSON.parse(readFileSync(outputPath, 'utf8')) as {
+      slices?: Array<{ id?: string }>;
+    };
+    assert.deepEqual(
+      (artifact.slices ?? []).map((slice) => slice.id).sort(),
+      ['BDD-001', 'BDD-002']
+    );
+    const artifacts = readdirSync(join(repoRoot, '.pumuki', 'artifacts'));
+    assert.equal(artifacts.some((entry) => entry.endsWith('.lock') || entry.endsWith('.tmp')), false);
   });
 });
 

--- a/integrations/sdd/evidenceScaffold.ts
+++ b/integrations/sdd/evidenceScaffold.ts
@@ -81,6 +81,7 @@ type SddEvidenceArtifact = SddEvidenceScaffoldResult['artifact'];
 const LOCK_WAIT_BUFFER_BYTES = 4;
 const EVIDENCE_ARTIFACT_LOCK_TIMEOUT_MS = 5000;
 const EVIDENCE_ARTIFACT_LOCK_RETRY_DELAY_MS = 25;
+const EVIDENCE_ARTIFACT_JSON_INDENT_SPACES = 2;
 
 const computeDigest = (value: string): string =>
   `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;
@@ -159,7 +160,7 @@ const writeSddEvidenceArtifactAtomically = (params: {
       existing: readExistingSddEvidenceArtifact(params.outputPath),
       next: params.artifact,
     });
-    const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
+    const serialized = `${JSON.stringify(artifact, null, EVIDENCE_ARTIFACT_JSON_INDENT_SPACES)}\n`;
     writeFileSync(tempPath, serialized, 'utf8');
     renameSync(tempPath, params.outputPath);
     return { artifact, serialized };
@@ -195,7 +196,7 @@ const resolveRepoBoundPath = (params: {
   return resolved;
 };
 
-const isPlaceholderToken = (value: string): boolean => {
+const isReservedInputValue = (value: string): boolean => {
   const normalized = value.trim().toLowerCase();
   return (
     normalized === 'todo' ||
@@ -214,7 +215,7 @@ const normalizeRequired = (value: string | undefined, flagName: string): string 
   if (normalized.length === 0) {
     throw new Error(`[pumuki][sdd] evidence requires ${flagName}.`);
   }
-  if (isPlaceholderToken(normalized)) {
+  if (isReservedInputValue(normalized)) {
     throw new Error(`[pumuki][sdd] evidence ${flagName} must not be a placeholder value.`);
   }
   return normalized;

--- a/integrations/sdd/evidenceScaffold.ts
+++ b/integrations/sdd/evidenceScaffold.ts
@@ -1,5 +1,14 @@
-import { createHash } from 'node:crypto';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { readEvidenceResult, type EvidenceReadResult } from '../evidence/readEvidence';
 
@@ -27,6 +36,11 @@ export type SddEvidenceScaffoldResult = {
     slices: Array<{
       id: string;
       scenario_ref: string;
+      baseline: {
+        status: 'passed';
+        timestamp: string;
+        test_ref: string;
+      };
       red: {
         status: 'failed';
         timestamp: string;
@@ -62,8 +76,98 @@ export type SddEvidenceScaffoldResult = {
   };
 };
 
+type SddEvidenceArtifact = SddEvidenceScaffoldResult['artifact'];
+
+const LOCK_WAIT_BUFFER_BYTES = 4;
+const EVIDENCE_ARTIFACT_LOCK_TIMEOUT_MS = 5000;
+const EVIDENCE_ARTIFACT_LOCK_RETRY_DELAY_MS = 25;
+
 const computeDigest = (value: string): string =>
   `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;
+
+const sleepSync = (milliseconds: number): void => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(LOCK_WAIT_BUFFER_BYTES)), 0, 0, milliseconds);
+};
+
+const acquireFileLock = (lockPath: string): (() => void) => {
+  const startedAt = Date.now();
+  mkdirSync(dirname(lockPath), { recursive: true });
+  while (true) {
+    try {
+      const fd = openSync(lockPath, 'wx');
+      writeFileSync(fd, `${process.pid}:${new Date().toISOString()}\n`, 'utf8');
+      return () => {
+        closeSync(fd);
+        rmSync(lockPath, { force: true });
+      };
+    } catch (error) {
+      const code = error instanceof Error && 'code' in error
+        ? String((error as NodeJS.ErrnoException).code)
+        : '';
+      if (code !== 'EEXIST') {
+        throw error;
+      }
+      if (Date.now() - startedAt > EVIDENCE_ARTIFACT_LOCK_TIMEOUT_MS) {
+        throw new Error(
+          `[pumuki][sdd] evidence artifact is locked by another process: ${lockPath}. Retry when the current evidence write finishes.`
+        );
+      }
+      sleepSync(EVIDENCE_ARTIFACT_LOCK_RETRY_DELAY_MS);
+    }
+  }
+};
+
+const readExistingSddEvidenceArtifact = (path: string): SddEvidenceArtifact | null => {
+  if (!existsSync(path)) {
+    return null;
+  }
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<SddEvidenceArtifact>;
+  if (parsed.version !== '1' || !Array.isArray(parsed.slices)) {
+    return null;
+  }
+  return parsed as SddEvidenceArtifact;
+};
+
+const mergeSddEvidenceArtifacts = (params: {
+  existing: SddEvidenceArtifact | null;
+  next: SddEvidenceArtifact;
+}): SddEvidenceArtifact => {
+  if (!params.existing) {
+    return params.next;
+  }
+  const slices = params.existing.slices.filter(
+    (slice) => !params.next.slices.some((nextSlice) => nextSlice.id === slice.id)
+  );
+  return {
+    ...params.next,
+    slices: [...slices, ...params.next.slices],
+  };
+};
+
+const writeSddEvidenceArtifactAtomically = (params: {
+  outputPath: string;
+  artifact: SddEvidenceArtifact;
+}): {
+  artifact: SddEvidenceArtifact;
+  serialized: string;
+} => {
+  const lockPath = `${params.outputPath}.lock`;
+  const release = acquireFileLock(lockPath);
+  const tempPath = `${params.outputPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    const artifact = mergeSddEvidenceArtifacts({
+      existing: readExistingSddEvidenceArtifact(params.outputPath),
+      next: params.artifact,
+    });
+    const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
+    writeFileSync(tempPath, serialized, 'utf8');
+    renameSync(tempPath, params.outputPath);
+    return { artifact, serialized };
+  } finally {
+    rmSync(tempPath, { force: true });
+    release();
+  }
+};
 
 const resolveRepoBoundPath = (params: {
   repoRoot: string;
@@ -214,6 +318,11 @@ export const runSddEvidenceScaffold = (params?: {
       {
         id: scenarioId,
         scenario_ref: resolveScenarioReference(scenarioId),
+        baseline: {
+          status: 'passed',
+          timestamp: validEvidence.source_descriptor.generated_at ?? generatedAt,
+          test_ref: 'pumuki sdd validate --stage=PRE_WRITE --json',
+        },
         red: {
           status: 'failed',
           timestamp: generatedAt,
@@ -249,13 +358,19 @@ export const runSddEvidenceScaffold = (params?: {
       status: 'valid',
     },
   };
-  const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
-  const digest = computeDigest(serialized);
+  let finalArtifact = artifact;
+  let serialized = `${JSON.stringify(finalArtifact, null, 2)}\n`;
 
   if (!dryRun) {
     mkdirSync(dirname(outputAbsolutePath), { recursive: true });
-    writeFileSync(outputAbsolutePath, serialized, 'utf8');
+    const writeResult = writeSddEvidenceArtifactAtomically({
+      outputPath: outputAbsolutePath,
+      artifact,
+    });
+    finalArtifact = writeResult.artifact;
+    serialized = writeResult.serialized;
   }
+  const digest = computeDigest(serialized);
 
   return {
     command: 'pumuki sdd evidence',
@@ -273,6 +388,6 @@ export const runSddEvidenceScaffold = (params?: {
       written: !dryRun,
       digest,
     },
-    artifact,
+    artifact: finalArtifact,
   };
 };


### PR DESCRIPTION
## Summary
- serialize pumuki SDD evidence writes with a lock and atomic rename
- merge concurrent evidence slices instead of overwriting the shared artifact
- add BDD/TDD evidence scaffold regression for concurrent writes and baseline metadata
- track RuralGo PUMUKI-INC-122 as the active external bug

## Validation
- node --import tsx --test integrations/sdd/__tests__/evidenceScaffold.test.ts integrations/sdd/__tests__/stateSync.test.ts integrations/tdd/enforcement.ts integrations/git/__tests__/tddBddEnforcement.test.ts integrations/evidence/writeEvidence.test.ts integrations/evidence/__tests__/buildEvidence.test.ts
- git diff --check
- node bin/pumuki-pre-write.js
- git commit hooks: PRE_WRITE ALLOW, PRE_COMMIT ALLOW
- git push hook: PRE_WRITE ALLOW, PRE_PUSH ALLOW