### PR TITLE
chore(release): prepare 6.3.144

### DIFF
--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This file tracks the active deterministic framework line used in this repository
 Canonical release chronology lives in `CHANGELOG.md`.
 This file keeps only the operational highlights and rollout notes that matter while running the framework.
 
+### 2026-05-05 (v6.3.144)
+
+- **RuralGo PUMUKI-INC-122:** `pumuki sdd evidence` serializa escrituras concurrentes del artefacto `.pumuki/artifacts/pumuki-evidence-v1.json` con lock local y rename atómico.
+- **Sin pérdida de slices:** dos ejecuciones paralelas fusionan slices existentes/nuevas en lugar de pisar el JSON compartido; además el scaffold genera baseline TDD/BDD válido desde la evidencia PRE_WRITE.
+- **Rollout:** publicar `pumuki@6.3.144`, repinear primero RuralGo y revalidar `status`, `doctor` y una ráfaga concurrente de `pumuki sdd evidence`.
+
 ### 2026-05-05 (v6.3.143)
 
 - **RuralGo PUMUKI-INC-060:** PRE_WRITE deja de aceptar evidencia TDD/BDD de baseline caducada para cambios in-scope.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.143",
+  "version": "6.3.144",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.143",
+      "version": "6.3.144",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.143",
+  "version": "6.3.144",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package metadata to pumuki@6.3.144
- add release notes for RuralGo PUMUKI-INC-122

## Validation
- node --import tsx --test integrations/sdd/__tests__/evidenceScaffold.test.ts integrations/sdd/__tests__/stateSync.test.ts integrations/tdd/enforcement.ts integrations/git/__tests__/tddBddEnforcement.test.ts integrations/evidence/writeEvidence.test.ts integrations/evidence/__tests__/buildEvidence.test.ts
- npm pack --dry-run
- git diff --check
- commit hooks: PRE_WRITE ALLOW, PRE_COMMIT ALLOW
- push hook: PRE_WRITE ALLOW, PRE_PUSH ALLOW

## CI note
GitHub Actions are currently failing before job start because the account is locked due to a billing issue; no code executed remotely.