### PR TITLE
fix: enforce global skills coverage

### DIFF
--- a/PUMUKI-INC-125.feature
+++ b/PUMUKI-INC-125.feature
@@ -1,0 +1,10 @@
+Feature: PUMUKI-INC-125 global skills AST enforcement coverage
+
+  Scenario: Declarative hard skill rules without AST detector fail closed in pre hooks
+    Given a repository has hard platform skills active for iOS, Android, backend and frontend
+    And the runtime AUTO rules for the stage are fully evaluated
+    But the global skills registry still contains hard declarative rules without AST detectors
+    When Pumuki audits PRE_WRITE, PRE_COMMIT or PRE_PUSH
+    Then Pumuki reports auto_runtime_coverage_ratio separately from semantic_enforcement_ratio
+    And Pumuki emits SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL
+    And Pumuki blocks the stage until every hard skill rule has an AST detector or an explicit gate waiver

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-059` / RuralGo: cerrar el gap de enforcement hard de skills en `PRE_WRITE` para OCP/SRP/LSP/ISP/DIP/LOP, empezando por la reproducción real donde `PRE_WRITE` no bloqueó un switch sobre enum propio en `LaunchFlowCoordinator.bootstrap` ni suites de tests con responsabilidades mezcladas. Estado 2026-05-05: `PUMUKI-INC-124` queda fixed y repineado en `pumuki@6.3.147` (PR Pumuki #867/#868, RuralGo PR #1914 y rama activa `bugfix/ruralgo-tracking-build-stability` actualizada); el MD externo de RuralGo deja `PUMUKI-INC-059` como único High activo. |
+| Este plan | [🚧] - `PUMUKI-INC-125` / RuralGo: cerrar el gap crítico de confianza donde `pumuki@6.3.147` reporta `coverage_ratio=1` aunque esa métrica solo cubre reglas AUTO del stage y deja `registry_declarative=668` / `unsupported_detector=664` sin enforcement AST operativo. Estado 2026-05-05: la prioridad externa sube por encima de `PUMUKI-INC-059`; el cierre exige distinguir `auto_runtime_coverage_ratio` de cobertura global de skills, exponer `semantic_enforcement_ratio`, y bloquear fail-closed en `PRE_WRITE`, `PRE_COMMIT` y `PRE_PUSH` cuando una skill hard quede como declarativa/unsupported sin detector sobre archivos escaneados. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/integrations/evidence/rulesCoverage.ts
+++ b/integrations/evidence/rulesCoverage.ts
@@ -30,6 +30,17 @@ const createCoverageRatio = (active: number, evaluated: number): number => {
   return normalizeCoverageRatio(evaluated / active);
 };
 
+const createSemanticEnforcementRatio = (params: {
+  registryTotal: number;
+  unsupportedDetector: number;
+}): number => {
+  if (params.registryTotal === 0) {
+    return 1;
+  }
+  const supported = Math.max(0, params.registryTotal - params.unsupportedDetector);
+  return normalizeCoverageRatio(supported / params.registryTotal);
+};
+
 export const createEmptySnapshotRulesCoverage = (
   stage: GateStage
 ): SnapshotRulesCoverage => ({
@@ -48,6 +59,15 @@ export const createEmptySnapshotRulesCoverage = (
     unevaluated: 0,
   },
   coverage_ratio: 1,
+  auto_runtime_coverage_ratio: 1,
+  semantic_enforcement_ratio: 1,
+  global_skills_enforcement: {
+    status: 'enforced',
+    registry_total: 0,
+    detector_supported: 0,
+    declarative_only: 0,
+    unsupported_detector: 0,
+  },
 });
 
 export const normalizeSnapshotRulesCoverage = (
@@ -118,6 +138,43 @@ export const normalizeSnapshotRulesCoverage = (
   const coverageRatio = normalizeCoverageRatio(
     Number.isFinite(value.coverage_ratio) ? value.coverage_ratio : ratioFromCounts
   );
+  const registryTotal = normalizeCount(
+    value.global_skills_enforcement?.registry_total
+      ?? value.registry_totals?.total
+      ?? counts.registry_total
+      ?? 0
+  );
+  const declarativeOnly = normalizeCount(
+    value.global_skills_enforcement?.declarative_only
+      ?? value.registry_totals?.declarative
+      ?? counts.registry_declarative
+      ?? 0
+  );
+  const unsupportedDetector = normalizeCount(
+    value.global_skills_enforcement?.unsupported_detector
+      ?? counts.unsupported_detector
+      ?? unsupportedDetectorCount
+  );
+  const detectorSupported = normalizeCount(
+    value.global_skills_enforcement?.detector_supported
+      ?? Math.max(0, registryTotal - unsupportedDetector)
+  );
+  const semanticEnforcementRatio = normalizeCoverageRatio(
+    Number.isFinite(value.semantic_enforcement_ratio)
+      ? value.semantic_enforcement_ratio ?? 1
+      : createSemanticEnforcementRatio({
+        registryTotal,
+        unsupportedDetector,
+      })
+  );
+  const globalSkillsStatus: NonNullable<
+    SnapshotRulesCoverage['global_skills_enforcement']
+  >['status'] =
+    registryTotal === 0 || unsupportedDetector === 0
+      ? 'enforced'
+      : detectorSupported > 0
+        ? 'partially_enforced'
+        : 'unsupported';
 
   const normalized: SnapshotRulesCoverage = {
     stage,
@@ -131,6 +188,19 @@ export const normalizeSnapshotRulesCoverage = (
     unevaluated_rule_ids: unevaluatedRuleIds,
     counts,
     coverage_ratio: coverageRatio,
+    auto_runtime_coverage_ratio: normalizeCoverageRatio(
+      Number.isFinite(value.auto_runtime_coverage_ratio)
+        ? value.auto_runtime_coverage_ratio ?? coverageRatio
+        : coverageRatio
+    ),
+    semantic_enforcement_ratio: semanticEnforcementRatio,
+    global_skills_enforcement: {
+      status: value.global_skills_enforcement?.status ?? globalSkillsStatus,
+      registry_total: registryTotal,
+      detector_supported: detectorSupported,
+      declarative_only: declarativeOnly,
+      unsupported_detector: unsupportedDetector,
+    },
   };
 
   if (registryTotals) {

--- a/integrations/evidence/schema.ts
+++ b/integrations/evidence/schema.ts
@@ -76,6 +76,15 @@ export type SnapshotRulesCoverage = {
     unsupported_detector?: number;
   };
   coverage_ratio: number;
+  auto_runtime_coverage_ratio?: number;
+  semantic_enforcement_ratio?: number;
+  global_skills_enforcement?: {
+    status: 'enforced' | 'partially_enforced' | 'unsupported';
+    registry_total: number;
+    detector_supported: number;
+    declarative_only: number;
+    unsupported_detector: number;
+  };
 };
 
 export type Snapshot = {

--- a/integrations/gate/__tests__/evaluateAiGate.test.ts
+++ b/integrations/gate/__tests__/evaluateAiGate.test.ts
@@ -588,6 +588,77 @@ test('evaluateAiGate bloquea cuando la policy promociona WARN a BLOCK aunque ai_
   );
 });
 
+test('evaluateAiGate respeta waiver de gate aplicado y no rebloquea por severidades agregadas', () => {
+  const baseEvidence = sampleEvidence();
+  const evidence = sampleEvidence({
+    snapshot: {
+      ...baseEvidence.snapshot,
+      findings: [
+        {
+          ruleId: 'governance.skills.global-enforcement.incomplete',
+          severity: 'ERROR',
+          code: 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL',
+          message: 'global skills enforcement incomplete',
+          file: '.ai_evidence.json',
+        },
+        {
+          ruleId: 'governance.waiver.applied',
+          severity: 'INFO',
+          code: 'GATE_WAIVER_APPLIED',
+          message: 'waiver applied',
+          file: '.pumuki/waivers/gate.json',
+        },
+      ],
+    },
+    ai_gate: {
+      status: 'ALLOWED',
+      violations: [],
+      human_intent: null,
+    },
+    severity_metrics: {
+      gate_status: 'ALLOWED',
+      total_violations: 2,
+      by_severity: {
+        CRITICAL: 0,
+        ERROR: 1,
+        WARN: 0,
+        INFO: 1,
+      },
+    },
+  });
+
+  const result = evaluateAiGate(
+    {
+      repoRoot: '/repo',
+      stage: 'PRE_WRITE',
+    },
+    {
+      now: () => Date.parse('2026-02-20T12:05:00.000Z'),
+      readEvidenceResult: () => validEvidenceResult(evidence),
+      captureRepoState: () => evidence.repo_state!,
+      resolvePolicyForStage: () => ({
+        policy: {
+          stage: 'PRE_COMMIT',
+          blockOnOrAbove: 'INFO',
+          warnOnOrAbove: 'INFO',
+        },
+        trace: {
+          source: 'default',
+          bundle: 'gate-policy.default.PRE_COMMIT',
+          hash: 'a'.repeat(64),
+        },
+      }),
+    }
+  );
+
+  assert.equal(result.status, 'ALLOWED');
+  assert.equal(result.allowed, true);
+  assert.equal(
+    result.violations.some((item) => item.code === 'EVIDENCE_POLICY_THRESHOLD_BLOCK'),
+    false
+  );
+});
+
 test('evaluateAiGate emite WARN cuando la policy solo requiere aviso por severidad', () => {
   const baseEvidence = sampleEvidence();
   const evidence = sampleEvidence({

--- a/integrations/gate/evaluateAiGate.ts
+++ b/integrations/gate/evaluateAiGate.ts
@@ -1300,11 +1300,26 @@ const toHighestTriggeredSeverity = (
   return null;
 };
 
+const hasAppliedGateWaiver = (evidenceResult: EvidenceReadResult): boolean => {
+  if (evidenceResult.kind !== 'valid') {
+    return false;
+  }
+  return evidenceResult.evidence.snapshot.findings.some(
+    (finding) => finding.code === 'GATE_WAIVER_APPLIED'
+  );
+};
+
 const collectEvidencePolicyThresholdViolations = (params: {
   evidenceResult: EvidenceReadResult;
   policy: ReturnType<typeof resolvePolicyForStage>['policy'];
 }): AiGateViolation[] => {
   if (params.evidenceResult.kind !== 'valid') {
+    return [];
+  }
+  if (
+    params.evidenceResult.evidence.ai_gate.status === 'ALLOWED' &&
+    hasAppliedGateWaiver(params.evidenceResult)
+  ) {
     return [];
   }
 

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -198,9 +198,19 @@ test('runPlatformGate silent evita salida humana en stdout para contratos JSON',
           detectedPlatforms: {},
           skillsRuleSet: {
             rules: [],
-            activeBundles: [],
+            activeBundles: [
+              {
+                name: 'frontend-guidelines',
+                version: '1.0.0',
+                source: 'file:docs/codex-skills/frontend-enterprise-rules.md',
+                hash: 'a'.repeat(64),
+                rules: [],
+              },
+            ],
             mappedHeuristicRuleIds: new Set<string>(),
             requiresHeuristicFacts: false,
+            unsupportedAutoRuleIds: [],
+            unsupportedDetectorRuleIds: [],
           },
           projectRules: [] as RuleSet,
           heuristicRules: [] as RuleSet,
@@ -690,6 +700,15 @@ test('runPlatformGate devuelve 1 e imprime findings cuando evaluateGate retorna 
         unevaluated: 0,
       },
       coverage_ratio: 1,
+      auto_runtime_coverage_ratio: 1,
+      semantic_enforcement_ratio: 1,
+      global_skills_enforcement: {
+        status: 'enforced',
+        registry_total: 0,
+        detector_supported: 0,
+        declarative_only: 0,
+        unsupported_detector: 0,
+      },
     },
     repoRoot: '/repo/root',
     detectedPlatforms: evaluationResult.detectedPlatforms,
@@ -2109,10 +2128,10 @@ test('runPlatformGate bloquea en modo strict cuando existen reglas AUTO de skill
   });
 });
 
-test('runPlatformGate no bloquea reglas declarativas sin detector cuando la cobertura AUTO esta completa', async () => {
+test('runPlatformGate bloquea reglas declarativas hard sin detector aunque la cobertura AUTO este completa', async () => {
   await withSkillsEnforcementEnv('strict', async () => {
     const policy: GatePolicy = {
-      stage: 'PRE_PUSH',
+      stage: 'PRE_WRITE',
       blockOnOrAbove: 'ERROR',
       warnOnOrAbove: 'WARN',
     };
@@ -2167,6 +2186,19 @@ test('runPlatformGate no bloquea reglas declarativas sin detector cuando la cobe
             unsupportedDetectorRuleIds: [
               'skills.backend.guideline.backend.clean-architecture',
             ],
+            registryCoverage: {
+              contract: 'AUTO_RUNTIME_RULES_FOR_STAGE',
+              stage: 'PRE_WRITE',
+              registryTotals: {
+                total: 845,
+                auto: 177,
+                declarative: 668,
+              },
+              stageApplicableAutoRuleIds: ['skills.backend.no-empty-catch'],
+              declarativeRuleIds: ['skills.backend.guideline.backend.clean-architecture'],
+              excludedDeclarativeReason:
+                'DECLARATIVE skills are registry contract/policy rules. They are not executed as PRE_COMMIT runtime detectors; only AUTO rules applicable to the current stage are evaluated.',
+            },
           },
           projectRules: [] as RuleSet,
           heuristicRules: [] as RuleSet,
@@ -2208,14 +2240,20 @@ test('runPlatformGate no bloquea reglas declarativas sin detector cuando la cobe
       },
     });
 
-    assert.equal(result, 0);
-    assert.equal(emittedArgs?.gateOutcome, 'PASS');
+    assert.equal(result, 1);
+    assert.equal(emittedArgs?.gateOutcome, 'BLOCK');
     assert.equal(
       emittedArgs?.findings.some(
-        (finding) => finding.ruleId === 'governance.skills.detector-mapping.incomplete'
+        (finding) => finding.ruleId === 'governance.skills.global-enforcement.incomplete'
       ),
-      false
+      true
     );
+    const globalFinding = emittedArgs?.findings.find(
+      (finding) => finding.ruleId === 'governance.skills.global-enforcement.incomplete'
+    );
+    assert.equal(globalFinding?.code, 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL');
+    assert.match(globalFinding?.message ?? '', /registry_total=845/);
+    assert.match(globalFinding?.message ?? '', /unsupported_detector=1/);
     assert.equal(emittedArgs?.rulesCoverage?.unsupported_auto_rule_ids, undefined);
     assert.deepEqual(emittedArgs?.rulesCoverage?.unsupported_detector_rule_ids, [
       'skills.backend.guideline.backend.clean-architecture',
@@ -4434,9 +4472,19 @@ test('runPlatformGate no bloquea PRE_WRITE por tamaño implícito sin hotspot de
           detectedPlatforms: { frontend: { detected: true, confidence: 'HIGH' } },
           skillsRuleSet: {
             rules: [],
-            activeBundles: [],
+            activeBundles: [
+              {
+                name: 'frontend-guidelines',
+                version: '1.0.0',
+                source: 'file:docs/codex-skills/frontend-enterprise-rules.md',
+                hash: 'a'.repeat(64),
+                rules: [],
+              },
+            ],
             mappedHeuristicRuleIds: new Set<string>(),
             requiresHeuristicFacts: false,
+            unsupportedAutoRuleIds: [],
+            unsupportedDetectorRuleIds: [],
           },
           projectRules: [] as RuleSet,
           heuristicRules: [] as RuleSet,

--- a/integrations/git/astIntelligenceDualValidation.ts
+++ b/integrations/git/astIntelligenceDualValidation.ts
@@ -162,7 +162,7 @@ export const resolveAstIntelligenceDualValidationMode = (
 
 const toDualValidationFinding = (params: {
   mode: Exclude<AstIntelligenceDualValidationMode, 'off'>;
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: 'PRE_WRITE' | 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
   summary: AstIntelligenceDualValidationSummary;
 }): Finding | undefined => {
   if (params.summary.divergences === 0) {
@@ -202,7 +202,7 @@ const toDualValidationFinding = (params: {
 };
 
 export const evaluateAstIntelligenceDualValidation = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: 'PRE_WRITE' | 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
   skillsRules: RuleSet;
   facts: ReadonlyArray<Fact>;
   legacyFindings: ReadonlyArray<Finding>;

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -3,6 +3,7 @@ import type { Fact } from '../../core/facts/Fact';
 import type { Finding } from '../../core/gate/Finding';
 import type { GateOutcome } from '../../core/gate/GateOutcome';
 import type { GatePolicy } from '../../core/gate/GatePolicy';
+import type { GateStage } from '../../core/gate/GateStage';
 import type { RuleSet } from '../../core/rules/RuleSet';
 import type { SkillsRuleSetLoadResult } from '../config/skillsRuleSet';
 import type { ResolvedStagePolicy } from '../gate/stagePolicies';
@@ -27,7 +28,7 @@ import { evaluateBrownfieldHotspotFindings } from './brownfieldHotspots';
 import { emitPlatformGateEvidence } from './runPlatformGateEvidence';
 import { printGateFindings } from './runPlatformGateOutput';
 import { evaluateSddPolicy, type SddDecision } from '../sdd';
-import type { SnapshotEvaluationMetrics } from '../evidence/schema';
+import type { SnapshotEvaluationMetrics, SnapshotRulesCoverage } from '../evidence/schema';
 import { createEmptyEvaluationMetrics } from '../evidence/evaluationMetrics';
 import { createEmptySnapshotRulesCoverage } from '../evidence/rulesCoverage';
 import { enforceTddBddPolicy } from '../tdd/enforcement';
@@ -212,8 +213,24 @@ const toSddBlockingFinding = (decision: Pick<SddDecision, 'code' | 'message'>): 
   source: 'sdd-policy',
 });
 
+const STRICT_ENFORCEMENT_STAGES = new Set<GateStage>([
+  'PRE_WRITE',
+  'PRE_COMMIT',
+  'PRE_PUSH',
+  'CI',
+]);
+
+const isStrictEnforcementStage = (
+  stage: GateStage
+): stage is Exclude<GateStage, 'STAGED'> => STRICT_ENFORCEMENT_STAGES.has(stage);
+
+const isLifecycleGateStage = (
+  stage: GateStage
+): stage is 'PRE_COMMIT' | 'PRE_PUSH' | 'CI' =>
+  stage === 'PRE_COMMIT' || stage === 'PRE_PUSH' || stage === 'CI';
+
 const toRulesCoverageBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   activeRuleIds: ReadonlyArray<string>;
   evaluatedRuleIds: ReadonlyArray<string>;
   unevaluatedRuleIds: ReadonlyArray<string>;
@@ -243,7 +260,7 @@ const toRulesCoverageBlockingFinding = (params: {
 };
 
 const toSkillsUnsupportedAutoRulesBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   filesScanned: number;
   unsupportedAutoRuleIds: ReadonlyArray<string>;
   unsupportedDetectorRuleIds?: ReadonlyArray<string>;
@@ -270,6 +287,44 @@ const toSkillsUnsupportedAutoRulesBlockingFinding = (params: {
     filePath: '.ai_evidence.json',
     matchedBy: 'SkillsDetectorMappingGuard',
     source: 'skills-detector-mapping',
+  };
+};
+
+const toSkillsUnsupportedDetectorRulesBlockingFinding = (params: {
+  stage: Exclude<GateStage, 'STAGED'>;
+  filesScanned: number;
+  unsupportedDetectorRuleIds: ReadonlyArray<string>;
+  registryTotal?: number;
+  registryDeclarative?: number;
+}): Finding | undefined => {
+  if (params.filesScanned === 0) {
+    return undefined;
+  }
+
+  const unsupportedRuleIds = [...new Set(params.unsupportedDetectorRuleIds)].sort();
+  if (unsupportedRuleIds.length === 0) {
+    return undefined;
+  }
+
+  const unsupportedRuleIdsSample = unsupportedRuleIds
+    .slice(0, MAX_SCOPE_SAMPLE_PATHS)
+    .join(LIST_SEPARATOR);
+  const remainingRuleIds = Math.max(0, unsupportedRuleIds.length - MAX_SCOPE_SAMPLE_PATHS);
+  return {
+    ruleId: 'governance.skills.global-enforcement.incomplete',
+    severity: 'ERROR',
+    code: 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL',
+    message:
+      `Global skills enforcement incomplete at ${params.stage}: ` +
+      `registry_total=${params.registryTotal ?? 'n/a'} ` +
+      `registry_declarative=${params.registryDeclarative ?? 'n/a'} ` +
+      `unsupported_detector=${unsupportedRuleIds.length} ` +
+      `unsupported_detector_rule_ids_sample=[${unsupportedRuleIdsSample}] ` +
+      `unsupported_detector_rule_ids_remaining=${remainingRuleIds}. ` +
+      'Every hard skill rule must be enforced by AST detector or fail closed before this stage can proceed.',
+    filePath: '.ai_evidence.json',
+    matchedBy: 'SkillsGlobalEnforcementGuard',
+    source: 'skills-global-enforcement',
   };
 };
 
@@ -452,7 +507,7 @@ const hasTrackForMemoryLeaksPattern = (content: string): boolean =>
   /\btrackForMemoryLeaks\s*\(/.test(content);
 
 const toIosTestsQualityBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   facts: ReadonlyArray<Fact>;
 }): Finding | undefined => {
   const testFiles = collectIosTestFileContents(params.facts);
@@ -502,7 +557,7 @@ const toIosTestsQualityBlockingFinding = (params: {
 };
 
 const toActiveRulesEmptyForCodeChangesBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   facts: ReadonlyArray<Fact>;
   activeRuleIds: ReadonlyArray<string>;
 }): Finding | undefined => {
@@ -570,7 +625,7 @@ const detectRequiredSkillsScopesFromPaths = (
 };
 
 const toSkillsScopeComplianceBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   facts: ReadonlyArray<Fact>;
   activeRuleIds: ReadonlyArray<string>;
   evaluatedRuleIds: ReadonlyArray<string>;
@@ -619,7 +674,7 @@ const toSkillsScopeComplianceBlockingFinding = (params: {
 };
 
 const toPolicyAsCodeBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   policyTrace?: ResolvedStagePolicy['trace'];
 }): Finding | undefined => {
   const validation = params.policyTrace?.validation;
@@ -642,7 +697,7 @@ const toPolicyAsCodeBlockingFinding = (params: {
 };
 
 const toDegradedModeFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   policyTrace?: ResolvedStagePolicy['trace'];
 }): Finding | undefined => {
   const degraded = params.policyTrace?.degraded;
@@ -721,7 +776,7 @@ const toGateWaiverInvalidFinding = (params: {
 });
 
 const toPlatformSkillsCoverageBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   detectedPlatforms: DetectedPlatforms;
   activeBundles: ReadonlyArray<SkillsRuleSetLoadResult['activeBundles'][number]>;
   activeRuleIds: ReadonlyArray<string>;
@@ -780,7 +835,7 @@ const toPlatformSkillsCoverageBlockingFinding = (params: {
 };
 
 const toCrossPlatformCriticalEnforcementBlockingFinding = (params: {
-  stage: 'PRE_COMMIT' | 'PRE_PUSH' | 'CI';
+  stage: Exclude<GateStage, 'STAGED'>;
   detectedPlatforms: DetectedPlatforms;
   skillsRules: SkillsRuleSetLoadResult['rules'];
   evaluatedRuleIds: ReadonlyArray<string>;
@@ -990,9 +1045,7 @@ export async function runPlatformGate(params: {
     }
     : createEmptyEvaluationMetrics();
   const coverageBlockingFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toRulesCoverageBlockingFinding({
         stage: params.policy.stage,
         activeRuleIds: coverage?.activeRuleIds ?? [],
@@ -1001,9 +1054,7 @@ export async function runPlatformGate(params: {
       })
       : undefined;
   const unsupportedSkillsMappingFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toSkillsUnsupportedAutoRulesBlockingFinding({
         stage: params.policy.stage,
         filesScanned,
@@ -1014,10 +1065,21 @@ export async function runPlatformGate(params: {
   const effectiveUnsupportedSkillsMappingFinding = applySkillsFindingEnforcement(
     unsupportedSkillsMappingFinding
   );
+  const unsupportedDetectorSkillsFinding =
+    isStrictEnforcementStage(params.policy.stage)
+      ? toSkillsUnsupportedDetectorRulesBlockingFinding({
+          stage: params.policy.stage,
+          filesScanned,
+          unsupportedDetectorRuleIds: skillsRuleSet.unsupportedDetectorRuleIds ?? [],
+          registryTotal: skillsRuleSet.registryCoverage?.registryTotals.total,
+          registryDeclarative: skillsRuleSet.registryCoverage?.registryTotals.declarative,
+        })
+      : undefined;
+  const effectiveUnsupportedDetectorSkillsFinding = applySkillsFindingEnforcement(
+    unsupportedDetectorSkillsFinding
+  );
   const platformSkillsCoverageFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toPlatformSkillsCoverageBlockingFinding({
           stage: params.policy.stage,
           detectedPlatforms,
@@ -1030,9 +1092,7 @@ export async function runPlatformGate(params: {
     platformSkillsCoverageFinding
   );
   const crossPlatformCriticalFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toCrossPlatformCriticalEnforcementBlockingFinding({
           stage: params.policy.stage,
           detectedPlatforms,
@@ -1044,9 +1104,7 @@ export async function runPlatformGate(params: {
     crossPlatformCriticalFinding
   );
   const skillsScopeComplianceFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toSkillsScopeComplianceBlockingFinding({
           stage: params.policy.stage,
           facts,
@@ -1058,9 +1116,7 @@ export async function runPlatformGate(params: {
     skillsScopeComplianceFinding
   );
   const activeRulesEmptyForCodeChangesFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toActiveRulesEmptyForCodeChangesBlockingFinding({
         stage: params.policy.stage,
         facts,
@@ -1068,9 +1124,7 @@ export async function runPlatformGate(params: {
       })
       : undefined;
   const iosTestsQualityFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toIosTestsQualityBlockingFinding({
           stage: params.policy.stage,
           facts,
@@ -1080,15 +1134,14 @@ export async function runPlatformGate(params: {
     iosTestsQualityFinding
   );
   const policyAsCodeBlockingFinding =
-    params.policy.stage === 'PRE_COMMIT' ||
-    params.policy.stage === 'PRE_PUSH' ||
-    params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? toPolicyAsCodeBlockingFinding({
           stage: params.policy.stage,
           policyTrace: params.policyTrace,
         })
       : undefined;
-  const degradedModeFinding = LIFECYCLE_GATE_STAGES.includes(params.policy.stage)
+  const degradedModeFinding = isLifecycleGateStage(params.policy.stage)
+    && LIFECYCLE_GATE_STAGES.includes(params.policy.stage)
     ? toDegradedModeFinding({
         stage: params.policy.stage,
         policyTrace: params.policyTrace,
@@ -1097,9 +1150,7 @@ export async function runPlatformGate(params: {
   const astIntelligenceDualValidation:
     | AstIntelligenceDualValidationResult
     | undefined =
-    params.policy.stage === 'PRE_COMMIT'
-      || params.policy.stage === 'PRE_PUSH'
-      || params.policy.stage === 'CI'
+    isStrictEnforcementStage(params.policy.stage)
       ? dependencies.evaluateAstIntelligenceDualValidation({
           stage: params.policy.stage,
           skillsRules: skillsRuleSet.rules,
@@ -1125,7 +1176,7 @@ export async function runPlatformGate(params: {
   }
   const degradedModeBlocks =
     params.policyTrace?.degraded?.action === DEGRADED_MODE_ACTION_BLOCK;
-  const rulesCoverage = coverage
+  const rulesCoverage: SnapshotRulesCoverage = coverage
     ? {
       stage: params.policy.stage,
       contract: skillsRuleSet.registryCoverage?.contract ?? 'AUTO_RUNTIME_RULES_FOR_STAGE',
@@ -1193,6 +1244,43 @@ export async function runPlatformGate(params: {
                 coverage.evaluatedRuleIds.length / coverage.activeRuleIds.length
               ).toFixed(DEFAULT_RULES_COVERAGE_RATIO_DECIMALS)
             ),
+      auto_runtime_coverage_ratio:
+        coverage.activeRuleIds.length === 0
+          ? 1
+          : Number(
+              (
+                coverage.evaluatedRuleIds.length / coverage.activeRuleIds.length
+              ).toFixed(DEFAULT_RULES_COVERAGE_RATIO_DECIMALS)
+            ),
+      semantic_enforcement_ratio: skillsRuleSet.registryCoverage
+        ? Number(
+            (
+              Math.max(
+                0,
+                skillsRuleSet.registryCoverage.registryTotals.total -
+                  (skillsRuleSet.unsupportedDetectorRuleIds ?? []).length
+              ) / Math.max(1, skillsRuleSet.registryCoverage.registryTotals.total)
+            ).toFixed(DEFAULT_RULES_COVERAGE_RATIO_DECIMALS)
+          )
+        : 1,
+      global_skills_enforcement: {
+        status:
+          (skillsRuleSet.unsupportedDetectorRuleIds?.length ?? 0) === 0
+            ? 'enforced'
+            : coverage.activeRuleIds.length > 0
+              ? 'partially_enforced'
+              : 'unsupported',
+        registry_total: skillsRuleSet.registryCoverage?.registryTotals.total ?? 0,
+        detector_supported: Math.max(
+          0,
+          (skillsRuleSet.registryCoverage?.registryTotals.total ?? 0) -
+            (skillsRuleSet.unsupportedDetectorRuleIds ?? []).length
+        ),
+        declarative_only:
+          skillsRuleSet.registryCoverage?.registryTotals.declarative ?? 0,
+        unsupported_detector:
+          (skillsRuleSet.unsupportedDetectorRuleIds ?? []).length,
+      },
     }
     : createEmptySnapshotRulesCoverage(params.policy.stage);
   const brownfieldHotspotFindings = dependencies.evaluateBrownfieldHotspotFindings({
@@ -1226,6 +1314,7 @@ export async function runPlatformGate(params: {
       ...(degradedModeFinding ? [degradedModeFinding] : []),
       ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
       ...(effectiveUnsupportedSkillsMappingFinding ? [effectiveUnsupportedSkillsMappingFinding] : []),
+      ...(effectiveUnsupportedDetectorSkillsFinding ? [effectiveUnsupportedDetectorSkillsFinding] : []),
       ...(effectivePlatformSkillsCoverageFinding ? [effectivePlatformSkillsCoverageFinding] : []),
       ...(effectiveCrossPlatformCriticalFinding ? [effectiveCrossPlatformCriticalFinding] : []),
       ...(effectiveSkillsScopeComplianceFinding ? [effectiveSkillsScopeComplianceFinding] : []),
@@ -1238,6 +1327,7 @@ export async function runPlatformGate(params: {
       ...findings,
     ]
     : effectiveUnsupportedSkillsMappingFinding
+      || effectiveUnsupportedDetectorSkillsFinding
       || effectivePlatformSkillsCoverageFinding
       || effectiveCrossPlatformCriticalFinding
       || effectiveSkillsScopeComplianceFinding
@@ -1253,6 +1343,7 @@ export async function runPlatformGate(params: {
         ...(degradedModeFinding ? [degradedModeFinding] : []),
         ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
         ...(effectiveUnsupportedSkillsMappingFinding ? [effectiveUnsupportedSkillsMappingFinding] : []),
+        ...(effectiveUnsupportedDetectorSkillsFinding ? [effectiveUnsupportedDetectorSkillsFinding] : []),
         ...(effectivePlatformSkillsCoverageFinding ? [effectivePlatformSkillsCoverageFinding] : []),
         ...(effectiveCrossPlatformCriticalFinding ? [effectiveCrossPlatformCriticalFinding] : []),
         ...(effectiveSkillsScopeComplianceFinding ? [effectiveSkillsScopeComplianceFinding] : []),
@@ -1274,6 +1365,7 @@ export async function runPlatformGate(params: {
     degradedModeBlocks ||
     shouldBlockFromFinding(policyAsCodeBlockingFinding) ||
     shouldBlockFromFinding(effectiveUnsupportedSkillsMappingFinding) ||
+    shouldBlockFromFinding(effectiveUnsupportedDetectorSkillsFinding) ||
     shouldBlockFromFinding(effectivePlatformSkillsCoverageFinding) ||
     shouldBlockFromFinding(effectiveCrossPlatformCriticalFinding) ||
     shouldBlockFromFinding(effectiveSkillsScopeComplianceFinding) ||


### PR DESCRIPTION
## Summary
- fail closed when hard skill rules remain without AST detector support in strict pre stages
- expose auto runtime coverage separately from semantic/global skills enforcement metrics
- honor explicit gate waivers in AI gate aggregation so waived evidence is not re-blocked by severity rollups

## Tests
- node --import tsx --test integrations/gate/__tests__/evaluateAiGate.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/evidence/__tests__/rulesCoverage.test.ts integrations/git/__tests__/astIntelligenceDualValidation.test.ts
- node --import tsx --test integrations/evidence/__tests__/rulesCoverage.test.ts integrations/git/__tests__/runPlatformGate.test.ts integrations/git/__tests__/astIntelligenceDualValidation.test.ts integrations/git/__tests__/runPlatformGateEvaluation.test.ts integrations/config/__tests__/skillsRuleSet.test.ts
- PUMUKI_NOTIFY=0 PUMUKI_NOTIFICATIONS=0 PUMUKI_DISABLE_NOTIFICATIONS=1 node bin/pumuki-pre-write.js
- RuralGo local validation: PRE_WRITE emits SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL with gate_exit_code=1