### PR TITLE
feat: expose Android SOLID AST baseline

### DIFF
--- a/PARITY-ANDROID-001.feature
+++ b/PARITY-ANDROID-001.feature
@@ -1,0 +1,8 @@
+Feature: Android enterprise baseline parity
+
+  Scenario: Android SOLID rules are enforced by semantic AST bindings
+    Given the Android enterprise rules require Clean Architecture and SOLID boundaries
+    When Pumuki compiles the skills detector registry
+    Then skills.android.no-solid-violations maps to Android semantic AST heuristic rules
+    And the Android heuristic rule set exposes SRP, OCP, DIP, ISP and LSP findings as locked Android rules
+    And the slice does not claim full Android parity beyond this initial SOLID baseline

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -931,12 +931,18 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | `[🚧] - PARITY-IOS-SWIFTDATA-001` / iOS persistence skills parity: cerrar en rama limpia la integración Core Data + SwiftData en skills/reglas AST por nodos, sin romper brownfield Core Data ni prometer enforcement inexistente. |
+| Este plan | `[🚧] - PARITY-ANDROID-001` / Android enterprise baseline parity: abrir el baseline Android equivalente con bindings AST semánticos reales, empezando por SOLID en Kotlin/Compose sin prometer cobertura Android total. |
 
 Snapshot PARITY-IOS-SWIFTDATA-001 (2026-05-12):
 - Reapertura limpia: PR #890 queda descartado como ruta de merge directa porque estaba basado en `bugfix/pumuki-inc130-ios-helper-critical-quality-final2` y no en `main`, arrastrando historia antigua.
 - Implementación objetivo: rehacer la slice en `feature/parity-ios-swiftdata-clean` desde `origin/main`, aplicando solo el patch SwiftData/Core Data.
 - Alcance explícito: no se declara cobertura total de SwiftData; esta slice cierra la frontera de capas enterprise para APIs de persistencia SwiftData y mantiene intactas las reglas brownfield Core Data existentes.
+- Cierre: PR #899 mergeado en `main`, release `pumuki@6.3.176` publicada y RuralGo repineado a `6.3.176` con `status` sin drift y policy válida en `PRE_WRITE`, `PRE_COMMIT`, `PRE_PUSH` y `CI`.
+
+Snapshot PARITY-ANDROID-001 (2026-05-12):
+- Diagnóstico: el extractor ya emitía heurísticas semánticas SOLID Android para SRP/OCP/DIP/ISP/LSP, pero `androidRules` solo exponía reglas básicas (`Thread.sleep`, `GlobalScope`, `runBlocking`) y `skills.android.no-solid-violations` no estaba enlazada al registry.
+- Implementación objetivo: exponer esas heurísticas como baseline Android locked y mapear la skill canónica a detectores AST reales, sin introducir reglas por regex estática ni umbrales arbitrarios.
+- Alcance explícito: esta slice abre paridad Android con SOLID semántico inicial; quedan fuera Compose state, Room, Hilt, Navigation y coroutines avanzadas hasta slices posteriores.
 
 Snapshot PUMUKI-INC-061 (2026-05-12):
 - Cerrado con release publicada `pumuki@6.3.175`.

--- a/core/rules/presets/heuristics/android.test.ts
+++ b/core/rules/presets/heuristics/android.test.ts
@@ -3,13 +3,18 @@ import test from 'node:test';
 import { androidRules } from './android';
 
 test('androidRules define reglas heurísticas locked para plataforma android', () => {
-  assert.equal(androidRules.length, 3);
+  assert.equal(androidRules.length, 8);
 
   const ids = androidRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
     'heuristics.android.thread-sleep.ast',
     'heuristics.android.globalscope.ast',
     'heuristics.android.run-blocking.ast',
+    'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
+    'heuristics.android.solid.ocp.discriminator-branching.ast',
+    'heuristics.android.solid.dip.concrete-framework-dependency.ast',
+    'heuristics.android.solid.isp.fat-interface-dependency.ast',
+    'heuristics.android.solid.lsp.narrowed-precondition.ast',
   ]);
 
   const byId = new Map(androidRules.map((rule) => [rule.id, rule]));
@@ -24,6 +29,26 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
   assert.equal(
     byId.get('heuristics.android.run-blocking.ast')?.then.code,
     'HEURISTICS_ANDROID_RUN_BLOCKING_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.solid.srp.presentation-mixed-responsibilities.ast')?.then.code,
+    'HEURISTICS_ANDROID_SOLID_SRP_PRESENTATION_MIXED_RESPONSIBILITIES_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.solid.ocp.discriminator-branching.ast')?.then.code,
+    'HEURISTICS_ANDROID_SOLID_OCP_DISCRIMINATOR_BRANCHING_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.solid.dip.concrete-framework-dependency.ast')?.then.code,
+    'HEURISTICS_ANDROID_SOLID_DIP_CONCRETE_FRAMEWORK_DEPENDENCY_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.solid.isp.fat-interface-dependency.ast')?.then.code,
+    'HEURISTICS_ANDROID_SOLID_ISP_FAT_INTERFACE_DEPENDENCY_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.solid.lsp.narrowed-precondition.ast')?.then.code,
+    'HEURISTICS_ANDROID_SOLID_LSP_NARROWED_PRECONDITION_AST'
   );
 
   for (const rule of androidRules) {

--- a/core/rules/presets/heuristics/android.ts
+++ b/core/rules/presets/heuristics/android.ts
@@ -55,4 +55,104 @@ export const androidRules: RuleSet = [
       code: 'HEURISTICS_ANDROID_RUN_BLOCKING_AST',
     },
   },
+  {
+    id: 'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
+    description:
+      'Detects Android presentation types mixing session, networking, persistence and navigation responsibilities.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected Android presentation code mixing multiple responsibilities.',
+      code: 'HEURISTICS_ANDROID_SOLID_SRP_PRESENTATION_MIXED_RESPONSIBILITIES_AST',
+    },
+  },
+  {
+    id: 'heuristics.android.solid.ocp.discriminator-branching.ast',
+    description:
+      'Detects Android application or presentation code branching on discriminators instead of extending behavior.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.solid.ocp.discriminator-branching.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected Android discriminator branching that weakens OCP.',
+      code: 'HEURISTICS_ANDROID_SOLID_OCP_DISCRIMINATOR_BRANCHING_AST',
+    },
+  },
+  {
+    id: 'heuristics.android.solid.dip.concrete-framework-dependency.ast',
+    description:
+      'Detects Android application or presentation code depending on concrete framework infrastructure.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.solid.dip.concrete-framework-dependency.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected Android concrete framework dependency in a high-level layer.',
+      code: 'HEURISTICS_ANDROID_SOLID_DIP_CONCRETE_FRAMEWORK_DEPENDENCY_AST',
+    },
+  },
+  {
+    id: 'heuristics.android.solid.isp.fat-interface-dependency.ast',
+    description:
+      'Detects Android application or presentation code depending on interfaces broader than the members used.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.solid.isp.fat-interface-dependency.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected Android dependency on a fat interface.',
+      code: 'HEURISTICS_ANDROID_SOLID_ISP_FAT_INTERFACE_DEPENDENCY_AST',
+    },
+  },
+  {
+    id: 'heuristics.android.solid.lsp.narrowed-precondition.ast',
+    description:
+      'Detects Android application or presentation subtypes that narrow preconditions and break substitution.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.solid.lsp.narrowed-precondition.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected Android subtype narrowing a contract precondition.',
+      code: 'HEURISTICS_ANDROID_SOLID_LSP_NARROWED_PRECONDITION_AST',
+    },
+  },
 ];

--- a/docs/codex-skills/android-enterprise-rules.md
+++ b/docs/codex-skills/android-enterprise-rules.md
@@ -117,6 +117,11 @@ app/
   di/                      # Hilt modules
 ```
 
+### Enforcement AST inicial de arquitectura Android
+✅ `skills.android.no-solid-violations` debe mapear a detectores AST semánticos, no a conteos de líneas ni umbrales arbitrarios.
+✅ El baseline Android debe cubrir al menos SRP en presentation, OCP por branching de discriminadores, DIP por dependencias concretas de framework, ISP por interfaces demasiado anchas y LSP por precondiciones estrechadas.
+✅ Estos detectores son paridad parcial Android: no sustituyen una auditoría completa de arquitectura, pero sí evitan que reglas SOLID críticas queden como doctrina declarativa sin señal ejecutable.
+
 ### Dependency Injection (Hilt):
 ✅ **Hilt** - DI framework (NO manual factories)
 ✅ **@HiltAndroidApp** - Application class

--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -89,6 +89,13 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
   assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-globalscope'), [
     'heuristics.android.globalscope.ast',
   ]);
+  assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-solid-violations'), [
+    'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
+    'heuristics.android.solid.ocp.discriminator-branching.ast',
+    'heuristics.android.solid.dip.concrete-framework-dependency.ast',
+    'heuristics.android.solid.isp.fat-interface-dependency.ast',
+    'heuristics.android.solid.lsp.narrowed-precondition.ast',
+  ]);
 });
 
 test('devuelve lista ordenada de bindings y binding completo por ruleId', () => {

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -213,6 +213,13 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
   'skills.android.no-runblocking': heuristicDetector('android.run-blocking', [
     'heuristics.android.run-blocking.ast',
   ]),
+  'skills.android.no-solid-violations': heuristicDetector('android.solid', [
+    'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
+    'heuristics.android.solid.ocp.discriminator-branching.ast',
+    'heuristics.android.solid.dip.concrete-framework-dependency.ast',
+    'heuristics.android.solid.isp.fat-interface-dependency.ast',
+    'heuristics.android.solid.lsp.narrowed-precondition.ast',
+  ]),
 };
 
 export const listSkillsDetectorBindings = (): ReadonlyArray<{


### PR DESCRIPTION
## Trazabilidad\n- escenario: PARITY-ANDROID-001 / baseline Android enterprise inicial.\n- tests: npx tsx --test core/facts/detectors/text/android.test.ts core/rules/presets/heuristics/android.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts\n- evidencia: 50/50 pass; npm run -s typecheck; npm run -s skills:lock:check; git diff --check.\n- task: PARITY-ANDROID-001.\n\n## Cambios\n- Expone SRP/OCP/DIP/ISP/LSP Android como reglas locked en androidRules.\n- Mapea skills.android.no-solid-violations a heurísticas AST semánticas Android existentes.\n- Documenta alcance: paridad Android parcial inicial, sin prometer cobertura total de Compose/Room/Hilt/coroutines.