### PR TITLE
fix(ios): allow XCTest brownfield helpers

### DIFF
--- a/PUMUKI-INC-130-XCTEST-HELPERS-BROWNFIELD.feature
+++ b/PUMUKI-INC-130-XCTEST-HELPERS-BROWNFIELD.feature
@@ -1,0 +1,9 @@
+Feature: PUMUKI-INC-130 XCTest brownfield helpers
+
+  Scenario: XCTest helpers and factories are not treated as migrable test suites
+    Given a brownfield iOS repository has XCTest helper or factory files
+    And those files import XCTest but do not declare XCTestCase suites with test methods
+    When Pumuki evaluates PRE_COMMIT skills enforcement
+    Then Pumuki must not emit skills.ios.prefer-swift-testing for those helpers
+    And Pumuki must not emit governance.skills.ios-test-quality.incomplete for those helpers
+    And real XCTestCase suites remain covered by the iOS test quality guard

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,7 +931,7 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | [🚧] - `PUMUKI-INC-129` / RuralGo: permitir commit de remediación iOS que elimina `makeSUT()` + `trackForMemoryLeaks()` sin bloquear por `governance.skills.global-enforcement.incomplete`, y respetar aliases de notificaciones desactivadas (`PUMUKI_SYSTEM_NOTIFICATIONS=0`, `PUMUKI_NOTIFICATIONS=0`). Estado 2026-05-06: bug externo activo; congelada la continuación interna de `PARITY-IOS-001` hasta publicar fix, repinear primero RuralGo y validar commit normal sin `--no-verify`. |
+| Este plan | [🚧] - `PUMUKI-INC-130` / RuralGo: permitir helpers y factories XCTest brownfield (`AuthTestFactories.swift`, `TestHelpers.swift`) sin tratarlos como suites migrables a Swift Testing ni exigir `makeSUT()`/`trackForMemoryLeaks()` en archivos que no contienen `XCTestCase` con métodos `test...`. Estado 2026-05-06: bug externo activo; congelada la continuación interna de `PARITY-IOS-001` hasta publicar fix, repinear primero RuralGo y validar hook normal sin `--no-verify`. |
 
 Snapshot de rollout `6.3.81` (2026-04-20):
 - `SAAS` (`chore/pumuki-6-3-81-rollout`): repin a `pumuki@6.3.81` completado; `status` y `doctor` alineados en `6.3.81`; `pumuki-pre-commit` termina en `ALLOW`.

--- a/core/facts/detectors/text/ios.test.ts
+++ b/core/facts/detectors/text/ios.test.ts
@@ -669,6 +669,26 @@ final class LoginModelTests: XCTestCase {
   assert.equal(hasSwiftModernizableXCTestSuiteUsage(missingQualityContract), false);
 });
 
+test('detectores Swift Testing excluyen helpers y factories XCTest brownfield sin XCTestCase', () => {
+  const helperSource = `
+import XCTest
+
+final class AuthTestFactories {
+  static func makeToken() -> String {
+    "token"
+  }
+}
+
+func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+  addTeardownBlock { _ = instance }
+}
+  `;
+
+  assert.equal(hasSwiftLegacyXCTestImportUsage(helperSource), false);
+  assert.equal(hasSwiftModernizableXCTestSuiteUsage(helperSource), false);
+  assert.equal(hasSwiftXCTestAssertionUsage(helperSource), false);
+});
+
 test('hasSwiftXCTUnwrapUsage detecta XCTUnwrap real y evita strings', () => {
   const source = `
 let value = try XCTUnwrap(optionalValue)

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -845,6 +845,10 @@ export const hasSwiftLegacyXCTestImportUsage = (source: string): boolean => {
     return false;
   }
 
+  if (!hasSwiftXCTestCaseSubclassUsage(source) || !hasSwiftLegacyXCTestMethodUsage(source)) {
+    return false;
+  }
+
   if (hasSwiftLegacyXCTestUiOrPerformanceUsage(source)) {
     return false;
   }

--- a/integrations/git/__tests__/runPlatformGate.test.ts
+++ b/integrations/git/__tests__/runPlatformGate.test.ts
@@ -3798,6 +3798,161 @@ final class BuyerCommerceUISmokeTests: XCTestCase {
   );
 });
 
+test('runPlatformGate permite helpers XCTest brownfield sin exigir makeSUT ni leak tracking', async () => {
+  const policy: GatePolicy = {
+    stage: 'PRE_COMMIT',
+    blockOnOrAbove: 'ERROR',
+    warnOnOrAbove: 'WARN',
+  };
+  const scope = { kind: 'staged' as const };
+  const git = buildGitStub('/repo/root');
+  const evidence = buildEvidenceStub();
+  const facts: ReadonlyArray<Fact> = [
+    {
+      kind: 'FileContent',
+      path: 'apps/ios/Tests/Mac/Auth/AuthTestFactories.swift',
+      content: `
+import XCTest
+
+final class AuthTestFactories {
+  static func makeSuccessfulLoginResult() -> String {
+    "ok"
+  }
+}
+      `.trim(),
+      source: 'git:staged',
+    },
+    {
+      kind: 'FileContent',
+      path: 'apps/ios/Tests/iOS/Common/TestHelpers.swift',
+      content: `
+import XCTest
+
+func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+  addTeardownBlock { _ = instance }
+}
+      `.trim(),
+      source: 'git:staged',
+    },
+  ];
+
+  let emitted:
+    | {
+      findings: ReadonlyArray<Finding>;
+      gateOutcome: 'PASS' | 'ALLOW' | 'WARN' | 'BLOCK';
+    }
+    | undefined;
+
+  const result = await runPlatformGate({
+    policy,
+    scope,
+    services: {
+      git,
+      evidence,
+    },
+    dependencies: {
+      evaluateSddForStage: () => ({
+        allowed: true,
+        code: 'ALLOWED',
+        message: 'ok',
+      }),
+      resolveFactsForGateScope: async () => facts,
+      evaluatePlatformGateFindings: () => ({
+        detectedPlatforms: {
+          ios: { detected: true, confidence: 'HIGH' },
+        },
+        skillsRuleSet: {
+          rules: [
+            createSkillRule({
+              id: 'skills.ios.critical-test-quality',
+              severity: 'ERROR',
+              platform: 'ios',
+            }),
+          ] as RuleSet,
+          activeBundles: [
+            {
+              name: 'ios-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/windsurf-rules-ios.md',
+              hash: 'a'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-concurrency-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swift-concurrency.md',
+              hash: 'b'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-swiftui-expert-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swiftui-expert-skill.md',
+              hash: 'c'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-swift-testing-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/swift-testing-expert.md',
+              hash: 'd'.repeat(64),
+              rules: [],
+            },
+            {
+              name: 'ios-core-data-guidelines',
+              version: '1.0.0',
+              source: 'file:docs/codex-skills/core-data-expert.md',
+              hash: 'e'.repeat(64),
+              rules: [],
+            },
+          ],
+          mappedHeuristicRuleIds: new Set<string>(),
+          requiresHeuristicFacts: false,
+          unsupportedAutoRuleIds: [],
+        },
+        projectRules: [] as RuleSet,
+        heuristicRules: [] as RuleSet,
+        coverage: {
+          factsTotal: facts.length,
+          filesScanned: 2,
+          rulesTotal: 1,
+          baselineRules: 0,
+          heuristicRules: 0,
+          skillsRules: 1,
+          projectRules: 0,
+          matchedRules: 0,
+          unmatchedRules: 1,
+          unevaluatedRules: 0,
+          activeRuleIds: ['skills.ios.critical-test-quality'],
+          evaluatedRuleIds: ['skills.ios.critical-test-quality'],
+          matchedRuleIds: [],
+          unmatchedRuleIds: ['skills.ios.critical-test-quality'],
+          unevaluatedRuleIds: [],
+        },
+        findings: [],
+      }),
+      evaluateGate: (findingsArg) => evaluateGateFromFindings(findingsArg, policy),
+      enforceTddBddPolicy: () => buildOutOfScopeTddBddResult(),
+      emitPlatformGateEvidence: (paramsArg) => {
+        emitted = {
+          findings: paramsArg.findings,
+          gateOutcome: paramsArg.gateOutcome,
+        };
+      },
+      printGateFindings: () => {},
+    },
+  });
+
+  assert.equal(result, 0);
+  assert.equal(emitted?.gateOutcome, 'PASS');
+  assert.equal(
+    emitted?.findings.some(
+      (entry) => entry.ruleId === 'governance.skills.ios-test-quality.incomplete'
+    ),
+    false
+  );
+});
+
 test('runPlatformGate bloquea cuando test iOS XCTest usa makeSUT y trackForMemoryLeaks pero el contrato de skills sigue incompleto', async () => {
   const policy: GatePolicy = {
     stage: 'PRE_COMMIT',

--- a/integrations/git/runPlatformGate.ts
+++ b/integrations/git/runPlatformGate.ts
@@ -655,6 +655,13 @@ const isXCTestSource = (content: string): boolean => {
   return /\bimport\s+XCTest\b/.test(content) || /\bXCTestCase\b/.test(content);
 };
 
+const isXCTestSuiteSource = (content: string): boolean => {
+  return (
+    /\bclass\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*XCTestCase\b/.test(content) &&
+    /^\s*(?:override\s+)?func\s+test[A-Za-z0-9_]*\s*\(/m.test(content)
+  );
+};
+
 const isXCTestUiOrPerformanceCompatibilitySource = (content: string): boolean => {
   return /\bXCUIApplication\b|\bXCTMetric\b|\bmeasure\s*(?:\(|\{)/.test(content);
 };
@@ -676,6 +683,9 @@ const toIosTestsQualityBlockingFinding = (params: {
   const invalidFiles: string[] = [];
   for (const testFile of testFiles) {
     if (!isXCTestSource(testFile.content)) {
+      continue;
+    }
+    if (!isXCTestSuiteSource(testFile.content)) {
       continue;
     }
     if (isXCTestUiOrPerformanceCompatibilitySource(testFile.content)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.162",
+  "version": "6.3.163",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.162",
+      "version": "6.3.163",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.162",
+  "version": "6.3.163",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- fixes PUMUKI-INC-130 by excluding XCTest helpers/factories without XCTestCase test methods from Swift Testing migration findings
- keeps real XCTestCase suites covered by the iOS test quality guard
- publishes pumuki@6.3.163 for RuralGo rollout

## Validation
- node --import tsx --test core/facts/detectors/text/ios.test.ts --test-name-pattern 'XCTest|Swift Testing|helpers|factories'
- node --import tsx --test integrations/git/__tests__/runPlatformGate.test.ts --test-name-pattern 'helpers XCTest brownfield|test iOS XCTest|UI automation'
- git diff --check
- npm pack --dry-run
- npm publish --access public
- RuralGo: pumuki-pre-commit --quiet -> 0 with pumuki@6.3.163