### PR TITLE
chore(release): pumuki 6.3.151

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.150",
+  "version": "6.3.151",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.150",
+      "version": "6.3.151",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.150",
+  "version": "6.3.151",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Release pumuki@6.3.151 with PUMUKI-INC-126 remediation-progress gate.

## Evidence
- node --import tsx --test integrations/git/__tests__/runPlatformGate.test.ts
- npm publish --dry-run --access public
