### PR TITLE
fix: unblock inc127 prewrite remediation commits

### DIFF
--- a/PUMUKI-INC-127.feature
+++ b/PUMUKI-INC-127.feature
@@ -1,0 +1,8 @@
+Feature: PUMUKI-INC-127 remediation progress advisories do not reblock PRE_WRITE
+
+  Scenario: PRE_WRITE policy threshold ignores non-blocking remediation advisories
+    Given a staged remediation fix reduces supported detector findings without adding new findings
+    And Pumuki emits remediation progress findings with blocking false
+    When the chained PRE_WRITE gate evaluates evidence with block_on_or_above set to INFO
+    Then the evidence policy threshold must not convert those advisory findings into a block
+    And the real git commit path must match pumuki-pre-commit remediation progress behavior

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-126` / RuralGo: permitir commits staged de remediación neta sin bypass cuando el diff reduce una violación soportada por detector y no introduce findings nuevos, aunque el fail-closed global de skills siga bloqueando feature work por `SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_CRITICAL`. Estado 2026-05-05: `PUMUKI-INC-060` queda verificado en RuralGo con `pumuki@6.3.149`; `PUMUKI-INC-061` queda publicado en `pumuki@6.3.150`; la prioridad externa viva es desbloquear el fix iOS `ios.no-force-unwrap` en `BuyerProfilePresentation.swift` sin usar `--no-verify`. |
+| Este plan | [🚧] - `PUMUKI-INC-127` / RuralGo reporta divergencia High entre `npx pumuki-pre-commit --quiet` y el hook real de `git commit`: el pre-commit directo permite el staged remediation fix con `pumuki@6.3.151`, pero el tramo chained `PRE_WRITE` del commit sigue bloqueando por `EVIDENCE_POLICY_THRESHOLD_BLOCK` al tratar advisories `INFO` de remediation progress como bloqueo hard. Prioridad absoluta por MD externo; cualquier slice interna queda congelada hasta reproducir, corregir, cubrir con regresión, publicar si aplica y repinear primero RuralGo. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-127` / RuralGo reporta divergencia High entre `npx pumuki-pre-commit --quiet` y el hook real de `git commit`: el pre-commit directo permite el staged remediation fix con `pumuki@6.3.151`, pero el tramo chained `PRE_WRITE` del commit sigue bloqueando por `EVIDENCE_POLICY_THRESHOLD_BLOCK` al tratar advisories `INFO` de remediation progress como bloqueo hard. Prioridad absoluta por MD externo; cualquier slice interna queda congelada hasta reproducir, corregir, cubrir con regresión, publicar si aplica y repinear primero RuralGo. |
+| Este plan | [🚧] - `PARITY-ANDROID-001` / Single Activity - Multiples Composables/Fragments, no Activities. Estado 2026-05-05: los bugs externos activos quedan a 0 tras cerrar `PUMUKI-INC-127` en `pumuki@6.3.153` y repinear primero RuralGo; se reactiva el baseline Android por AST real siguiendo la siguiente pieza lógica ya registrada en este plan. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/integrations/gate/__tests__/evaluateAiGate.test.ts
+++ b/integrations/gate/__tests__/evaluateAiGate.test.ts
@@ -588,6 +588,74 @@ test('evaluateAiGate bloquea cuando la policy promociona WARN a BLOCK aunque ai_
   );
 });
 
+test('evaluateAiGate no rebloquea advisories no bloqueantes aunque block_on_or_above sea INFO', () => {
+  const baseEvidence = sampleEvidence();
+  const evidence = sampleEvidence({
+    snapshot: {
+      ...baseEvidence.snapshot,
+      findings: [
+        {
+          ruleId: 'governance.remediation.progress.allowed',
+          severity: 'INFO',
+          code: 'REMEDIATION_PROGRESS_ALLOWED',
+          message: 'remediation progress allowed',
+          file: '.ai_evidence.json',
+          blocking: false,
+        },
+        {
+          ruleId: 'governance.skills.global-enforcement.incomplete',
+          severity: 'INFO',
+          code: 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_REMEDIATION_ADVISORY',
+          message: 'global skills enforcement converted to advisory',
+          file: '.ai_evidence.json',
+          blocking: false,
+        },
+      ],
+    },
+    severity_metrics: {
+      gate_status: 'ALLOWED',
+      total_violations: 2,
+      by_severity: {
+        CRITICAL: 0,
+        ERROR: 0,
+        WARN: 0,
+        INFO: 2,
+      },
+    },
+  });
+
+  const result = evaluateAiGate(
+    {
+      repoRoot: '/repo',
+      stage: 'PRE_WRITE',
+    },
+    {
+      now: () => Date.parse('2026-02-20T12:05:00.000Z'),
+      readEvidenceResult: () => validEvidenceResult(evidence),
+      captureRepoState: () => evidence.repo_state!,
+      resolvePolicyForStage: () => ({
+        policy: {
+          stage: 'PRE_WRITE',
+          blockOnOrAbove: 'INFO',
+          warnOnOrAbove: 'INFO',
+        },
+        trace: {
+          source: 'file:.pumuki/policy-as-code.json',
+          bundle: 'gate-policy.default.PRE_WRITE',
+          hash: 'a'.repeat(64),
+        },
+      }),
+    }
+  );
+
+  assert.equal(result.status, 'ALLOWED');
+  assert.equal(result.allowed, true);
+  assert.equal(
+    result.violations.some((item) => item.code === 'EVIDENCE_POLICY_THRESHOLD_BLOCK'),
+    false
+  );
+});
+
 test('evaluateAiGate respeta waiver de gate aplicado y no rebloquea por severidades agregadas', () => {
   const baseEvidence = sampleEvidence();
   const evidence = sampleEvidence({

--- a/integrations/gate/evaluateAiGate.ts
+++ b/integrations/gate/evaluateAiGate.ts
@@ -1309,6 +1309,26 @@ const hasAppliedGateWaiver = (evidenceResult: EvidenceReadResult): boolean => {
   );
 };
 
+const collectBlockingSeverityCounts = (
+  evidenceResult: Extract<EvidenceReadResult, { kind: 'valid' }>
+): Record<'INFO' | 'WARN' | 'ERROR' | 'CRITICAL', number> => {
+  const counts = {
+    INFO: 0,
+    WARN: 0,
+    ERROR: 0,
+    CRITICAL: 0,
+  };
+
+  for (const finding of evidenceResult.evidence.snapshot.findings) {
+    if (finding.blocking === false) {
+      continue;
+    }
+    counts[finding.severity] += 1;
+  }
+
+  return counts;
+};
+
 const collectEvidencePolicyThresholdViolations = (params: {
   evidenceResult: EvidenceReadResult;
   policy: ReturnType<typeof resolvePolicyForStage>['policy'];
@@ -1323,7 +1343,7 @@ const collectEvidencePolicyThresholdViolations = (params: {
     return [];
   }
 
-  const severityCounts = params.evidenceResult.evidence.severity_metrics.by_severity;
+  const severityCounts = collectBlockingSeverityCounts(params.evidenceResult);
   const blockSeverity = toHighestTriggeredSeverity(
     severityCounts,
     params.policy.blockOnOrAbove

--- a/integrations/lifecycle/__tests__/preWriteAutomation.test.ts
+++ b/integrations/lifecycle/__tests__/preWriteAutomation.test.ts
@@ -307,6 +307,7 @@ test('buildPreWriteAutomationTrace refresca evidence aunque SDD esté inválido 
 
 test('buildPreWriteAutomationTrace refresca evidencia cuando PRE_WRITE llega con EVIDENCE_GATE_BLOCKED', async () => {
   let runPlatformGateCalls = 0;
+  const scopes: string[] = [];
   let runEnterpriseCalls = 0;
   let sleepCalled = false;
   const refreshedAiGate = buildAiGate([]);
@@ -316,8 +317,9 @@ test('buildPreWriteAutomationTrace refresca evidencia cuando PRE_WRITE llega con
       repoRoot: '/repo',
       sdd: buildSddAllowed(),
       aiGate: buildAiGate([toViolation('EVIDENCE_GATE_BLOCKED')]),
-      runPlatformGate: async () => {
+      runPlatformGate: async (params) => {
         runPlatformGateCalls += 1;
+        scopes.push(params.scope.kind);
         return 0;
       },
     },
@@ -353,6 +355,7 @@ test('buildPreWriteAutomationTrace refresca evidencia cuando PRE_WRITE llega con
   );
 
   assert.equal(runPlatformGateCalls, 1);
+  assert.deepEqual(scopes, ['staged']);
   assert.equal(runEnterpriseCalls, 1);
   assert.equal(sleepCalled, false);
   assert.equal(result.aiGate.allowed, true);

--- a/integrations/lifecycle/preWriteAutomation.ts
+++ b/integrations/lifecycle/preWriteAutomation.ts
@@ -116,7 +116,7 @@ export const buildPreWriteAutomationTrace = async (params: {
           warnOnOrAbove: 'INFO',
         },
         scope: {
-          kind: 'workingTree',
+          kind: 'staged',
         },
         auditMode: 'gate',
         dependencies: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.151",
+  "version": "6.3.152",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.151",
+      "version": "6.3.152",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.152",
+  "version": "6.3.153",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.152",
+      "version": "6.3.153",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.152",
+  "version": "6.3.153",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.151",
+  "version": "6.3.152",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Ignore snapshot findings marked blocking=false when applying evidence policy thresholds.
- Refresh PRE_WRITE auto-heal evidence from staged scope so git commit matches pumuki-pre-commit remediation behavior.
- Publish pumuki@6.3.153 and resume Android parity tracking after RuralGo validation.

## Validation
- node --import tsx --test integrations/lifecycle/__tests__/preWriteAutomation.test.ts
- node --import tsx --test integrations/gate/__tests__/evaluateAiGate.test.ts
- node --import tsx --test integrations/git/__tests__/runPlatformGate.test.ts --test-name-pattern 'remediation|PUMUKI-INC-126|progreso'
- npm publish --dry-run --access public
- npm publish --access public -> pumuki@6.3.153
- RuralGo: npx pumuki-pre-commit --quiet -> EXIT:0
- RuralGo: .git/hooks/pre-commit -> EXIT:0
- RuralGo: status runtime=consumerInstalled=lifecycleInstalled=6.3.153 drift=null