### PR TITLE
fix: enforce ios solid prewrite gaps

### DIFF
--- a/PUMUKI-INC-059.feature
+++ b/PUMUKI-INC-059.feature
@@ -1,0 +1,14 @@
+Feature: PUMUKI-INC-059 iOS SOLID enforcement in PRE_WRITE
+  Pumuki must block hard iOS skill violations before a consumer persists code.
+
+  Scenario: PRE_WRITE blocks OCP switch over outcome in an iOS coordinator
+    Given ios-enterprise-rules are active for a Swift consumer
+    When a coordinator introduces a switch over an AppConfigurationOutcome-style outcome
+    Then AST Intelligence emits heuristics.ios.solid.ocp.discriminator-switch.ast
+    And the mapped ios.solid.ocp.discriminator-switch-branching rule blocks the gate
+
+  Scenario: PRE_WRITE blocks XCTestCase suites mixing responsibilities
+    Given ios-enterprise-rules are active for Swift tests
+    When one XCTestCase mixes configuration, session, onboarding, permissions, tutorial or splash responsibilities
+    Then AST Intelligence emits heuristics.ios.solid.srp.presentation-mixed-responsibilities.ast
+    And the mapped ios.solid.srp.presentation-mixed-responsibilities rule blocks the gate

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1157,6 +1157,78 @@ test('detects semantic OCP heuristic for iOS application types with discriminato
   assert.match(finding.expected_fix ?? '', /estrategia|protocolo|registry/i);
 });
 
+test('detects semantic OCP heuristic for iOS coordinator switch over outcome', () => {
+  const extracted = extractHeuristicFacts({
+    facts: [
+      fileContentFact(
+        'apps/ios/Presentation/Onboarding/LaunchFlowCoordinator.swift',
+        [
+          'public final class LaunchFlowCoordinator {',
+          '  public func bootstrap() async {',
+          '    let outcome = await appConfigurationUseCase.execute()',
+          '    switch outcome {',
+          '    case .mandatoryUpdate:',
+          '      route = .updateRequired',
+          '    case .maintenance:',
+          '      route = .maintenance',
+          '    case .proceed:',
+          '      route = .home',
+          '    }',
+          '  }',
+          '}',
+        ].join('\n')
+      ),
+    ],
+    detectedPlatforms: {
+      ios: { detected: true },
+    },
+  });
+
+  const finding = extracted.find(
+    (entry) => entry.ruleId === 'heuristics.ios.solid.ocp.discriminator-switch.ast'
+  );
+
+  assert.ok(finding);
+  assert.equal(finding.primary_node?.name, 'LaunchFlowCoordinator');
+  assert.deepEqual(finding.related_nodes, [
+    { kind: 'member', name: 'discriminator switch: outcome', lines: [4] },
+    { kind: 'member', name: 'case .mandatoryUpdate', lines: [5] },
+    { kind: 'member', name: 'case .maintenance', lines: [7] },
+    { kind: 'member', name: 'case .proceed', lines: [9] },
+  ]);
+});
+
+test('detects semantic SRP heuristic for XCTestCase suites with mixed responsibilities', () => {
+  const extracted = extractHeuristicFacts({
+    facts: [
+      fileContentFact(
+        'apps/ios/Tests/Mac/Presentation/LaunchFlowCoordinatorConfigTests.spec.swift',
+        [
+          'import XCTest',
+          '',
+          'final class LaunchFlowCoordinatorConfigTests: XCTestCase {',
+          '  func test_bootstrap_whenMandatoryUpdate_routesToUpdateRequired() async {}',
+          '  func test_bootstrap_whenSessionIsValid_routesHome() async {}',
+          '  func test_completeOnboarding_marksProgressAndRoutesToLogin() async {}',
+          '}',
+        ].join('\n')
+      ),
+    ],
+    detectedPlatforms: {
+      ios: { detected: true },
+    },
+  });
+
+  const finding = extracted.find(
+    (entry) => entry.ruleId === 'heuristics.ios.solid.srp.presentation-mixed-responsibilities.ast'
+  );
+
+  assert.ok(finding);
+  assert.equal(finding.code, 'HEURISTICS_IOS_SOLID_SRP_XCTEST_MIXED_RESPONSIBILITIES_AST');
+  assert.equal(finding.primary_node?.name, 'LaunchFlowCoordinatorConfigTests');
+  assert.match(finding.why ?? '', /XCTestCase|SRP/);
+});
+
 test('detects semantic OCP heuristic for backend application types with discriminator branching', () => {
   const extracted = extractHeuristicFacts({
     facts: [

--- a/core/facts/detectors/text/ios.test.ts
+++ b/core/facts/detectors/text/ios.test.ts
@@ -6,6 +6,7 @@ import {
   findSwiftOpenClosedSwitchMatch,
   findSwiftConcreteDependencyDipMatch,
   findSwiftPresentationSrpMatch,
+  findSwiftXCTestSrpMatch,
   hasSwiftAnyViewUsage,
   hasSwiftCallbackStyleSignature,
   hasSwiftCornerRadiusUsage,
@@ -886,6 +887,69 @@ final class PumukiOcpIosCanaryUseCase {
   assert.match(match.why, /OCP/i);
   assert.match(match.impact, /nuevo caso|nuevo comportamiento/i);
   assert.match(match.expected_fix, /estrategia|protocolo|registry/i);
+});
+
+test('findSwiftOpenClosedSwitchMatch detecta switch sobre outcome en Coordinator iOS', () => {
+  const source = `public final class LaunchFlowCoordinator {
+  public func bootstrap() async {
+    let outcome = await appConfigurationUseCase.execute()
+    switch outcome {
+    case .mandatoryUpdate:
+      route = .updateRequired
+    case .maintenance:
+      route = .maintenance
+    case .proceed:
+      route = .home
+    }
+  }
+}
+`;
+
+  const match = findSwiftOpenClosedSwitchMatch(source);
+
+  assert.ok(match);
+  assert.equal(match.primary_node.name, 'LaunchFlowCoordinator');
+  assert.deepEqual(match.related_nodes, [
+    { kind: 'member', name: 'discriminator switch: outcome', lines: [4] },
+    { kind: 'member', name: 'case .mandatoryUpdate', lines: [5] },
+    { kind: 'member', name: 'case .maintenance', lines: [7] },
+    { kind: 'member', name: 'case .proceed', lines: [9] },
+  ]);
+  assert.match(match.why, /OCP/);
+});
+
+test('findSwiftXCTestSrpMatch detecta XCTestCase con responsabilidades mezcladas', () => {
+  const source = `import XCTest
+
+final class LaunchFlowCoordinatorConfigTests: XCTestCase {
+  func test_bootstrap_whenMandatoryUpdate_routesToUpdateRequired() async {}
+  func test_bootstrap_whenSessionIsValid_routesHome() async {}
+  func test_completeOnboarding_marksProgressAndRoutesToLogin() async {}
+}
+`;
+
+  const match = findSwiftXCTestSrpMatch(source);
+
+  assert.ok(match);
+  assert.equal(match.primary_node.name, 'LaunchFlowCoordinatorConfigTests');
+  assert.deepEqual(match.related_nodes, [
+    { kind: 'member', name: 'session routing tests', lines: [5] },
+    { kind: 'member', name: 'onboarding progress tests', lines: [6] },
+  ]);
+  assert.match(match.why, /XCTestCase|SRP/);
+});
+
+test('findSwiftXCTestSrpMatch permite XCTestCase enfocado en una responsabilidad', () => {
+  const source = `import XCTest
+
+final class LaunchFlowCoordinatorNonBlockingConfigTests: XCTestCase {
+  func test_bootstrap_whenConfigFetchFailsWithCache_usesCachedConfigAndContinues() async {}
+  func test_bootstrap_whenOptionalUpdate_allowsAccessAndContinues() async {}
+  func test_bootstrap_whenProceed_continuesToSessionValidation() async {}
+}
+`;
+
+  assert.equal(findSwiftXCTestSrpMatch(source), undefined);
 });
 
 test('findSwiftInterfaceSegregationMatch devuelve payload semantico para ISP-iOS en application', () => {

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -32,6 +32,8 @@ export type SwiftPresentationSrpMatch = {
   lines: readonly number[];
 };
 
+export type SwiftXCTestSrpMatch = SwiftPresentationSrpMatch;
+
 export type SwiftConcreteDependencyDipMatch = {
   primary_node: SwiftSemanticNodeMatch;
   related_nodes: readonly SwiftSemanticNodeMatch[];
@@ -1185,6 +1187,100 @@ export const findSwiftPresentationSrpMatch = (
   };
 };
 
+export const findSwiftXCTestSrpMatch = (source: string): SwiftXCTestSrpMatch | undefined => {
+  if (!hasSwiftXCTestCaseSubclassUsage(source)) {
+    return undefined;
+  }
+
+  const classPattern = /\b(?:final\s+)?class\s+([A-Za-z0-9_]*Tests?)\s*:\s*XCTestCase\b/;
+  const classLines = collectSwiftRegexLines(source, classPattern);
+  if (classLines.length === 0) {
+    return undefined;
+  }
+
+  const classLine = source.split(/\r?\n/)[classLines[0] - 1] ?? '';
+  const className = classLine.match(classPattern)?.[1];
+  if (!className) {
+    return undefined;
+  }
+
+  const sourceLines = source.split(/\r?\n/);
+  const familyPatterns: ReadonlyArray<{
+    key: string;
+    name: string;
+    tokens: readonly string[];
+  }> = [
+    { key: 'configuration', name: 'configuration outcome tests', tokens: ['config', 'configuration', 'update', 'cache'] },
+    { key: 'session', name: 'session routing tests', tokens: ['session', 'login', 'auth', 'valid', 'invalid'] },
+    { key: 'onboarding', name: 'onboarding progress tests', tokens: ['onboarding', 'progress', 'completeonboarding'] },
+    { key: 'permissions', name: 'permissions routing tests', tokens: ['permission', 'camera', 'location', 'notification'] },
+    { key: 'tutorial', name: 'tutorial or feature discovery tests', tokens: ['tutorial', 'featurediscovery'] },
+    { key: 'splash', name: 'splash delay tests', tokens: ['splash', 'delay', 'start'] },
+  ];
+  const matchesFamily = (value: string, tokens: readonly string[]): boolean => {
+    const normalizedValue = value.toLowerCase();
+    return tokens.some((token) => normalizedValue.includes(token));
+  };
+
+  const classFamilyKeys = new Set(
+    familyPatterns
+      .filter((entry) => matchesFamily(className, entry.tokens))
+      .map((entry) => entry.key)
+  );
+  const matchedFamilies = new Map<string, SwiftSemanticNodeMatch>();
+
+  sourceLines.forEach((line, index) => {
+    const sanitizedLine = stripSwiftLineForSemanticScan(line);
+    const methodMatch = sanitizedLine.match(/\bfunc\s+(test[A-Za-z0-9_]+)\s*\(/);
+    const methodName = methodMatch?.[1];
+    if (!methodName) {
+      return;
+    }
+
+    for (const family of familyPatterns) {
+      if (!matchesFamily(methodName, family.tokens)) {
+        continue;
+      }
+      if (classFamilyKeys.has(family.key)) {
+        continue;
+      }
+      if (!matchedFamilies.has(family.key)) {
+        matchedFamilies.set(family.key, {
+          kind: 'member',
+          name: family.name,
+          lines: [index + 1],
+        });
+      }
+    }
+  });
+
+  const relatedNodes = [...matchedFamilies.values()];
+  if (relatedNodes.length < 2) {
+    return undefined;
+  }
+
+  const relatedNodeNames = relatedNodes.map((node) => node.name).join(', ');
+  const allLines = sortedUniqueLines([
+    ...classLines,
+    ...relatedNodes.flatMap((node) => [...node.lines]),
+  ]);
+
+  return {
+    primary_node: {
+      kind: 'class',
+      name: className,
+      lines: classLines,
+    },
+    related_nodes: relatedNodes,
+    why: `${className} mezcla ${relatedNodeNames} dentro del mismo XCTestCase, rompiendo SRP en la suite de tests.`,
+    impact:
+      'La suite acumula múltiples razones de cambio, oculta regresiones por responsabilidad y hace más difícil aislar el baseline afectado antes de PRE_WRITE.',
+    expected_fix:
+      'Divide la suite por responsabilidad observable: configuración, sesión, onboarding, permisos, tutorial o splash deben vivir en XCTestCase separados.',
+    lines: allLines,
+  };
+};
+
 export const findSwiftConcreteDependencyDipMatch = (
   source: string
 ): SwiftConcreteDependencyDipMatch | undefined => {
@@ -1275,7 +1371,7 @@ export const findSwiftOpenClosedSwitchMatch = (
   }
 
   const lines = source.split(/\r?\n/);
-  const discriminatorPattern = /\b(?:kind|type|mode|channel|variant|provider|route|flow|source|experience)\b/i;
+  const discriminatorPattern = /\b(?:kind|type|mode|channel|variant|provider|route|flow|source|experience|outcome|state|status|configuration|config)\b/i;
   const switchPattern = /\bswitch\s+([A-Za-z_][A-Za-z0-9_\.]*)\s*\{/;
 
   for (let index = 0; index < lines.length; index += 1) {

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -901,11 +901,30 @@ export const extractHeuristicFacts = (
       }
     }
 
-    if (
-      params.detectedPlatforms.ios?.detected &&
-      isIOSSwiftPath(fileFact.path) &&
-      !isSwiftTestPath(fileFact.path)
-    ) {
+    if (params.detectedPlatforms.ios?.detected && isIOSSwiftPath(fileFact.path)) {
+      if (isSwiftTestPath(fileFact.path)) {
+        const semanticTestSrpMatch = TextIOS.findSwiftXCTestSrpMatch(fileFact.content);
+        if (semanticTestSrpMatch) {
+          heuristicFacts.push(
+            createHeuristicFact({
+              ruleId: 'heuristics.ios.solid.srp.presentation-mixed-responsibilities.ast',
+              code: 'HEURISTICS_IOS_SOLID_SRP_XCTEST_MIXED_RESPONSIBILITIES_AST',
+              message:
+                'Semantic iOS SRP heuristic detected an XCTestCase suite mixing multiple responsibilities.',
+              filePath: fileFact.path,
+              lines: semanticTestSrpMatch.lines,
+              severity: 'CRITICAL',
+              primary_node: semanticTestSrpMatch.primary_node,
+              related_nodes: semanticTestSrpMatch.related_nodes,
+              why: semanticTestSrpMatch.why,
+              impact: semanticTestSrpMatch.impact,
+              expected_fix: semanticTestSrpMatch.expected_fix,
+            })
+          );
+        }
+      }
+
+      if (!isSwiftTestPath(fileFact.path)) {
       if (isIOSApplicationOrPresentationPath(fileFact.path)) {
         const semanticOcpMatch = TextIOS.findSwiftOpenClosedSwitchMatch(fileFact.content);
         if (semanticOcpMatch) {
@@ -1026,6 +1045,7 @@ export const extractHeuristicFacts = (
             expected_fix: semanticCanaryMatch.expected_fix,
           })
         );
+      }
       }
     }
 


### PR DESCRIPTION
## Summary
- detect iOS coordinator OCP switches over outcome/config/state/status discriminators
- detect mixed-responsibility XCTestCase suites as iOS SRP violations
- add PUMUKI-INC-059 BDD feature and regression tests

## Validation
- node --import tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/iosEnterpriseRuleSet.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts -> 155/155 pass