### PR TITLE
chore: release pumuki 6.3.145

### DIFF
--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This file tracks the active deterministic framework line used in this repository
 Canonical release chronology lives in `CHANGELOG.md`.
 This file keeps only the operational highlights and rollout notes that matter while running the framework.
 
+### 2026-05-05 (v6.3.145)
+
+- **RuralGo PUMUKI-INC-124:** `skills.ios.critical-test-quality` deja de bloquear tests XCTest de UI automation/performance cuando usan `XCUIApplication`, `XCTMetric` o `measure`.
+- **Swift Testing sin regresión:** los unit/integration tests XCTest modernizables siguen bloqueados si incumplen el contrato; solo se respeta la compatibilidad explícita que `swift-testing-expert` permite para UI/performance.
+- **Rollout:** publicar `pumuki@6.3.145`, repinear primero RuralGo y revalidar el smoke UI XCTest que estaba bloqueado.
+
 ### 2026-05-05 (v6.3.144)
 
 - **RuralGo PUMUKI-INC-122:** `pumuki sdd evidence` serializa escrituras concurrentes del artefacto `.pumuki/artifacts/pumuki-evidence-v1.json` con lock local y rename atómico.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.144",
+  "version": "6.3.145",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.144",
+      "version": "6.3.145",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.144",
+  "version": "6.3.145",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package to 6.3.145
- document RuralGo PUMUKI-INC-124 rollout

## Tests
- git diff --check
- node --import tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/iosAvdleeParity.test.ts integrations/git/__tests__/runPlatformGate.test.ts
- npm pack --dry-run --json