### PR TITLE
fix(gate): allow net remediation commits under global skills fail-closed

### DIFF
--- a/PUMUKI-INC-126.feature
+++ b/PUMUKI-INC-126.feature
@@ -1,0 +1,17 @@
+Feature: PUMUKI-INC-126 remediation progress gate
+
+  Scenario: Allow a staged remediation that removes a supported detector finding
+    Given a consumer has a staged iOS change
+    And HEAD contains a supported "skills.ios.no-force-unwrap" violation in the staged file
+    And the staged version removes that violation without adding new findings
+    And global declarative skills enforcement is still incomplete
+    When Pumuki evaluates the staged PRE_COMMIT gate
+    Then the global enforcement gap is recorded as advisory for this remediation commit
+    And the gate allows the commit without a waiver or "--no-verify"
+
+  Scenario: Keep feature work blocked while global skills enforcement is incomplete
+    Given a consumer has a staged code change
+    And the change does not reduce any supported detector finding from HEAD
+    And global declarative skills enforcement is still incomplete
+    When Pumuki evaluates the staged PRE_COMMIT gate
+    Then Pumuki blocks the gate with "SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL"

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-061` / RuralGo: hacer accionable la remediación visible de governance cuando el bloqueo requiere reconciliar policy-as-code. Estado 2026-05-05: `PUMUKI-INC-060` queda verificado en RuralGo con `pumuki@6.3.149` (`PRE_WRITE` bloquea por `TDD_BDD_EVIDENCE_STALE`); la prioridad externa viva es evitar que notificaciones/hooks sugieran `policy reconcile --strict --json` sin `--apply` cuando la convergencia real requiere escribir contrato. |
+| Este plan | [🚧] - `PUMUKI-INC-126` / RuralGo: permitir commits staged de remediación neta sin bypass cuando el diff reduce una violación soportada por detector y no introduce findings nuevos, aunque el fail-closed global de skills siga bloqueando feature work por `SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL`. Estado 2026-05-05: `PUMUKI-INC-060` queda verificado en RuralGo con `pumuki@6.3.149`; `PUMUKI-INC-061` queda publicado en `pumuki@6.3.150`; la prioridad externa viva es desbloquear el fix iOS `ios.no-force-unwrap` en `BuyerProfilePresentation.swift` sin usar `--no-verify`. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -3934,6 +3934,176 @@ final class LoginUseCaseTests: XCTestCase {
   );
 });
 
+test('runPlatformGate permite remediation staged que elimina findings soportados aunque el enforcement global siga incompleto', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const repoRoot = '/repo/root';
+  const stagedPath = 'apps/ios/Presentation/BuyerProfilePresentation.swift';
+  const git = buildGitStub(repoRoot);
+  git.runGit = (args) => {
+    const command = args.join(' ');
+    if (command === 'diff --cached --name-only') {
+      return stagedPath;
+    }
+    if (command === `show HEAD:${stagedPath}`) {
+      return 'let greeting = userName!';
+    }
+    return '';
+  };
+  const evidence = buildEvidenceStub();
+  const stagedFacts: ReadonlyArray<Fact> = [
+    {
+      kind: 'FileChange',
+      path: stagedPath,
+      changeType: 'modified',
+      source: 'git:staged',
+    },
+    {
+      kind: 'FileContent',
+      path: stagedPath,
+      content: 'if let userName { print(userName) }',
+      source: 'git:staged',
+    },
+  ];
+  const iosBundles = [
+    'ios-guidelines',
+    'ios-concurrency-guidelines',
+    'ios-swiftui-expert-guidelines',
+    'ios-swift-testing-guidelines',
+    'ios-core-data-guidelines',
+  ].map((name, index) => ({
+    name,
+    version: '1.0.0',
+    source: 'test',
+    hash: String(index).repeat(64).slice(0, 64).padEnd(64, '0'),
+    rules: [],
+  }));
+  let emitted:
+    | {
+      gateOutcome: 'PASS' | 'WARN' | 'BLOCK';
+      findings: ReadonlyArray<Finding>;
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope: { kind: 'staged' },
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      resolveFactsForGateScope: async () => stagedFacts,
+      evaluatePlatformGateFindings: ({ facts }) => {
+        const content = facts
+          .filter((fact): fact is Extract<Fact, { kind: 'FileContent' }> => fact.kind === 'FileContent')
+          .map((fact) => fact.content)
+          .join('\n');
+        const previousFindings: ReadonlyArray<Finding> = content.includes('userName!')
+          ? [
+            {
+              ruleId: 'skills.ios.no-force-unwrap',
+              severity: 'CRITICAL',
+              code: 'SKILLS_IOS_NO_FORCE_UNWRAP',
+              message: 'Force unwrap is not allowed.',
+              filePath: stagedPath,
+              matchedBy: 'Heuristic',
+              source: 'heuristics:ast',
+            },
+          ]
+          : [];
+        return {
+          detectedPlatforms: {
+            ios: { detected: true, confidence: 'HIGH' },
+          },
+          skillsRuleSet: {
+            rules: [
+              createSkillRule({
+                id: 'skills.ios.no-force-unwrap',
+                severity: 'CRITICAL',
+                platform: 'ios',
+              }),
+            ],
+            activeBundles: iosBundles,
+            mappedHeuristicRuleIds: new Set(['heuristics.ios.force-unwrap.ast']),
+            requiresHeuristicFacts: true,
+            unsupportedAutoRuleIds: [],
+            unsupportedDetectorRuleIds: ['skills.ios.guideline.declarative-only'],
+            registryCoverage: {
+              contract: 'AUTO_RUNTIME_RULES_FOR_STAGE',
+              stage: 'PRE_COMMIT',
+              registryTotals: {
+                total: 2,
+                auto: 1,
+                declarative: 1,
+              },
+              stageApplicableAutoRuleIds: ['skills.ios.no-force-unwrap'],
+              declarativeRuleIds: ['skills.ios.guideline.declarative-only'],
+              excludedDeclarativeReason: 'declarative-only',
+            },
+          },
+          projectRules: [] as RuleSet,
+          heuristicRules: [] as RuleSet,
+          coverage: {
+            factsTotal: facts.length,
+            filesScanned: 1,
+            rulesTotal: 1,
+            baselineRules: 0,
+            heuristicRules: 0,
+            skillsRules: 1,
+            projectRules: 0,
+            matchedRules: previousFindings.length,
+            unmatchedRules: previousFindings.length === 0 ? 1 : 0,
+            unevaluatedRules: 0,
+            activeRuleIds: ['skills.ios.no-force-unwrap'],
+            evaluatedRuleIds: ['skills.ios.no-force-unwrap'],
+            matchedRuleIds: previousFindings.length > 0 ? ['skills.ios.no-force-unwrap'] : [],
+            unmatchedRuleIds: previousFindings.length === 0 ? ['skills.ios.no-force-unwrap'] : [],
+            unevaluatedRuleIds: [],
+          },
+          findings: previousFindings,
+        };
+      },
+      evaluateGate: (findingsArg) => evaluateGateFromFindings(findingsArg, policy),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveActiveGateWaiver: () => ({
+        kind: 'none',
+        path: '.pumuki/waivers/gate.json',
+      }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emitted = {
+          gateOutcome: paramsArg.gateOutcome,
+          findings: paramsArg.findings,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  assert.equal(emitted?.gateOutcome, 'PASS');
+  assert.equal(
+    emitted?.findings.some((finding) => finding.code === 'REMEDIATION_PROGRESS_ALLOWED'),
+    true
+  );
+  assert.equal(
+    emitted?.findings.some(
+      (finding) =>
+        finding.code === 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_REMEDIATION_ADVISORY' &&
+        finding.severity === 'INFO'
+    ),
+    true
+  );
+});
+
 test('runPlatformGate permite continuar cuando existe waiver de gate válido para stage bloqueante', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_PUSH',

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -447,6 +447,88 @@ const collectStagedPaths = (git: IGitService, repoRoot: string): ReadonlyArray<s
   }
 };
 
+const toBlockingFindingsForPaths = (
+  findings: ReadonlyArray<Finding>,
+  paths: ReadonlySet<string>
+): ReadonlyArray<Finding> => {
+  return findings.filter((finding) => {
+    if (finding.severity !== 'ERROR' && finding.severity !== 'CRITICAL') {
+      return false;
+    }
+    const path = finding.filePath ? toNormalizedPath(finding.filePath) : '';
+    return path.length > 0 && paths.has(path);
+  });
+};
+
+const buildHeadFactsForPaths = (params: {
+  git: IGitService;
+  repoRoot: string;
+  paths: ReadonlyArray<string>;
+}): ReadonlyArray<Fact> => {
+  const facts: Fact[] = [];
+  for (const path of params.paths) {
+    try {
+      const content = params.git.runGit(['show', `HEAD:${path}`], params.repoRoot);
+      facts.push({
+        kind: 'FileChange',
+        path,
+        changeType: 'modified',
+        source: 'git:staged:HEAD',
+      });
+      facts.push({
+        kind: 'FileContent',
+        path,
+        content,
+        source: 'git:staged:HEAD',
+      });
+    } catch {
+      continue;
+    }
+  }
+  return facts;
+};
+
+const toRemediationProgressAllowedFinding = (params: {
+  stage: Exclude<GateStage, 'STAGED'>;
+  currentBlockingCount: number;
+  previousBlockingCount: number;
+  paths: ReadonlyArray<string>;
+  ruleIds: ReadonlyArray<string>;
+}): Finding => {
+  const samplePaths = params.paths.slice(0, MAX_SCOPE_SAMPLE_PATHS).join(LIST_SEPARATOR);
+  const sampleRuleIds = params.ruleIds.slice(0, MAX_SCOPE_SAMPLE_PATHS).join(LIST_SEPARATOR);
+  return {
+    ruleId: 'governance.remediation.progress.allowed',
+    severity: 'INFO',
+    code: 'REMEDIATION_PROGRESS_ALLOWED',
+    message:
+      `Remediation progress allowed at ${params.stage}: ` +
+      `previous_blocking_findings=${params.previousBlockingCount} ` +
+      `current_blocking_findings=${params.currentBlockingCount} ` +
+      `paths=[${samplePaths}] remediated_rule_ids=[${sampleRuleIds}]. ` +
+      'Feature work remains blocked until global skills enforcement is complete.',
+    filePath: '.ai_evidence.json',
+    matchedBy: 'RemediationProgressGuard',
+    source: 'remediation-progress',
+    blocking: false,
+  };
+};
+
+const toRemediationProgressAdvisoryFinding = (finding: Finding): Finding => ({
+  ...finding,
+  severity: 'INFO',
+  code:
+    finding.code === 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL'
+      ? 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_REMEDIATION_ADVISORY'
+      : finding.code === 'TDD_BDD_EVIDENCE_STALE'
+        ? 'TDD_BDD_EVIDENCE_STALE_REMEDIATION_ADVISORY'
+        : finding.code,
+  message:
+    `${finding.message} Remediation progress mode converted this blocker to advisory ` +
+    'because the staged diff reduces existing supported-detector findings and introduces none.',
+  blocking: false,
+});
+
 const shouldAugmentStagedSkillsContractFactsWithRepoFacts = (params: {
   scope: GateScope;
   facts: ReadonlyArray<Fact>;
@@ -1305,16 +1387,91 @@ export async function runPlatformGate(params: {
   const hasNativeBlockingFinding = findings.some(
     (finding) => finding.severity === 'ERROR' || finding.severity === 'CRITICAL'
   );
+  const stagedCodePaths = stagedPaths.filter((path) => isObservedCodePath(path));
+  const stagedCodePathSet = new Set(stagedCodePaths);
+  const currentBlockingFindingsForStagedPaths = toBlockingFindingsForPaths(
+    findings,
+    stagedCodePathSet
+  );
+  const previousFactsForStagedPaths =
+    isStrictEnforcementStage(params.policy.stage) &&
+    params.scope.kind === 'staged' &&
+    stagedCodePaths.length > 0 &&
+    currentBlockingFindingsForStagedPaths.length === 0
+      ? buildHeadFactsForPaths({
+          git,
+          repoRoot,
+          paths: stagedCodePaths,
+        })
+      : [];
+  const previousEvaluationForStagedPaths =
+    previousFactsForStagedPaths.length > 0
+      ? dependencies.evaluatePlatformGateFindings({
+          facts: previousFactsForStagedPaths,
+          stage: params.policy.stage,
+          repoRoot,
+        })
+      : undefined;
+  const previousBlockingFindingsForStagedPaths = previousEvaluationForStagedPaths
+    ? toBlockingFindingsForPaths(
+        previousEvaluationForStagedPaths.findings,
+        stagedCodePathSet
+      )
+    : [];
+  const remediationProgressFinding =
+    previousBlockingFindingsForStagedPaths.length > currentBlockingFindingsForStagedPaths.length &&
+    currentBlockingFindingsForStagedPaths.length === 0
+      ? toRemediationProgressAllowedFinding({
+          stage: params.policy.stage as Exclude<GateStage, 'STAGED'>,
+          currentBlockingCount: currentBlockingFindingsForStagedPaths.length,
+          previousBlockingCount: previousBlockingFindingsForStagedPaths.length,
+          paths: stagedCodePaths,
+          ruleIds: [
+            ...new Set(
+              previousBlockingFindingsForStagedPaths.map((finding) => finding.ruleId)
+            ),
+          ].sort(),
+        })
+      : undefined;
+  const remediationProgressAllowsGlobalGap = remediationProgressFinding !== undefined;
+  const effectiveTddBddFindings = remediationProgressAllowsGlobalGap
+    ? tddBddEvaluation.findings.map((finding) =>
+        finding.code === 'TDD_BDD_EVIDENCE_STALE'
+          ? toRemediationProgressAdvisoryFinding(finding)
+          : finding
+      )
+    : tddBddEvaluation.findings;
+  const effectiveTddBddSnapshot =
+    remediationProgressAllowsGlobalGap &&
+    tddBddSnapshot?.status === 'blocked' &&
+    tddBddEvaluation.findings.length > 0 &&
+    tddBddEvaluation.findings.every((finding) => finding.code === 'TDD_BDD_EVIDENCE_STALE')
+      ? {
+          ...tddBddSnapshot,
+          status: 'advisory' as const,
+          evidence: {
+            ...tddBddSnapshot.evidence,
+            errors: ['TDD_BDD_EVIDENCE_STALE_REMEDIATION_ADVISORY'],
+          },
+        }
+      : tddBddSnapshot;
+  const effectiveHasTddBddBlockingFinding = effectiveTddBddFindings.some(
+    (finding) => finding.severity === 'ERROR' || finding.severity === 'CRITICAL'
+  );
   const effectivePlatformSkillsCoverageFinding = effectivePlatformSkillsCoverageInput;
   const effectiveCrossPlatformCriticalFinding = effectiveCrossPlatformCriticalInput;
   const effectiveSkillsScopeComplianceFinding = effectiveSkillsScopeComplianceInput;
+  const effectiveUnsupportedDetectorSkillsFindingForOutcome =
+    remediationProgressAllowsGlobalGap && effectiveUnsupportedDetectorSkillsFinding
+      ? toRemediationProgressAdvisoryFinding(effectiveUnsupportedDetectorSkillsFinding)
+      : effectiveUnsupportedDetectorSkillsFinding;
   const effectiveFindings = sddBlockingFinding
     ? [
       sddBlockingFinding,
       ...(degradedModeFinding ? [degradedModeFinding] : []),
       ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
       ...(effectiveUnsupportedSkillsMappingFinding ? [effectiveUnsupportedSkillsMappingFinding] : []),
-      ...(effectiveUnsupportedDetectorSkillsFinding ? [effectiveUnsupportedDetectorSkillsFinding] : []),
+      ...(effectiveUnsupportedDetectorSkillsFindingForOutcome ? [effectiveUnsupportedDetectorSkillsFindingForOutcome] : []),
       ...(effectivePlatformSkillsCoverageFinding ? [effectivePlatformSkillsCoverageFinding] : []),
       ...(effectiveCrossPlatformCriticalFinding ? [effectiveCrossPlatformCriticalFinding] : []),
       ...(effectiveSkillsScopeComplianceFinding ? [effectiveSkillsScopeComplianceFinding] : []),
@@ -1323,11 +1480,12 @@ export async function runPlatformGate(params: {
       ...(astIntelligenceDualFinding ? [astIntelligenceDualFinding] : []),
       ...(coverageBlockingFinding ? [coverageBlockingFinding] : []),
       ...brownfieldHotspotFindings,
-      ...tddBddEvaluation.findings,
+      ...effectiveTddBddFindings,
+      ...(remediationProgressFinding ? [remediationProgressFinding] : []),
       ...findings,
     ]
     : effectiveUnsupportedSkillsMappingFinding
-      || effectiveUnsupportedDetectorSkillsFinding
+      || effectiveUnsupportedDetectorSkillsFindingForOutcome
       || effectivePlatformSkillsCoverageFinding
       || effectiveCrossPlatformCriticalFinding
       || effectiveSkillsScopeComplianceFinding
@@ -1338,12 +1496,13 @@ export async function runPlatformGate(params: {
       || brownfieldHotspotFindings.length > 0
       || policyAsCodeBlockingFinding
       || degradedModeFinding
-      || tddBddEvaluation.findings.length > 0
+      || effectiveTddBddFindings.length > 0
+      || remediationProgressFinding
       ? [
         ...(degradedModeFinding ? [degradedModeFinding] : []),
         ...(policyAsCodeBlockingFinding ? [policyAsCodeBlockingFinding] : []),
         ...(effectiveUnsupportedSkillsMappingFinding ? [effectiveUnsupportedSkillsMappingFinding] : []),
-        ...(effectiveUnsupportedDetectorSkillsFinding ? [effectiveUnsupportedDetectorSkillsFinding] : []),
+        ...(effectiveUnsupportedDetectorSkillsFindingForOutcome ? [effectiveUnsupportedDetectorSkillsFindingForOutcome] : []),
         ...(effectivePlatformSkillsCoverageFinding ? [effectivePlatformSkillsCoverageFinding] : []),
         ...(effectiveCrossPlatformCriticalFinding ? [effectiveCrossPlatformCriticalFinding] : []),
         ...(effectiveSkillsScopeComplianceFinding ? [effectiveSkillsScopeComplianceFinding] : []),
@@ -1352,20 +1511,22 @@ export async function runPlatformGate(params: {
         ...(astIntelligenceDualFinding ? [astIntelligenceDualFinding] : []),
         ...(coverageBlockingFinding ? [coverageBlockingFinding] : []),
         ...brownfieldHotspotFindings,
-        ...tddBddEvaluation.findings,
+        ...effectiveTddBddFindings,
+        ...(remediationProgressFinding ? [remediationProgressFinding] : []),
         ...findings,
       ]
       : brownfieldHotspotFindings.length > 0
         ? [...brownfieldHotspotFindings, ...findings]
         : findings;
   const hasAstIntelligenceBlockingFinding = shouldBlockFromFinding(astIntelligenceDualFinding);
-  const decision = dependencies.evaluateGate([...effectiveFindings], params.policy);
+  const gateDecisionFindings = effectiveFindings.filter((finding) => finding.blocking !== false);
+  const decision = dependencies.evaluateGate([...gateDecisionFindings], params.policy);
   const baseGateOutcome =
     sddBlockingFinding ||
     degradedModeBlocks ||
     shouldBlockFromFinding(policyAsCodeBlockingFinding) ||
     shouldBlockFromFinding(effectiveUnsupportedSkillsMappingFinding) ||
-    shouldBlockFromFinding(effectiveUnsupportedDetectorSkillsFinding) ||
+    shouldBlockFromFinding(effectiveUnsupportedDetectorSkillsFindingForOutcome) ||
     shouldBlockFromFinding(effectivePlatformSkillsCoverageFinding) ||
     shouldBlockFromFinding(effectiveCrossPlatformCriticalFinding) ||
     shouldBlockFromFinding(effectiveSkillsScopeComplianceFinding) ||
@@ -1374,9 +1535,9 @@ export async function runPlatformGate(params: {
     hasAstIntelligenceBlockingFinding ||
     shouldBlockFromFinding(coverageBlockingFinding) ||
     brownfieldHotspotFindings.some((finding) => shouldBlockFromFinding(finding)) ||
-    hasTddBddBlockingFinding
+    effectiveHasTddBddBlockingFinding
       ? 'BLOCK'
-      : (decision.outcome === 'PASS' && tddBddSnapshot?.status === 'advisory'
+      : (decision.outcome === 'PASS' && effectiveTddBddSnapshot?.status === 'advisory'
           ? 'WARN'
           : decision.outcome);
   const gateWaiverStage =
@@ -1426,7 +1587,7 @@ export async function runPlatformGate(params: {
     try {
       memoryShadowRecommendation = dependencies.buildMemoryShadowRecommendation({
         findings: findingsWithWaiver,
-        ...(tddBddSnapshot ? { tddBddSnapshot } : {}),
+        ...(effectiveTddBddSnapshot ? { tddBddSnapshot: effectiveTddBddSnapshot } : {}),
       });
     } catch (error) {
       const rawReason = error instanceof Error ? error.message : String(error);
@@ -1477,7 +1638,7 @@ export async function runPlatformGate(params: {
     filesScanned,
     evaluationMetrics,
     rulesCoverage,
-    ...(tddBddSnapshot ? { tddBdd: tddBddSnapshot } : {}),
+    ...(effectiveTddBddSnapshot ? { tddBdd: effectiveTddBddSnapshot } : {}),
     ...(memoryShadow ? { memoryShadow } : {}),
     repoRoot,
     detectedPlatforms,


### PR DESCRIPTION
## Summary
- Adds PUMUKI-INC-126 remediation-progress gate for staged commits that remove supported-detector findings without adding new findings.
- Keeps global skills fail-closed for feature work, but records the global gap and stale TDD/BDD baseline as advisory for verified net remediation.
- Updates the reset plan to make PUMUKI-INC-126 the active external RuralGo bug.

## Evidence
- node --import tsx --test integrations/git/__tests__/runPlatformGate.test.ts
- node --import tsx --test integrations/git/__tests__/stageRunners.test.ts --test-name-pattern 'TDD|policy reconcile|pre-commit'
- RuralGo local validation: node bin/pumuki-pre-commit.js --quiet returns 0 for staged BuyerProfilePresentation force-unwrap remediation.
