### PR TITLE
fix(gate): prioritize evidence root cause notifications

### DIFF
--- a/PUMUKI-INC-123.feature
+++ b/PUMUKI-INC-123.feature
@@ -1,0 +1,8 @@
+Feature: PUMUKI-INC-123 evidence root cause notification
+
+  Scenario: TDD/BDD evidence errors are shown before tracking context
+    Given an AI gate blocked event contains EVIDENCE_GATE_BLOCKED and a TDD/BDD evidence error
+    And tracking context is available for the repository
+    When Pumuki builds the gate blocked notification
+    Then the visible cause names the TDD/BDD evidence problem
+    And the visible remediation does not instruct the user to fix tracking

--- a/integrations/gate/blockingCause.ts
+++ b/integrations/gate/blockingCause.ts
@@ -1,0 +1,40 @@
+type BlockingCauseCandidate = {
+  code?: string;
+  message?: string;
+  remediation?: string;
+  severity?: string;
+};
+
+const UMBRELLA_EVIDENCE_CODES = new Set([
+  'EVIDENCE_GATE_BLOCKED',
+  'AI_GATE_BLOCKED',
+  'GATE_BLOCKED',
+]);
+
+export const isTddBddBlockingCause = (candidate?: {
+  code?: string;
+  message?: string;
+}): boolean => {
+  const code = candidate?.code ?? '';
+  const message = candidate?.message ?? '';
+  return code.startsWith('TDD_BDD_') || /\bTDD_BDD_[A-Z0-9_]+\b/u.test(message);
+};
+
+export const resolvePrimaryBlockingCause = <T extends BlockingCauseCandidate>(
+  candidates: ReadonlyArray<T>
+): T | undefined => {
+  const tddBddCause = candidates.find(isTddBddBlockingCause);
+  if (tddBddCause) {
+    return tddBddCause;
+  }
+
+  const specificCause = candidates.find((candidate) => {
+    const code = candidate.code ?? '';
+    return code.length > 0 && !UMBRELLA_EVIDENCE_CODES.has(code);
+  });
+  if (specificCause) {
+    return specificCause;
+  }
+
+  return candidates[0];
+};

--- a/integrations/gate/remediationCatalog.ts
+++ b/integrations/gate/remediationCatalog.ts
@@ -12,6 +12,14 @@ export const REMEDIATION_HINT_BY_CODE: Readonly<Record<string, string>> = {
   EVIDENCE_BRANCH_MISMATCH: 'Regenera evidencia en la rama actual y reintenta.',
   TDD_BDD_BASELINE_BLOCKED:
     'Corrige el baseline TDD/BDD roto y regenera la evidencia antes de continuar.',
+  TDD_BDD_EVIDENCE_INVALID:
+    'Regenera la evidencia TDD/BDD válida del escenario afectado y vuelve a ejecutar el gate.',
+  TDD_BDD_SCENARIO_FILE_MISSING:
+    'Crea o corrige el fichero .feature referenciado por la evidencia TDD/BDD y revalida.',
+  TDD_BDD_EVIDENCE_STALE:
+    'Reejecuta los tests baseline del componente tocado, refresca la evidencia TDD/BDD y revalida.',
+  TDD_BDD_EVIDENCE_MISSING:
+    'Genera evidencia TDD/BDD para el cambio actual antes de continuar.',
   EVIDENCE_RULES_COVERAGE_MISSING: 'Ejecuta auditoría completa para recalcular rules_coverage.',
   EVIDENCE_RULES_COVERAGE_INCOMPLETE: 'Asegura coverage_ratio=1 y unevaluated=0.',
   ACTIVE_RULE_IDS_EMPTY_FOR_CODE_CHANGES_HIGH:

--- a/integrations/git/__tests__/stageRunners.test.ts
+++ b/integrations/git/__tests__/stageRunners.test.ts
@@ -1029,9 +1029,9 @@ test('runPreCommitStage bloquea con causa explícita si no puede restagear evide
     assert.equal(exitCode, 1);
     assert.equal(blocked.length, 1);
     assert.equal(blocked[0]?.stage, 'PRE_COMMIT');
-    assert.equal(blocked[0]?.causeCode, 'SKILLS_SKILLS_BACKEND_AVOID_EXPLICIT_ANY');
-    assert.match(blocked[0]?.causeMessage ?? '', /explicit any/i);
-    assert.match(blocked[0]?.remediation ?? '', /Corrige la causa del bloqueo/i);
+    assert.equal(blocked[0]?.causeCode, 'TDD_BDD_EVIDENCE_STALE');
+    assert.match(blocked[0]?.causeMessage ?? '', /TDD\/BDD evidence is stale/i);
+    assert.match(blocked[0]?.remediation ?? '', /TDD\/BDD/i);
   });
 });
 

--- a/integrations/git/stageRunners.ts
+++ b/integrations/git/stageRunners.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_GATE_REMEDIATION as DEFAULT_BLOCKED_REMEDIATION,
   REMEDIATION_HINT_BY_CODE as BLOCKED_REMEDIATION_BY_CODE,
 } from '../gate/remediationCatalog';
+import { resolvePrimaryBlockingCause } from '../gate/blockingCause';
 
 const PRE_PUSH_UPSTREAM_REQUIRED_MESSAGE =
   'pumuki pre-push blocked: branch has no upstream tracking reference. Configure upstream first (for example: git push --set-upstream origin <branch>) and retry.';
@@ -273,10 +274,16 @@ const notifyGateBlockedForStage = (params: {
     evidence?.snapshot.stage === params.stage
       ? evidence.snapshot.findings
       : [];
-  const primaryStageFinding = resolvePrimaryBlockedStageFinding(stageFindings);
-  const firstViolation = evidence?.ai_gate.violations[0];
-  const causeCode = primaryStageFinding?.code ?? firstViolation?.code ?? params.fallbackCauseCode;
-  const causeMessage = primaryStageFinding?.message ?? firstViolation?.message ?? params.fallbackCauseMessage;
+  const blockingStageFindings = stageFindings.filter((finding) =>
+    isSeverityAtLeast(finding.severity, 'ERROR')
+  );
+  const primaryCause = resolvePrimaryBlockingCause([
+    ...blockingStageFindings,
+    ...(evidence?.ai_gate.violations ?? []),
+  ]);
+  const primaryStageFinding = primaryCause ?? resolvePrimaryBlockedStageFinding(stageFindings);
+  const causeCode = primaryStageFinding?.code ?? params.fallbackCauseCode;
+  const causeMessage = primaryStageFinding?.message ?? params.fallbackCauseMessage;
   const remediation =
     BLOCKED_REMEDIATION_BY_CODE[causeCode]
     ?? params.fallbackRemediation

--- a/integrations/lifecycle/cliSdd.ts
+++ b/integrations/lifecycle/cliSdd.ts
@@ -21,6 +21,7 @@ import {
   type PreWriteEnforcementResolution,
 } from '../policy/preWriteEnforcement';
 import { readLifecycleExperimentalFeaturesSnapshot } from './experimentalFeaturesSnapshot';
+import { resolvePrimaryBlockingCause } from '../gate/blockingCause';
 
 import {
   type ParsedArgs,
@@ -321,9 +322,9 @@ export const runSddCommand = async (parsed: ParsedArgs, activeDependencies: Life
             return 1;
           }
           if (aiGate && !aiGate.allowed && preWriteEnforcement.blocking) {
-            const firstViolation = aiGate.violations[0];
-            const causeCode = firstViolation?.code ?? 'AI_GATE_BLOCKED';
-            const causeMessage = firstViolation?.message ?? 'AI gate blocked PRE_WRITE stage.';
+            const primaryViolation = resolvePrimaryBlockingCause(aiGate.violations);
+            const causeCode = primaryViolation?.code ?? 'AI_GATE_BLOCKED';
+            const causeMessage = primaryViolation?.message ?? 'AI gate blocked PRE_WRITE stage.';
             activeDependencies.emitGateBlockedNotification({
               repoRoot: process.cwd(),
               stage: result.stage,

--- a/integrations/lifecycle/watch.ts
+++ b/integrations/lifecycle/watch.ts
@@ -36,6 +36,7 @@ import {
   resolveGitAtomicityEnforcement,
   type GitAtomicityEnforcementResolution,
 } from '../policy/gitAtomicityEnforcement';
+import { resolvePrimaryBlockingCause } from '../gate/blockingCause';
 
 export type LifecycleWatchStage = 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
 export type LifecycleWatchScope = 'workingTree' | 'staged' | 'repoAndStaged' | 'repo';
@@ -119,6 +120,11 @@ type LifecycleWatchDependencies = {
 };
 
 const defaultGitService = new GitService();
+const GIT_STATUS_PORCELAIN_ARGS = [
+  'status',
+  '--porcelain=v1',
+  '--untracked-files=all',
+] as const;
 
 class RepoScopedGitService extends GitService implements IGitService {
   constructor(private readonly repoRoot: string) {
@@ -137,7 +143,7 @@ class RepoScopedGitService extends GitService implements IGitService {
 const defaultDependencies: LifecycleWatchDependencies = {
   resolveRepoRoot: () => defaultGitService.resolveRepoRoot(),
   readChangeToken: (repoRoot) =>
-    defaultGitService.runGit(['status', '--porcelain=v1', '--untracked-files=all'], repoRoot),
+    defaultGitService.runGit([...GIT_STATUS_PORCELAIN_ARGS], repoRoot),
   resolvePolicyForStage: (stage) => resolvePolicyForStage(stage),
   resolveUpstreamRef,
   resolvePrePushBootstrapBaseRef,
@@ -155,7 +161,10 @@ const defaultDependencies: LifecycleWatchDependencies = {
   ensureRuntimeArtifactsIgnored: (repoRoot) => {
     try {
       ensureRuntimeArtifactsIgnored(repoRoot);
-    } catch {
+    } catch (error) {
+      process.stderr.write(
+        `[pumuki][watch] unable to ensure runtime artifacts are ignored: ${String(error)}\n`
+      );
     }
   },
   emitAuditSummaryNotificationFromEvidence,
@@ -180,6 +189,16 @@ const BLOCKED_REMEDIATION_BY_CODE: Readonly<Record<string, string>> = {
   SDD_SESSION_MISSING: 'Abre sesión SDD y vuelve a intentar.',
   SDD_SESSION_INVALID: 'Refresca la sesión SDD y vuelve a intentar.',
   OPENSPEC_MISSING: 'Instala OpenSpec y reintenta la validación.',
+  TDD_BDD_EVIDENCE_INVALID:
+    'Regenera la evidencia TDD/BDD válida del escenario afectado y vuelve a ejecutar el gate.',
+  TDD_BDD_SCENARIO_FILE_MISSING:
+    'Crea o corrige el fichero .feature referenciado por la evidencia TDD/BDD y revalida.',
+  TDD_BDD_EVIDENCE_STALE:
+    'Reejecuta los tests baseline del componente tocado, refresca la evidencia TDD/BDD y revalida.',
+  TDD_BDD_EVIDENCE_MISSING:
+    'Genera evidencia TDD/BDD para el cambio actual antes de continuar.',
+  TDD_BDD_BASELINE_BLOCKED:
+    'Corrige el baseline TDD/BDD roto y regenera la evidencia antes de continuar.',
   MCP_ENTERPRISE_RECEIPT_MISSING: 'Genera el receipt enterprise de MCP antes de continuar.',
   MANIFEST_MUTATION_DETECTED:
     'Validación no debe mutar package.json/lockfiles. Revisa wiring y realiza upgrades solo con comando explícito.',
@@ -369,12 +388,13 @@ const toFirstCause = (params: {
   evidence: AiEvidenceV2_1 | undefined;
   matchedFindings: ReadonlyArray<SnapshotFinding>;
 }): { code: string; message: string; remediation: string } => {
-  const firstFinding = params.matchedFindings[0];
-  const firstViolation = params.evidence?.ai_gate.violations[0];
-  const code = firstFinding?.code ?? firstViolation?.code ?? 'WATCH_GATE_BLOCKED';
+  const primaryCause = resolvePrimaryBlockingCause([
+    ...params.matchedFindings,
+    ...(params.evidence?.ai_gate.violations ?? []),
+  ]);
+  const code = primaryCause?.code ?? 'WATCH_GATE_BLOCKED';
   const message =
-    firstFinding?.message ??
-    firstViolation?.message ??
+    primaryCause?.message ??
     `Watch gate bloqueado (${code}).`;
   const remediation =
     BLOCKED_REMEDIATION_BY_CODE[code] ??

--- a/scripts/__tests__/framework-menu-consumer-preflight-run.test.ts
+++ b/scripts/__tests__/framework-menu-consumer-preflight-run.test.ts
@@ -65,3 +65,76 @@ test('runConsumerPreflight genera hints operativos y eventos de notificación en
   assert.equal(result.hints.some((hint) => /Git-flow/i.test(hint)), true);
   assert.deepEqual(events, ['evidence.stale', 'gitflow.violation', 'gate.blocked']);
 });
+
+test('runConsumerPreflight notifica la causa TDD/BDD específica antes que el paraguas de evidencia', () => {
+  const blockedEvents: Array<{ causeCode?: string; causeMessage?: string }> = [];
+  runConsumerPreflight(
+    {
+      repoRoot: '/tmp/repo',
+      stage: 'PRE_WRITE',
+    },
+    {
+      evaluateAiGate: () => ({
+        stage: 'PRE_WRITE',
+        status: 'BLOCKED',
+        allowed: false,
+        policy: {
+          stage: 'PRE_WRITE',
+          resolved_stage: 'PRE_WRITE',
+          block_on_or_above: 'ERROR',
+          warn_on_or_above: 'WARN',
+          trace: { source: 'default', bundle: 'gate-policy.default.PRE_WRITE', hash: 'hash' },
+        },
+        evidence: {
+          kind: 'valid',
+          max_age_seconds: 300,
+          age_seconds: 1,
+          source: { source: 'local-file', path: '/tmp/repo/.ai_evidence.json', digest: null, generated_at: null },
+        },
+        repo_state: {
+          repo_root: '/tmp/repo',
+          git: {
+            available: true,
+            branch: 'feature/rgo-1900-01',
+            upstream: null,
+            ahead: 0,
+            behind: 0,
+            dirty: true,
+            staged: 1,
+            unstaged: 0,
+          },
+          lifecycle: {
+            installed: true,
+            package_version: '6.3.145',
+            lifecycle_version: '6.3.145',
+            hooks: { pre_commit: 'managed', pre_push: 'managed' },
+          },
+        },
+        violations: [
+          {
+            code: 'EVIDENCE_GATE_BLOCKED',
+            message: 'Evidence AI gate status is BLOCKED.',
+            severity: 'ERROR',
+          },
+          {
+            code: 'TDD_BDD_SCENARIO_FILE_MISSING',
+            message: 'TDD/BDD scenario file is missing.',
+            severity: 'ERROR',
+          },
+        ],
+      }),
+      emitSystemNotification: ({ event }) => {
+        if (event.kind === 'gate.blocked') {
+          blockedEvents.push({
+            causeCode: event.causeCode,
+            causeMessage: event.causeMessage,
+          });
+        }
+        return { delivered: false, reason: 'disabled' };
+      },
+    }
+  );
+
+  assert.equal(blockedEvents[0]?.causeCode, 'TDD_BDD_SCENARIO_FILE_MISSING');
+  assert.match(blockedEvents[0]?.causeMessage ?? '', /scenario file/i);
+});

--- a/scripts/__tests__/framework-menu-system-notifications-cause.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-cause.test.ts
@@ -51,6 +51,25 @@ test('resolveBlockedCauseSummary explica bloqueos de tracking enriquecidos', () 
   assert.doesNotMatch(result, /Evidence AI gate status/i);
 });
 
+test('resolveBlockedCauseSummary prioriza TDD/BDD sobre tracking enriquecido', () => {
+  const result = resolveBlockedCauseSummary(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_WRITE',
+      totalViolations: 2,
+      causeCode: 'TDD_BDD_SCENARIO_FILE_MISSING',
+      causeMessage:
+        'TDD/BDD evidence scenario file is missing. code=TDD_BDD_SCENARIO_FILE_MISSING active_entries=RGO-1900-01@L53 tracking_source=docs/RURALGO_SEGUIMIENTO.md',
+    },
+    'TDD_BDD_SCENARIO_FILE_MISSING'
+  );
+
+  assert.match(result, /escenario/i);
+  assert.match(result, /TDD\/BDD/i);
+  assert.doesNotMatch(result, /tracking bloqueado/i);
+  assert.doesNotMatch(result, /RGO-1900-01/);
+});
+
 test('resolveBlockedCauseSummary traduce el bloqueo umbrella de evidencia', () => {
   const result = resolveBlockedCauseSummary(
     {

--- a/scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts
@@ -59,3 +59,22 @@ test('buildGateBlockedPayload muestra causa y solución coherentes para tracking
   assert.match(payload.message, /comando:/i);
   assert.match(payload.message, /siguiente acción:/i);
 });
+
+test('buildGateBlockedPayload no culpa al tracking cuando la causa real es TDD/BDD', () => {
+  const payload = buildGateBlockedPayload(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_WRITE',
+      totalViolations: 2,
+      causeCode: 'TDD_BDD_EVIDENCE_INVALID',
+      causeMessage:
+        'TDD/BDD evidence is invalid. code=TDD_BDD_EVIDENCE_INVALID active_entries=RGO-1900-01@L53 tracking_source=docs/RURALGO_SEGUIMIENTO.md',
+    },
+    'R_GO · '
+  );
+
+  assert.match(payload.subtitle ?? '', /R_GO/);
+  assert.match(payload.subtitle ?? '', /TDD\/BDD/i);
+  assert.doesNotMatch(payload.subtitle ?? '', /Tracking bloqueado/i);
+  assert.doesNotMatch(payload.message, /corrige el MD de tracking/i);
+});

--- a/scripts/__tests__/framework-menu-system-notifications-remediation.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-remediation.test.ts
@@ -54,6 +54,24 @@ test('resolveBlockedRemediation prioriza tracking sobre comandos genéricos de r
   assert.doesNotMatch(result, /sdd validate/i);
 });
 
+test('resolveBlockedRemediation prioriza TDD/BDD sobre tracking enriquecido', () => {
+  const result = resolveBlockedRemediation(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_WRITE',
+      totalViolations: 2,
+      causeCode: 'TDD_BDD_EVIDENCE_INVALID',
+      causeMessage:
+        'TDD/BDD evidence is invalid. code=TDD_BDD_EVIDENCE_INVALID active_entries=RGO-1900-01@L53 tracking_source=docs/RURALGO_SEGUIMIENTO.md',
+    },
+    'TDD_BDD_EVIDENCE_INVALID'
+  );
+
+  assert.match(result, /evidencia TDD\/BDD/i);
+  assert.match(result, /regenera/i);
+  assert.doesNotMatch(result, /tracking/i);
+});
+
 test('resolveBlockedRemediation no muestra comandos genéricos para el bloqueo umbrella de evidencia', () => {
   const result = resolveBlockedRemediation(
     {

--- a/scripts/framework-menu-consumer-preflight-run.ts
+++ b/scripts/framework-menu-consumer-preflight-run.ts
@@ -2,6 +2,7 @@ import {
   evaluateAiGate,
   type AiGateCheckResult,
 } from '../integrations/gate/evaluateAiGate';
+import { resolvePrimaryBlockingCause } from '../integrations/gate/blockingCause';
 import { readLifecycleExperimentalFeaturesSnapshot } from '../integrations/lifecycle/experimentalFeaturesSnapshot';
 import { LifecycleGitService } from '../integrations/lifecycle/gitService';
 import { readGovernanceObservationSnapshot } from '../integrations/lifecycle/governanceObservationSnapshot';
@@ -36,6 +37,8 @@ const defaultDependencies: ConsumerPreflightDependencies = {
   readGovernanceNextAction,
 };
 
+const SECONDS_PER_MINUTE = 60;
+
 const buildNotificationEvents = (
   result: AiGateCheckResult
 ): ReadonlyArray<PumukiCriticalNotificationEvent> => {
@@ -45,7 +48,7 @@ const buildNotificationEvents = (
     events.push({
       kind: 'evidence.stale',
       evidencePath: '.ai_evidence.json',
-      ageMinutes: Math.max(1, Math.ceil(ageSeconds / 60)),
+      ageMinutes: Math.max(1, Math.ceil(ageSeconds / SECONDS_PER_MINUTE)),
     });
   }
   if (hasViolationCode(result.violations, 'GITFLOW_PROTECTED_BRANCH')) {
@@ -56,13 +59,13 @@ const buildNotificationEvents = (
     });
   }
   if (result.status === 'BLOCKED') {
-    const firstViolation = result.violations[0];
-    const causeCode = firstViolation?.code ?? 'GATE_BLOCKED';
+    const primaryViolation = resolvePrimaryBlockingCause(result.violations);
+    const causeCode = primaryViolation?.code ?? 'GATE_BLOCKED';
     const causeMessage =
-      firstViolation?.message
+      primaryViolation?.message
       ?? `Detected ${result.violations.length} blocking violations in stage ${result.stage}.`;
     const remediation =
-      (firstViolation ? ACTIONABLE_HINTS_BY_CODE[firstViolation.code] : undefined)
+      (primaryViolation ? ACTIONABLE_HINTS_BY_CODE[primaryViolation.code] : undefined)
       ?? 'Corrige la causa bloqueante y vuelve a ejecutar el gate.';
     events.push({
       kind: 'gate.blocked',

--- a/scripts/framework-menu-system-notifications-cause.ts
+++ b/scripts/framework-menu-system-notifications-cause.ts
@@ -7,9 +7,16 @@ import {
   buildNotificationTrackingCauseSummary,
   extractNotificationTrackingContext,
 } from './framework-menu-system-notifications-tracking';
+import { isTddBddBlockingCause } from '../integrations/gate/blockingCause';
 
 const BLOCKED_CAUSE_SUMMARY_BY_CODE: Readonly<Record<string, string>> = {
   EVIDENCE_GATE_BLOCKED: 'El gate de evidencia/gobernanza está bloqueado.',
+  TDD_BDD_EVIDENCE_INVALID: 'La evidencia TDD/BDD actual es inválida.',
+  TDD_BDD_SCENARIO_FILE_MISSING:
+    'Falta el fichero de escenario TDD/BDD referenciado por la evidencia.',
+  TDD_BDD_EVIDENCE_STALE: 'La evidencia TDD/BDD está caducada.',
+  TDD_BDD_EVIDENCE_MISSING: 'Falta evidencia TDD/BDD para el cambio actual.',
+  TDD_BDD_BASELINE_BLOCKED: 'La baseline TDD/BDD está bloqueada.',
   EVIDENCE_MISSING: 'Falta evidencia para validar este paso.',
   EVIDENCE_INVALID: 'La evidencia actual es inválida.',
   EVIDENCE_CHAIN_INVALID: 'La cadena de evidencia no es válida.',
@@ -31,6 +38,13 @@ const BLOCKED_CAUSE_SUMMARY_BY_CODE: Readonly<Record<string, string>> = {
   ACTIVE_RULE_IDS_EMPTY_FOR_CODE_CHANGES_HIGH:
     'No hay reglas activas para cambios de código.',
 };
+
+const TRACKING_COMPATIBLE_UMBRELLA_CODES = new Set([
+  'EVIDENCE_GATE_BLOCKED',
+  'AI_GATE_BLOCKED',
+  'AI_GATE_BLOCK',
+  'GATE_BLOCKED',
+]);
 
 const ENGLISH_CAUSE_HINTS = [
   'detected',
@@ -97,12 +111,21 @@ export const resolveBlockedCauseSummary = (
   causeCode: string
 ): string => {
   const trackingContext = extractNotificationTrackingContext(event.causeMessage);
-  if (trackingContext) {
+  if (isTddBddBlockingCause({ code: causeCode, message: event.causeMessage })) {
+    return (
+      BLOCKED_CAUSE_SUMMARY_BY_CODE[causeCode] ??
+      'La evidencia TDD/BDD bloquea el gate; revisa el escenario y el artefacto de evidencia.'
+    );
+  }
+  if (trackingContext && TRACKING_COMPATIBLE_UMBRELLA_CODES.has(causeCode)) {
     return buildNotificationTrackingCauseSummary(trackingContext);
   }
   const mapped = BLOCKED_CAUSE_SUMMARY_BY_CODE[causeCode];
   if (mapped) {
     return mapped;
+  }
+  if (trackingContext) {
+    return buildNotificationTrackingCauseSummary(trackingContext);
   }
   if (event.causeMessage && event.causeMessage.trim().length > 0) {
     const rawMessage = normalizeNotificationText(event.causeMessage).replace(/^[A-Z0-9_]+:\s*/, '');

--- a/scripts/framework-menu-system-notifications-remediation.ts
+++ b/scripts/framework-menu-system-notifications-remediation.ts
@@ -7,12 +7,23 @@ import {
   extractNotificationTrackingContext,
   TRACKING_BLOCKED_REMEDIATION,
 } from './framework-menu-system-notifications-tracking';
+import { isTddBddBlockingCause } from '../integrations/gate/blockingCause';
 
 type BlockedRemediationVariant = 'banner' | 'dialog';
 
 const BLOCKED_REMEDIATION_BY_CODE: Readonly<Record<string, string>> = {
   EVIDENCE_GATE_BLOCKED:
     'Revisa status/doctor para ver la causa exacta del gate, corrígela y revalida.',
+  TDD_BDD_EVIDENCE_INVALID:
+    'Regenera la evidencia TDD/BDD válida del escenario afectado y vuelve a ejecutar el gate.',
+  TDD_BDD_SCENARIO_FILE_MISSING:
+    'Crea o corrige el fichero .feature referenciado por la evidencia TDD/BDD y revalida.',
+  TDD_BDD_EVIDENCE_STALE:
+    'Reejecuta los tests baseline del componente tocado, refresca la evidencia TDD/BDD y revalida.',
+  TDD_BDD_EVIDENCE_MISSING:
+    'Genera evidencia TDD/BDD para el cambio actual antes de continuar.',
+  TDD_BDD_BASELINE_BLOCKED:
+    'Corrige la baseline TDD/BDD rota, registra evidencia pasada y vuelve a ejecutar el gate.',
   EVIDENCE_MISSING: 'Genera la evidencia del slice actual y vuelve a validar esta fase.',
   EVIDENCE_INVALID: 'Regenera la evidencia de esta iteración y repite la validación.',
   EVIDENCE_CHAIN_INVALID: 'Regenera la evidencia para restaurar la cadena de integridad y vuelve a validar.',
@@ -105,6 +116,9 @@ export const resolveBlockedRemediation = (
   const fromEvent = event.remediation
     ? normalizeBlockedRemediation(event.remediation)
     : '';
+  if (isTddBddBlockingCause({ code: causeCode, message: event.causeMessage })) {
+    return truncateNotificationText(resolveFallbackRemediation(causeCode), maxLength);
+  }
   if (extractNotificationTrackingContext(event.causeMessage)) {
     return truncateNotificationText(TRACKING_BLOCKED_REMEDIATION, maxLength);
   }


### PR DESCRIPTION
## Summary
- Prioritizes specific TDD/BDD evidence blockers over umbrella evidence gate blockers when building user-visible blocked notifications.
- Preserves tracking-specific copy when the umbrella evidence blocker is genuinely enriched with tracking context.
- Adds regression coverage for PUMUKI-INC-123 and BDD scenario traceability.

## Validation
- node --import tsx --test scripts/__tests__/framework-menu-system-notifications-cause.test.ts scripts/__tests__/framework-menu-system-notifications-remediation.test.ts scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts scripts/__tests__/framework-menu-consumer-preflight-run.test.ts integrations/git/__tests__/stageRunners.test.ts integrations/lifecycle/__tests__/watch.test.ts
- git diff --check
- node bin/pumuki.js sdd evidence --scenario-id=PUMUKI-INC-123 --test-command=... --test-status=passed --json
- pre-commit and pre-push hooks passed during commits/push

## Notes
- npm run typecheck still fails on pre-existing detector/lifecycle typing debt outside this slice.