### PR TITLE
fix: allow XCTest UI automation in iOS quality gate

### DIFF
--- a/PUMUKI-INC-124.feature
+++ b/PUMUKI-INC-124.feature
@@ -1,0 +1,8 @@
+Feature: PUMUKI-INC-124 iOS UI automation XCTest compatibility
+
+  Scenario: UI automation XCTest remains allowed while unit XCTest quality is enforced
+    Given an iOS UI automation test uses XCTest, XCUIApplication and XCTAssert
+    When Pumuki evaluates critical iOS test quality during a pre hook
+    Then Pumuki does not block that file for missing makeSUT or trackForMemoryLeaks
+    And Pumuki does not emit modern Swift Testing assertion findings for that UI automation file
+    But Pumuki still blocks modernizable XCTest unit tests that miss the quality contract

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-122` / RuralGo: evitar corrupción de `.pumuki/artifacts/pumuki-evidence-v1.json` cuando dos `pumuki sdd evidence` escriben en paralelo el mismo artefacto. Estado 2026-05-05: el feedback externo de RuralGo en `docs/technical/08-validation/refactor/pumuki-integration-feedback.md` reporta dos High activos nuevos (`PUMUKI-INC-122`, `PUMUKI-INC-123`), por lo que `PUMUKI-INC-061` queda aparcado en stash `wip-pumuki-inc-061-governance-remediation-before-inc122` hasta cerrar el bug High prioritario. |
+| Este plan | [🚧] - `PUMUKI-INC-124` / RuralGo: corregir `skills.ios.critical-test-quality` para no bloquear tests XCTest de UI automation cuando la propia skill `swift-testing-expert` permite XCTest con `XCUIApplication`, manteniendo bloqueo real sobre XCTest unitario que debe migrar o cumplir reglas. Estado 2026-05-05: `PUMUKI-INC-122` queda cerrado y publicado en `pumuki@6.3.144`, PR Pumuki #860/#861 mergeadas, npm publicado y RuralGo PR #1912 mergeado en `develop`; RuralGo informa bloqueo operativo por `PUMUKI-INC-124`, por lo que se prioriza sobre `PUMUKI-INC-123` y `PUMUKI-INC-061` hasta desbloquear el consumer. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.
@@ -948,6 +948,9 @@ Snapshot de rollout `6.3.142` (2026-05-05):
 
 Snapshot de rollout `6.3.143` (2026-05-05):
 - `R_GO` (`chore/pumuki-6-3-143-rollout`, PR #1910): repin a `pumuki@6.3.143` completado y mergeado en `develop`; `status` y `doctor` reportan `packageVersion=6.3.143` sin issues; canary staged en worktree aislado confirma bloqueo `PRE_WRITE` por evidencia TDD/BDD caducada (`TDD_BDD_EVIDENCE_STALE`); feedback externo actualizado en PR #1911 para cerrar `PUMUKI-INC-060` y dejar `PUMUKI-INC-061` como siguiente bug vivo.
+
+Snapshot de rollout `6.3.144` (2026-05-05):
+- `R_GO` (`chore/pumuki-6-3-144-rollout`, PR #1912): repin a `pumuki@6.3.144` completado y mergeado en `develop`; `status` y `doctor` reportan `runtime=consumerInstalled=lifecycleInstalled=6.3.144`, `driftWarning=null`, `issues=[]`; canary concurrente de `pumuki sdd evidence` conserva dos slices paralelos y deja JSON válido sin `.lock`/`.tmp` residual; feedback externo actualizado para cerrar `PUMUKI-INC-122` y dejar `PUMUKI-INC-123`/`PUMUKI-INC-124` como High activos.
 
 Snapshot de rollout `6.3.85` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-83-rollout`): verde sobre `6.3.85`; PR mergeada contra `main`: `app-supermercados#10` (`https://github.com/SwiftEnProfundidad/app-supermercados/pull/10`), squash `e643f9f83d6f860cbd72f7bee67855b74dea213e`.

--- a/core/facts/detectors/text/ios.test.ts
+++ b/core/facts/detectors/text/ios.test.ts
@@ -532,6 +532,23 @@ let text = "XCTAssertEqual(value, expected)"
   assert.equal(hasSwiftXCTestAssertionUsage(ignored), false);
 });
 
+test('hasSwiftXCTestAssertionUsage excluye XCTest compatible con UI automation', () => {
+  const uiSource = `
+import XCTest
+
+final class BuyerCommerceUISmokeTests: XCTestCase {
+  func test_buyer_flow() {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertTrue(app.buttons["Comprar"].exists)
+  }
+}
+`;
+
+  assert.equal(hasSwiftXCTestAssertionUsage(uiSource), false);
+  assert.equal(hasSwiftXCTUnwrapUsage(`${uiSource}\nlet value = try XCTUnwrap(optional)`), false);
+});
+
 test('hasSwiftXCTUnwrapUsage detecta XCTUnwrap real y evita strings', () => {
   const source = `
 let value = try XCTUnwrap(optionalValue)

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -767,6 +767,10 @@ export const hasSwiftMixedTestingFrameworksUsage = (source: string): boolean => 
 };
 
 export const hasSwiftXCTestAssertionUsage = (source: string): boolean => {
+  if (hasSwiftLegacyXCTestUiOrPerformanceUsage(source)) {
+    return false;
+  }
+
   return (
     collectSwiftRegexLines(source, /\bXCTAssert[A-Za-z0-9_]*\s*\(/).length > 0 ||
     collectSwiftRegexLines(source, /\bXCTFail\s*\(/).length > 0
@@ -774,6 +778,10 @@ export const hasSwiftXCTestAssertionUsage = (source: string): boolean => {
 };
 
 export const hasSwiftXCTUnwrapUsage = (source: string): boolean => {
+  if (hasSwiftLegacyXCTestUiOrPerformanceUsage(source)) {
+    return false;
+  }
+
   return collectSwiftRegexLines(source, /\bXCTUnwrap\s*\(/).length > 0;
 };
 

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -3615,6 +3615,151 @@ final class LoginUseCaseTests: XCTestCase {
   assert.match(finding.message, /trackForMemoryLeaks/i);
 });
 
+test('runPlatformGate permite XCTest en iOS UI automation aunque use XCTAssert sin makeSUT ni trackForMemoryLeaks', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'staged' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+  const facts: ReadonlyArray<Fact> = [
+    {
+      kind: 'FileContent',
+      path: 'apps/ios/Tests/iOS/BuyerUISmoke/BuyerCommerceUISmokeTests.swift',
+      content: `
+import XCTest
+
+final class BuyerCommerceUISmokeTests: XCTestCase {
+  func test_buyer_flow() {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertTrue(app.buttons["Buy"].exists)
+  }
+}
+      `.trim(),
+      source: 'git:staged',
+    },
+  ];
+
+  let emitted:
+    | {
+      findings: ReadonlyArray<Finding>;
+      gateOutcome: 'PASS' | 'ALLOW' | 'WARN' | 'BLOCK';
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => facts,
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {
+          ios: { detected: true, confidence: 'HIGH' },
+        },
+        skillsRuleSet: {
+          rules: [
+            createSkillRule({
+              id: 'skills.ios.critical-test-quality',
+              severity: 'ERROR',
+              platform: 'ios',
+            }),
+          ] as RuleSet,
+          activeBundles: [
+            {
+              name: 'ios-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-ios.md',
+              hash: 'a'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-concurrency-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swift-concurrency.md',
+              hash: 'b'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-swiftui-expert-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swiftui-expert-skill.md',
+              hash: 'c'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-swift-testing-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swift-testing-expert.md',
+              hash: 'd'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-core-data-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/core-data-expert.md',
+              hash: 'e'.repeat(64),
+              rules: [],
+            },
+          ],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: facts.length,
+          filesScanned: 1,
+          rulesTotal: 1,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 1,
+          projectRules: 0,
+          matchedRules: 0,
+          unmatchedRules: 1,
+          unevaluatedRules: 0,
+          activeRuleIds: ['skills.ios.critical-test-quality'],
+          evaluatedRuleIds: ['skills.ios.critical-test-quality'],
+          matchedRuleIds: [],
+          unmatchedRuleIds: ['skills.ios.critical-test-quality'],
+          unevaluatedRuleIds: [],
+        },
+        findings: [],
+      }),
+      evaluateGate: (findingsArg) => evaluateGateFromFindings(findingsArg, policy),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emitted = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  assert.equal(emitted?.gateOutcome, 'PASS');
+  assert.equal(
+    emitted?.findings.some(
+      (entry) => entry.ruleId === 'governance.skills.ios-test-quality.incomplete'
+    ),
+    false
+  );
+});
+
 test('runPlatformGate bloquea cuando test iOS XCTest usa makeSUT y trackForMemoryLeaks pero el contrato de skills sigue incompleto', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_COMMIT',

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -442,6 +442,10 @@ const isXCTestSource = (content: string): boolean => {
   return /\bimport\s+XCTest\b/.test(content) || /\bXCTestCase\b/.test(content);
 };
 
+const isXCTestUiOrPerformanceCompatibilitySource = (content: string): boolean => {
+  return /\bXCUIApplication\b|\bXCTMetric\b|\bmeasure\s*(?:\(|\{)/.test(content);
+};
+
 const hasMakeSUTPattern = (content: string): boolean => /\bmakeSUT\s*\(/.test(content);
 
 const hasTrackForMemoryLeaksPattern = (content: string): boolean =>
@@ -459,6 +463,9 @@ const toIosTestsQualityBlockingFinding = (params: {
   const invalidFiles: string[] = [];
   for (const testFile of testFiles) {
     if (!isXCTestSource(testFile.content)) {
+      continue;
+    }
+    if (isXCTestUiOrPerformanceCompatibilitySource(testFile.content)) {
       continue;
     }
     const missingMarkers: string[] = [];


### PR DESCRIPTION
## Summary
- allow XCTest UI automation/performance compatibility sources to bypass makeSUT/trackForMemoryLeaks unit-test guard
- suppress modern Swift Testing assertion heuristics for XCUIApplication/XCTMetric/measure compatibility sources
- add regression coverage and BDD scenario for PUMUKI-INC-124

## Tests
- node --import tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/iosAvdleeParity.test.ts integrations/git/__tests__/runPlatformGate.test.ts
- node bin/pumuki.js sdd evidence --scenario-id=PUMUKI-INC-124 --test-command="node --import tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/iosAvdleeParity.test.ts integrations/git/__tests__/runPlatformGate.test.ts" --test-status=passed --json
- node bin/pumuki-pre-write.js
- git push pre-push hook