### PR TITLE
feat(android): map coroutine baseline coverage

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -943,6 +943,7 @@ Snapshot PARITY-ANDROID-001 (2026-05-12):
 - Diagnóstico: el extractor ya emitía heurísticas semánticas SOLID Android para SRP/OCP/DIP/ISP/LSP, pero `androidRules` solo exponía reglas básicas (`Thread.sleep`, `GlobalScope`, `runBlocking`) y `skills.android.no-solid-violations` no estaba enlazada al registry.
 - Implementación objetivo: exponer esas heurísticas como baseline Android locked y mapear la skill canónica a detectores AST reales, sin introducir reglas por regex estática ni umbrales arbitrarios.
 - Alcance explícito: esta slice abre paridad Android con SOLID semántico inicial; quedan fuera Compose state, Room, Hilt, Navigation y coroutines avanzadas hasta slices posteriores.
+- Avance coroutines inicial: `skills.android.guideline.android.coroutines-async-await-no-callbacks` queda enlazada a los detectores ejecutables existentes `GlobalScope` y `runBlocking`, manteniendo explícitamente fuera `Flow`, `viewModelScope`, dispatchers y cancelación cooperativa hasta slices posteriores.
 
 Snapshot PUMUKI-INC-061 (2026-05-12):
 - Cerrado con release publicada `pumuki@6.3.175`.

--- a/core/rules/presets/heuristics/android.test.ts
+++ b/core/rules/presets/heuristics/android.test.ts
@@ -18,6 +18,16 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
   ]);
 
   const byId = new Map(androidRules.map((rule) => [rule.id, rule]));
+  const coroutineRuleIds = [
+    'heuristics.android.globalscope.ast',
+    'heuristics.android.run-blocking.ast',
+  ];
+
+  for (const ruleId of coroutineRuleIds) {
+    assert.equal(byId.get(ruleId)?.platform, 'android');
+    assert.equal(byId.get(ruleId)?.locked, true);
+  }
+
   assert.equal(
     byId.get('heuristics.android.thread-sleep.ast')?.then.code,
     'HEURISTICS_ANDROID_THREAD_SLEEP_AST'

--- a/docs/codex-skills/android-enterprise-rules.md
+++ b/docs/codex-skills/android-enterprise-rules.md
@@ -122,6 +122,11 @@ app/
 ✅ El baseline Android debe cubrir al menos SRP en presentation, OCP por branching de discriminadores, DIP por dependencias concretas de framework, ISP por interfaces demasiado anchas y LSP por precondiciones estrechadas.
 ✅ Estos detectores son paridad parcial Android: no sustituyen una auditoría completa de arquitectura, pero sí evitan que reglas SOLID críticas queden como doctrina declarativa sin señal ejecutable.
 
+### Enforcement AST inicial de coroutines Android
+✅ `skills.android.guideline.android.coroutines-async-await-no-callbacks` debe mapear a señales ejecutables existentes de uso inseguro de coroutines, empezando por `GlobalScope` y `runBlocking`.
+✅ El baseline inicial de coroutines es parcial: cubre APIs bloqueantes o scopes no estructurados, pero no declara todavía cobertura completa de `Flow`, `viewModelScope`, `supervisorScope`, dispatchers ni cancelación cooperativa.
+✅ Si se amplía esta cobertura, cada nueva regla debe aterrizar como detector AST/textual semántico con test dirigido antes de declararse cubierta en el registry.
+
 ### Dependency Injection (Hilt):
 ✅ **Hilt** - DI framework (NO manual factories)
 ✅ **@HiltAndroidApp** - Application class

--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -89,6 +89,15 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
   assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-globalscope'), [
     'heuristics.android.globalscope.ast',
   ]);
+  assert.deepEqual(
+    resolveMappedHeuristicRuleIds(
+      'skills.android.guideline.android.coroutines-async-await-no-callbacks'
+    ),
+    [
+      'heuristics.android.globalscope.ast',
+      'heuristics.android.run-blocking.ast',
+    ]
+  );
   assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-solid-violations'), [
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -213,6 +213,13 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
   'skills.android.no-runblocking': heuristicDetector('android.run-blocking', [
     'heuristics.android.run-blocking.ast',
   ]),
+  'skills.android.guideline.android.coroutines-async-await-no-callbacks': heuristicDetector(
+    'android.coroutines.baseline',
+    [
+      'heuristics.android.globalscope.ast',
+      'heuristics.android.run-blocking.ast',
+    ]
+  ),
   'skills.android.no-solid-violations': heuristicDetector('android.solid', [
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',


### PR DESCRIPTION
## Trazabilidad
- escenario: PARITY-ANDROID-001 / coroutines baseline inicial
- tests: skills:lock:check, typecheck, android + registry + extractor focused tests
- evidencia: 50/50 pass, lock FRESH, diff --check limpio
- task: PARITY-ANDROID-001

## Alcance
- Mapea la regla declarativa de coroutines Android al baseline ejecutable existente de GlobalScope/runBlocking.
- Documenta que Flow, viewModelScope, dispatchers y cancelacion cooperativa quedan fuera de esta slice.