### PR TITLE
fix(notifications): make policy reconcile remediation actionable

### DIFF
--- a/PUMUKI-INC-061.feature
+++ b/PUMUKI-INC-061.feature
@@ -1,0 +1,5 @@
+Feature: PUMUKI-INC-061 actionable policy remediation
+  Scenario: Blocked governance notification uses applying policy reconcile
+    Given a consumer gate is blocked because policy or skills governance must be reconciled
+    When Pumuki renders the blocked notification command
+    Then the visible remediation uses policy reconcile with strict apply before revalidation

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-059` / RuralGo: corregir el gap de enforcement de skills hard OCP/SRP/LISKOV/ISP/DIP/LOP en `PRE_WRITE`, `PRE_COMMIT` y `PRE_PUSH` tras cerrar `PUMUKI-INC-125` en `pumuki@6.3.148`. Estado 2026-05-05: `PUMUKI-INC-125` ya falla cerrado cuando el enforcement global de skills queda incompleto; la siguiente prioridad externa es demostrar detección/bloqueo semántico real de las violaciones OCP/SRP reportadas por RuralGo, no solo bloquear por el gap global de cobertura. |
+| Este plan | [🚧] - `PUMUKI-INC-061` / RuralGo: hacer accionable la remediación visible de governance cuando el bloqueo requiere reconciliar policy-as-code. Estado 2026-05-05: `PUMUKI-INC-060` queda verificado en RuralGo con `pumuki@6.3.149` (`PRE_WRITE` bloquea por `TDD_BDD_EVIDENCE_STALE`); la prioridad externa viva es evitar que notificaciones/hooks sugieran `policy reconcile --strict --json` sin `--apply` cuando la convergencia real requiere escribir contrato. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This file tracks the active deterministic framework line used in this repository
 Canonical release chronology lives in `CHANGELOG.md`.
 This file keeps only the operational highlights and rollout notes that matter while running the framework.
 
+### 2026-05-05 (v6.3.150)
+
+- **RuralGo PUMUKI-INC-061:** las notificaciones de bloqueo ya recomiendan `policy reconcile --strict --apply --json` cuando la remediación real requiere converger policy-as-code.
+- **UX sin loop falso:** `EVIDENCE_GATE_BLOCKED` y gaps de skills/policy dejan de mostrar un comando dry-run que no puede desbloquear el repo por sí solo.
+- **Rollout:** publicar `pumuki@6.3.150`, repinear primero RuralGo y revalidar un bloqueo de governance verificando el comando visible.
+
 ### 2026-05-05 (v6.3.145)
 
 - **RuralGo PUMUKI-INC-124:** `skills.ios.critical-test-quality` deja de bloquear tests XCTest de UI automation/performance cuando usan `XCUIApplication`, `XCTMetric` o `measure`.

--- a/scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts
@@ -57,7 +57,27 @@ test('buildGateBlockedPayload muestra causa y solución coherentes para tracking
   assert.match(payload.subtitle ?? '', /Tracking bloqueado/i);
   assert.match(payload.message, /tracking/i);
   assert.match(payload.message, /comando:/i);
+  assert.match(payload.message, /policy reconcile --strict --apply --json/i);
   assert.match(payload.message, /siguiente acción:/i);
+});
+
+test('buildGateBlockedPayload recomienda reconcile con apply para drift de policy', () => {
+  const payload = buildGateBlockedPayload(
+    {
+      kind: 'gate.blocked',
+      stage: 'PRE_COMMIT',
+      totalViolations: 1,
+      causeCode: 'EVIDENCE_SKILLS_CONTRACT_INCOMPLETE',
+      causeMessage: 'Active rules coverage is empty at PRE_COMMIT.',
+    },
+    {
+      projectPrefix: 'R_GO · ',
+      repoRoot: '/tmp/rgo',
+    }
+  );
+
+  assert.match(payload.message, /policy reconcile --strict --apply --json/i);
+  assert.doesNotMatch(payload.message, /policy reconcile --strict --json(?!\s*&&)/i);
 });
 
 test('buildGateBlockedPayload no culpa al tracking cuando la causa real es TDD/BDD', () => {

--- a/scripts/framework-menu-system-notifications-payloads-blocked.ts
+++ b/scripts/framework-menu-system-notifications-payloads-blocked.ts
@@ -64,7 +64,7 @@ export const resolveBlockedCommand = (params: {
     case 'EVIDENCE_CROSS_PLATFORM_CRITICAL_ENFORCEMENT_INCOMPLETE':
       return `${buildPinnedPumukiCommand({
         repoRoot: params.repoRoot,
-        executableAndArgs: 'pumuki policy reconcile --strict --json',
+        executableAndArgs: 'pumuki policy reconcile --strict --apply --json',
       })} && ${buildPinnedPumukiCommand({
         repoRoot: params.repoRoot,
         executableAndArgs: `pumuki sdd validate --stage=${params.event.stage} --json`,
@@ -79,7 +79,7 @@ export const resolveBlockedCommand = (params: {
     case 'EVIDENCE_GATE_BLOCKED':
       return `${buildPinnedPumukiCommand({
         repoRoot: params.repoRoot,
-        executableAndArgs: 'pumuki policy reconcile --strict --json',
+        executableAndArgs: 'pumuki policy reconcile --strict --apply --json',
       })} && ${buildPinnedPumukiCommand({
         repoRoot: params.repoRoot,
         executableAndArgs: `pumuki sdd validate --stage=${params.event.stage} --json`,

--- a/scripts/framework-menu-system-notifications-remediation.ts
+++ b/scripts/framework-menu-system-notifications-remediation.ts
@@ -41,7 +41,7 @@ const BLOCKED_REMEDIATION_BY_CODE: Readonly<Record<string, string>> = {
   TRACKING_CANONICAL_IN_PROGRESS_INVALID: TRACKING_BLOCKED_REMEDIATION,
   TRACKING_CANONICAL_SOURCE_CONFLICT: TRACKING_BLOCKED_REMEDIATION,
   ACTIVE_RULE_IDS_EMPTY_FOR_CODE_CHANGES_HIGH:
-    'Ejecuta `pumuki policy reconcile --strict --json` y revalida antes de continuar.',
+    'Ejecuta `pumuki policy reconcile --strict --apply --json` y revalida antes de continuar.',
 };
 
 const BLOCKED_REMEDIATION_MAX_LENGTH_BY_VARIANT: Readonly<Record<BlockedRemediationVariant, number>> = {


### PR DESCRIPTION
## Summary
- use policy reconcile --strict --apply --json in blocked notification commands when policy/skills reconciliation must converge the contract
- add PUMUKI-INC-061 BDD scenario and update active tracking/release notes

## Tests
- node --import tsx --test scripts/__tests__/framework-menu-system-notifications-payloads-blocked.test.ts scripts/__tests__/framework-menu-system-notifications-remediation.test.ts scripts/__tests__/framework-menu-system-notifications-cause.test.ts
- node --import tsx --test --test-name-pattern 'policy reconcile' integrations/lifecycle/__tests__/cli.test.ts integrations/lifecycle/__tests__/policyReconcile.test.ts