### PR TITLE
fix: unblock RuralGo iOS remediation commits

### DIFF
--- a/PUMUKI-INC-129.feature
+++ b/PUMUKI-INC-129.feature
@@ -1,0 +1,10 @@
+Feature: PUMUKI-INC-129 RuralGo iOS remediation commits must not be blocked by global skills backlog
+
+  Scenario: PRE_COMMIT allows staged iOS XCTest remediation that removes supported test-quality violations
+    Given a brownfield iOS XCTest file previously missed makeSUT and trackForMemoryLeaks
+    And the staged version adds makeSUT and trackForMemoryLeaks without introducing new supported findings
+    And global skills enforcement still has declarative rules waiting for AST detector coverage
+    When Pumuki evaluates PRE_COMMIT
+    Then the supported remediation is allowed to commit
+    And governance.skills.global-enforcement.incomplete is downgraded to an advisory for that remediation commit
+    And system notifications remain disabled when PUMUKI_SYSTEM_NOTIFICATIONS=0 or PUMUKI_NOTIFICATIONS=0

--- a/PUMUKI-INC-129.feature
+++ b/PUMUKI-INC-129.feature
@@ -7,4 +7,5 @@ Feature: PUMUKI-INC-129 RuralGo iOS remediation commits must not be blocked by g
     When Pumuki evaluates PRE_COMMIT
     Then the supported remediation is allowed to commit
     And governance.skills.global-enforcement.incomplete is downgraded to an advisory for that remediation commit
+    And Pumuki recognizes mixed-case detector implementation paths as skills-enforcement remediation
     And system notifications remain disabled when PUMUKI_SYSTEM_NOTIFICATIONS=0 or PUMUKI_NOTIFICATIONS=0

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PARITY-IOS-001` / cerrar primero cobertura AST por nodos de skills iOS. Estado 2026-05-05: `PUMUKI-INC-128` queda corregido, publicado y repineado primero en RuralGo; la versión útil vigente es `pumuki@6.3.157`, que incluye XCTest brownfield, dos reglas SwiftUI AST nuevas y la excepción segura de `PRE_PUSH` para ramas de remediación de skills. RuralGo ya no bloquea por migración Swift Testing obligatoria en XCTest brownfield, aunque mantiene bloqueos propios de tracking/calidad XCTest cuando sus cambios staged no cumplen el contrato del consumer. Siguiente paso interno: continuar iOS con la siguiente sub-slice de reglas declarativas de `ios-enterprise-rules`, `swift-concurrency`, `swiftui-expert-skill`, `swift-testing-expert` y `core-data-expert`, sin mezclar cambios de RuralGo. |
+| Este plan | [🚧] - `PUMUKI-INC-129` / RuralGo: permitir commit de remediación iOS que elimina `makeSUT()` + `trackForMemoryLeaks()` sin bloquear por `governance.skills.global-enforcement.incomplete`, y respetar aliases de notificaciones desactivadas (`PUMUKI_SYSTEM_NOTIFICATIONS=0`, `PUMUKI_NOTIFICATIONS=0`). Estado 2026-05-06: bug externo activo; congelada la continuación interna de `PARITY-IOS-001` hasta publicar fix, repinear primero RuralGo y validar commit normal sin `--no-verify`. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -4104,6 +4104,179 @@ test('runPlatformGate permite remediation staged que elimina findings soportados
   );
 });
 
+test('runPlatformGate permite remediation staged que elimina deuda makeSUT y leak tracking aunque el enforcement global siga incompleto', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const repoRoot = '/repo/root';
+  const stagedPath = 'apps/ios/Tests/Mac/Auth/AuthErrorMapperTests.swift';
+  const git = buildGitStub(repoRoot);
+  git.runGit = (args) => {
+    const command = args.join(' ');
+    if (command === 'diff --cached --name-only') {
+      return stagedPath;
+    }
+    if (command === `show HEAD:${stagedPath}`) {
+      return `
+import XCTest
+
+final class AuthErrorMapperTests: XCTestCase {
+  func test_mapsError() {
+    XCTAssertTrue(true)
+  }
+}
+      `.trim();
+    }
+    return '';
+  };
+  const evidence = buildEvidenceStub();
+  const stagedFacts: ReadonlyArray<Fact> = [
+    {
+      kind: 'FileChange',
+      path: stagedPath,
+      changeType: 'modified',
+      source: 'git:staged',
+    },
+    {
+      kind: 'FileContent',
+      path: stagedPath,
+      content: `
+import XCTest
+
+final class AuthErrorMapperTests: XCTestCase {
+  func test_mapsError() {
+    let sut = makeSUT()
+    trackForMemoryLeaks(sut)
+    XCTAssertTrue(true)
+  }
+
+  private func makeSUT() -> AnyObject {
+    NSObject()
+  }
+}
+      `.trim(),
+      source: 'git:staged',
+    },
+  ];
+  const iosBundles = [
+    'ios-guidelines',
+    'ios-concurrency-guidelines',
+    'ios-swiftui-expert-guidelines',
+    'ios-swift-testing-guidelines',
+    'ios-core-data-guidelines',
+  ].map((name, index) => ({
+    name,
+    version: '1.0.0',
+    source: 'test',
+    hash: String(index).repeat(64).slice(0, 64).padEnd(64, '0'),
+    rules: [],
+  }));
+  let emitted:
+    | {
+      gateOutcome: 'PASS' | 'WARN' | 'BLOCK';
+      findings: ReadonlyArray<Finding>;
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope: { kind: 'staged' },
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      resolveFactsForGateScope: async () => stagedFacts,
+      evaluatePlatformGateFindings: ({ facts }) => ({
+        detectedPlatforms: {
+          ios: { detected: true, confidence: 'HIGH' },
+        },
+        skillsRuleSet: {
+          rules: [
+            createSkillRule({
+              id: 'skills.ios.critical-test-quality',
+              severity: 'ERROR',
+              platform: 'ios',
+            }),
+          ],
+          activeBundles: iosBundles,
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+          unsupportedDetectorRuleIds: ['skills.ios.guideline.declarative-only'],
+          registryCoverage: {
+            contract: 'AUTO_RUNTIME_RULES_FOR_STAGE',
+            stage: 'PRE_COMMIT',
+            registryTotals: {
+              total: 2,
+              auto: 1,
+              declarative: 1,
+            },
+            stageApplicableAutoRuleIds: ['skills.ios.critical-test-quality'],
+            declarativeRuleIds: ['skills.ios.guideline.declarative-only'],
+            excludedDeclarativeReason: 'declarative-only',
+          },
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: facts.length,
+          filesScanned: 1,
+          rulesTotal: 1,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 1,
+          projectRules: 0,
+          matchedRules: 0,
+          unmatchedRules: 1,
+          unevaluatedRules: 0,
+          activeRuleIds: ['skills.ios.critical-test-quality'],
+          evaluatedRuleIds: ['skills.ios.critical-test-quality'],
+          matchedRuleIds: [],
+          unmatchedRuleIds: ['skills.ios.critical-test-quality'],
+          unevaluatedRuleIds: [],
+        },
+        findings: [],
+      }),
+      evaluateGate: (findingsArg) => evaluateGateFromFindings(findingsArg, policy),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveActiveGateWaiver: () => ({
+        kind: 'none',
+        path: '.pumuki/waivers/gate.json',
+      }),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emitted = {
+          gateOutcome: paramsArg.gateOutcome,
+          findings: paramsArg.findings,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  assert.equal(emitted?.gateOutcome, 'PASS');
+  assert.equal(
+    emitted?.findings.some((finding) => finding.code === 'REMEDIATION_PROGRESS_ALLOWED'),
+    true
+  );
+  assert.equal(
+    emitted?.findings.some(
+      (finding) =>
+        finding.code === 'SKILLS_GLOBAL_ENFORCEMENT_INCOMPLETE_REMEDIATION_ADVISORY' &&
+        finding.severity === 'INFO'
+    ),
+    true
+  );
+});
+
 test('runPlatformGate permite diffs de infraestructura que aumentan cobertura de skills aunque exista gap global', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_COMMIT',

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -1494,17 +1494,30 @@ export async function runPlatformGate(params: {
         stagedCodePathSet
       )
     : [];
+  const previousIosTestsQualityFinding =
+    previousFactsForStagedPaths.length > 0 &&
+    iosTestsQualityFinding === undefined &&
+    isStrictEnforcementStage(params.policy.stage)
+      ? toIosTestsQualityBlockingFinding({
+          stage: params.policy.stage,
+          facts: previousFactsForStagedPaths,
+        })
+      : undefined;
+  const previousRemediationBlockingFindings = [
+    ...previousBlockingFindingsForStagedPaths,
+    ...(previousIosTestsQualityFinding ? [previousIosTestsQualityFinding] : []),
+  ];
   const remediationProgressFinding =
-    previousBlockingFindingsForStagedPaths.length > currentBlockingFindingsForStagedPaths.length &&
+    previousRemediationBlockingFindings.length > currentBlockingFindingsForStagedPaths.length &&
     currentBlockingFindingsForStagedPaths.length === 0
       ? toRemediationProgressAllowedFinding({
           stage: params.policy.stage as Exclude<GateStage, 'STAGED'>,
           currentBlockingCount: currentBlockingFindingsForStagedPaths.length,
-          previousBlockingCount: previousBlockingFindingsForStagedPaths.length,
+          previousBlockingCount: previousRemediationBlockingFindings.length,
           paths: stagedCodePaths,
           ruleIds: [
             ...new Set(
-              previousBlockingFindingsForStagedPaths.map((finding) => finding.ruleId)
+              previousRemediationBlockingFindings.map((finding) => finding.ruleId)
             ),
           ].sort(),
         })

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -461,7 +461,7 @@ const isSkillsEnforcementRemediationDiff = (
     return false;
   }
 
-  const normalizedPaths = paths.map((path) => toNormalizedPath(path));
+  const normalizedPaths = paths.map((path) => toNormalizedPath(path).toLowerCase());
   const touchesDetectorSurface = normalizedPaths.some((path) =>
     path.startsWith('core/facts/') ||
     path.startsWith('core/rules/presets/heuristics/') ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.157",
+  "version": "6.3.158",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.157",
+      "version": "6.3.158",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.157",
+  "version": "6.3.158",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {

--- a/scripts/__tests__/framework-menu-system-notifications-gate.test.ts
+++ b/scripts/__tests__/framework-menu-system-notifications-gate.test.ts
@@ -24,6 +24,38 @@ test('resolveSystemNotificationGate bloquea config muteada', () => {
   assert.deepEqual(result, { delivered: false, reason: 'muted' });
 });
 
+test('resolveSystemNotificationGate respeta aliases legacy de desactivacion a cero', () => {
+  assert.deepEqual(
+    resolveSystemNotificationGate({
+      config: { enabled: true, channel: 'macos' },
+      nowMs: Date.parse('2026-03-04T12:00:00.000Z'),
+      env: { PUMUKI_SYSTEM_NOTIFICATIONS: '0' } as NodeJS.ProcessEnv,
+    }),
+    { delivered: false, reason: 'disabled' }
+  );
+  assert.deepEqual(
+    resolveSystemNotificationGate({
+      config: { enabled: true, channel: 'macos' },
+      nowMs: Date.parse('2026-03-04T12:00:00.000Z'),
+      env: { PUMUKI_NOTIFICATIONS: 'false' } as NodeJS.ProcessEnv,
+    }),
+    { delivered: false, reason: 'disabled' }
+  );
+});
+
+test('resolveSystemNotificationGate no desactiva aliases legacy cuando estan a uno', () => {
+  const result = resolveSystemNotificationGate({
+    config: { enabled: true, channel: 'macos' },
+    nowMs: Date.parse('2026-03-04T12:00:00.000Z'),
+    env: {
+      PUMUKI_SYSTEM_NOTIFICATIONS: '1',
+      PUMUKI_NOTIFICATIONS: 'true',
+    } as NodeJS.ProcessEnv,
+  });
+
+  assert.equal(result, null);
+});
+
 test('resolveSystemNotificationGate permite continuar cuando está habilitado (sin filtrar por plataforma)', () => {
   const result = resolveSystemNotificationGate({
     config: { enabled: true, channel: 'macos' },

--- a/scripts/framework-menu-system-notifications-env.ts
+++ b/scripts/framework-menu-system-notifications-env.ts
@@ -5,3 +5,11 @@ export const isTruthyEnvValue = (value?: string): boolean => {
   const normalized = value.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 };
+
+export const isFalsyEnvValue = (value?: string): boolean => {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off';
+};

--- a/scripts/framework-menu-system-notifications-gate.ts
+++ b/scripts/framework-menu-system-notifications-gate.ts
@@ -3,14 +3,21 @@ import type {
   SystemNotificationEmitResult,
   SystemNotificationsConfig,
 } from './framework-menu-system-notifications-types';
-import { isTruthyEnvValue } from './framework-menu-system-notifications-env';
+import {
+  isFalsyEnvValue,
+  isTruthyEnvValue,
+} from './framework-menu-system-notifications-env';
 
 export const resolveSystemNotificationGate = (params: {
   config: SystemNotificationsConfig;
   nowMs: number;
   env?: NodeJS.ProcessEnv;
 }): SystemNotificationEmitResult | null => {
-  if (isTruthyEnvValue(params.env?.PUMUKI_DISABLE_SYSTEM_NOTIFICATIONS)) {
+  if (
+    isTruthyEnvValue(params.env?.PUMUKI_DISABLE_SYSTEM_NOTIFICATIONS) ||
+    isFalsyEnvValue(params.env?.PUMUKI_SYSTEM_NOTIFICATIONS) ||
+    isFalsyEnvValue(params.env?.PUMUKI_NOTIFICATIONS)
+  ) {
     return { delivered: false, reason: 'disabled' };
   }
   if (!params.config.enabled) {


### PR DESCRIPTION
## Summary\n- Allow staged iOS XCTest remediation commits to downgrade global skills backlog to advisory when supported violations are removed.\n- Honor PUMUKI_SYSTEM_NOTIFICATIONS=0 and PUMUKI_NOTIFICATIONS=0 to stop blocked-dialog spam.\n- Publish pumuki 6.3.158 and repin RuralGo first.\n\n## Validation\n- node --import tsx --test integrations/git/__tests__/runPlatformGate.test.ts --test-name-pattern 'makeSUT|remediation staged|global|mapping incompleto'\n- node --import tsx --test scripts/__tests__/framework-menu-system-notifications-gate.test.ts scripts/__tests__/framework-menu-system-notifications-lib.test.ts --test-name-pattern 'alias|PUMUKI_DISABLE_SYSTEM_NOTIFICATIONS|gate|notificaciones'\n- npm pack --dry-run\n- npm publish --access public\n- npm view pumuki@6.3.158 version\n- RuralGo: PUMUKI_SYSTEM_NOTIFICATIONS=0 PUMUKI_NOTIFICATIONS=0 npx pumuki-pre-commit --quiet -> 0