### PR TITLE
chore(release): pumuki 6.3.146

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.145",
+  "version": "6.3.146",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.145",
+      "version": "6.3.146",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.145",
+  "version": "6.3.146",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps package version to 6.3.146 after PUMUKI-INC-123 fix.

## Validation
- npm pack --dry-run
- targeted PUMUKI-INC-123 suite: 82/82
- pre-commit/pre-push hooks passed.