### PR TITLE
fix(ios): allow brownfield XCTest quality suites

### DIFF
--- a/PUMUKI-INC-124.feature
+++ b/PUMUKI-INC-124.feature
@@ -1,4 +1,4 @@
-Feature: PUMUKI-INC-124 iOS UI automation XCTest compatibility
+Feature: PUMUKI-INC-124 iOS XCTest brownfield compatibility
 
   Scenario: UI automation XCTest remains allowed while unit XCTest quality is enforced
     Given an iOS UI automation test uses XCTest, XCUIApplication and XCTAssert
@@ -6,3 +6,10 @@ Feature: PUMUKI-INC-124 iOS UI automation XCTest compatibility
     Then Pumuki does not block that file for missing makeSUT or trackForMemoryLeaks
     And Pumuki does not emit modern Swift Testing assertion findings for that UI automation file
     But Pumuki still blocks modernizable XCTest unit tests that miss the quality contract
+
+  Scenario: Brownfield Mac XCTest with local quality contract remains allowed
+    Given a brownfield iOS or Mac test module uses XCTest as its existing baseline
+    And a unit XCTest file defines makeSUT and tracks memory leaks for the SUT and collaborators
+    When Pumuki evaluates critical iOS test quality during PRE_WRITE, PRE_COMMIT or PRE_PUSH
+    Then Pumuki does not emit Swift Testing migration findings for that compatible file
+    But a XCTest unit file without the brownfield quality contract remains blocked

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-123` / RuralGo: corregir el mensaje visible de bloqueo para que no diga que el problema es tracking cuando la causa raíz real es evidencia BDD/TDD inválida o escenario faltante. Estado 2026-05-05: `PUMUKI-INC-124` queda cerrado y publicado en `pumuki@6.3.145`; PR Pumuki #862/#863 mergeadas, npm `latest=6.3.145` verificado y RuralGo PR #1913 mergeado en `develop`. El feedback externo mantiene `PUMUKI-INC-123` como único High activo; `PUMUKI-INC-061` sigue aparcado hasta cerrar el High. |
+| Este plan | [🚧] - `PUMUKI-INC-124` / RuralGo: corregir `skills.ios.critical-test-quality` para que permita XCTest unitario/Mac en módulos brownfield cuando el archivo cumple el contrato de calidad local (`makeSUT`, `trackForMemoryLeaks`, aislamiento y async correcto), sin dejar pasar XCTest nuevo o deficiente. Estado 2026-05-05: RuralGo reabre `PUMUKI-INC-124` con commit `281f56fd0` tras comprobar que `pumuki@6.3.145` solo cubría UI automation (`XCUIApplication`) y seguía bloqueando XCTest brownfield válido; el repin `6.3.146` queda pausado hasta publicar una versión útil para este High activo. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -691,6 +691,50 @@ test('detects iOS Swift Testing and Core Data boundary heuristics in scoped file
   );
 });
 
+test('does not emit Swift Testing migration findings for compatible brownfield XCTest unit suites', () => {
+  const extracted = extractHeuristicFacts({
+    facts: [
+      fileContentFact(
+        'apps/ios/Tests/Mac/Presentation/LoginModelTests.spec.swift',
+        [
+          'import XCTest',
+          '',
+          'final class LoginModelTests: XCTestCase {',
+          '  func test_submit_validCredentials_storesSession() async throws {',
+          '    let (sut, repository) = makeSUT()',
+          '    try await sut.submit()',
+          '    XCTAssertEqual(repository.receivedRequests.count, 1)',
+          '    let session = try XCTUnwrap(repository.savedSession)',
+          '    XCTAssertEqual(session.userId, "buyer-1")',
+          '  }',
+          '',
+          '  private func makeSUT(',
+          '    file: StaticString = #filePath,',
+          '    line: UInt = #line',
+          '  ) -> (LoginModel, AuthRepositorySpy) {',
+          '    let repository = AuthRepositorySpy()',
+          '    let sut = LoginModel(repository: repository)',
+          '    trackForMemoryLeaks(sut, testCase: self, file: file, line: line)',
+          '    trackForMemoryLeaks(repository, testCase: self, file: file, line: line)',
+          '    return (sut, repository)',
+          '  }',
+          '}',
+        ].join('\n')
+      ),
+    ],
+    detectedPlatforms: {
+      ios: { detected: true },
+    },
+  });
+
+  const findings = evaluateRules(astHeuristicsRuleSet, extracted);
+  const testingFindings = findings.filter((finding) =>
+    finding.ruleId.startsWith('heuristics.ios.testing.')
+  );
+
+  assert.deepEqual(testingFindings.map((finding) => finding.ruleId), []);
+});
+
 test('detects IOS-CANARY-001 semantic heuristic with primary_node and related_nodes', () => {
   const extracted = extractHeuristicFacts({
     facts: [

--- a/core/facts/detectors/text/ios.test.ts
+++ b/core/facts/detectors/text/ios.test.ts
@@ -376,10 +376,33 @@ final class SyncTests: XCTestCase {
   }
 }
 `;
+  const brownfieldCompatibleUnitTest = `
+import XCTest
+
+final class LoginModelTests: XCTestCase {
+  func test_submit_validCredentials_storesSession() async throws {
+    let (sut, repository) = makeSUT()
+    try await sut.submit()
+    XCTAssertEqual(repository.receivedRequests.count, 1)
+  }
+
+  private func makeSUT(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) -> (LoginModel, AuthRepositorySpy) {
+    let repository = AuthRepositorySpy()
+    let sut = LoginModel(repository: repository)
+    trackForMemoryLeaks(sut, testCase: self, file: file, line: line)
+    trackForMemoryLeaks(repository, testCase: self, file: file, line: line)
+    return (sut, repository)
+  }
+}
+`;
 
   assert.equal(hasSwiftLegacyXCTestImportUsage(unitTest), true);
   assert.equal(hasSwiftLegacyXCTestImportUsage(uiTest), false);
   assert.equal(hasSwiftLegacyXCTestImportUsage(performanceTest), false);
+  assert.equal(hasSwiftLegacyXCTestImportUsage(brownfieldCompatibleUnitTest), false);
 });
 
 test('hasSwiftLegacySwiftUiObservableWrapperUsage detecta @StateObject/@ObservedObject legacy', () => {
@@ -477,10 +500,33 @@ final class LoginUITests: XCTestCase {
   }
 }
 `;
+  const brownfieldCompatibleSuite = `
+import XCTest
+
+final class LoginModelTests: XCTestCase {
+  func test_submit_validCredentials_storesSession() async throws {
+    let (sut, repository) = makeSUT()
+    try await sut.submit()
+    XCTAssertEqual(repository.receivedRequests.count, 1)
+  }
+
+  private func makeSUT(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) -> (LoginModel, AuthRepositorySpy) {
+    let repository = AuthRepositorySpy()
+    let sut = LoginModel(repository: repository)
+    trackForMemoryLeaks(sut, testCase: self, file: file, line: line)
+    trackForMemoryLeaks(repository, testCase: self, file: file, line: line)
+    return (sut, repository)
+  }
+}
+`;
 
   assert.equal(hasSwiftModernizableXCTestSuiteUsage(legacySuite), true);
   assert.equal(hasSwiftModernizableXCTestSuiteUsage(mixedSuite), false);
   assert.equal(hasSwiftModernizableXCTestSuiteUsage(uiSuite), false);
+  assert.equal(hasSwiftModernizableXCTestSuiteUsage(brownfieldCompatibleSuite), false);
 });
 
 test('hasSwiftMixedTestingFrameworksUsage detecta mezcla XCTestCase y Testing/@Test', () => {
@@ -547,6 +593,46 @@ final class BuyerCommerceUISmokeTests: XCTestCase {
 
   assert.equal(hasSwiftXCTestAssertionUsage(uiSource), false);
   assert.equal(hasSwiftXCTUnwrapUsage(`${uiSource}\nlet value = try XCTUnwrap(optional)`), false);
+});
+
+test('hasSwiftXCTestAssertionUsage excluye XCTest brownfield compatible y bloquea suites sin contrato de calidad', () => {
+  const compatibleSource = `
+import XCTest
+
+final class LoginModelTests: XCTestCase {
+  func test_submit_validCredentials_storesSession() async throws {
+    let (sut, repository) = makeSUT()
+    try await sut.submit()
+    XCTAssertEqual(repository.receivedRequests.count, 1)
+    let session = try XCTUnwrap(repository.savedSession)
+    XCTAssertEqual(session.userId, "buyer-1")
+  }
+
+  private func makeSUT(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) -> (LoginModel, AuthRepositorySpy) {
+    let repository = AuthRepositorySpy()
+    let sut = LoginModel(repository: repository)
+    trackForMemoryLeaks(sut, testCase: self, file: file, line: line)
+    trackForMemoryLeaks(repository, testCase: self, file: file, line: line)
+    return (sut, repository)
+  }
+}
+`;
+  const missingQualityContract = `
+import XCTest
+
+final class LoginModelTests: XCTestCase {
+  func test_submit_validCredentials_storesSession() async throws {
+    XCTAssertEqual(repository.receivedRequests.count, 1)
+  }
+}
+`;
+
+  assert.equal(hasSwiftXCTestAssertionUsage(compatibleSource), false);
+  assert.equal(hasSwiftXCTUnwrapUsage(compatibleSource), false);
+  assert.equal(hasSwiftXCTestAssertionUsage(missingQualityContract), true);
 });
 
 test('hasSwiftXCTUnwrapUsage detecta XCTUnwrap real y evita strings', () => {

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -730,12 +730,40 @@ const hasSwiftLegacyXCTestMethodUsage = (source: string): boolean => {
     .length > 0;
 };
 
+const hasSwiftMakeSutUsage = (source: string): boolean => {
+  return hasSwiftSanitizedRegexMatch(source, /\bmakeSUT\s*\(/);
+};
+
+const hasSwiftMemoryLeakTrackingUsage = (source: string): boolean => {
+  return hasSwiftSanitizedRegexMatch(source, /\btrackForMemoryLeaks\s*\(/);
+};
+
+const hasSwiftBrownfieldCompatibleXCTestUsage = (source: string): boolean => {
+  if (!hasSwiftXCTestImportUsage(source) || !hasSwiftXCTestCaseSubclassUsage(source)) {
+    return false;
+  }
+
+  if (!hasSwiftLegacyXCTestMethodUsage(source)) {
+    return false;
+  }
+
+  if (hasSwiftTestingImportUsage(source) || hasSwiftTestingSuiteAttributeUsage(source)) {
+    return false;
+  }
+
+  return hasSwiftMakeSutUsage(source) && hasSwiftMemoryLeakTrackingUsage(source);
+};
+
 export const hasSwiftLegacyXCTestImportUsage = (source: string): boolean => {
   if (!hasSwiftXCTestImportUsage(source)) {
     return false;
   }
 
   if (hasSwiftLegacyXCTestUiOrPerformanceUsage(source)) {
+    return false;
+  }
+
+  if (hasSwiftBrownfieldCompatibleXCTestUsage(source)) {
     return false;
   }
 
@@ -771,6 +799,10 @@ export const hasSwiftXCTestAssertionUsage = (source: string): boolean => {
     return false;
   }
 
+  if (hasSwiftBrownfieldCompatibleXCTestUsage(source)) {
+    return false;
+  }
+
   return (
     collectSwiftRegexLines(source, /\bXCTAssert[A-Za-z0-9_]*\s*\(/).length > 0 ||
     collectSwiftRegexLines(source, /\bXCTFail\s*\(/).length > 0
@@ -779,6 +811,10 @@ export const hasSwiftXCTestAssertionUsage = (source: string): boolean => {
 
 export const hasSwiftXCTUnwrapUsage = (source: string): boolean => {
   if (hasSwiftLegacyXCTestUiOrPerformanceUsage(source)) {
+    return false;
+  }
+
+  if (hasSwiftBrownfieldCompatibleXCTestUsage(source)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Allow brownfield XCTest unit/Mac suites when they keep the local quality contract: makeSUT plus trackForMemoryLeaks.
- Keep blocking XCTest unit suites without that quality contract and preserve UI automation XCTest compatibility.
- Reopen internal tracking for PUMUKI-INC-124 based on RuralGo feedback.

## Tests
- node --import tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/skillsRuleSet.test.ts
- git diff --check
- node bin/pumuki-pre-write.js
