### PR TITLE
feat(android): detect legacy livedata state exposure

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -944,6 +944,7 @@ Snapshot PARITY-ANDROID-001 (2026-05-12):
 - Implementación objetivo: exponer esas heurísticas como baseline Android locked y mapear la skill canónica a detectores AST reales, sin introducir reglas por regex estática ni umbrales arbitrarios.
 - Alcance explícito: esta slice abre paridad Android con SOLID semántico inicial; quedan fuera Compose state, Room, Hilt, Navigation y coroutines avanzadas hasta slices posteriores.
 - Avance coroutines inicial: `skills.android.guideline.android.coroutines-async-await-no-callbacks` queda enlazada a los detectores ejecutables existentes `GlobalScope` y `runBlocking`, manteniendo explícitamente fuera `Flow`, `viewModelScope`, dispatchers y cancelación cooperativa hasta slices posteriores.
+- Avance Flow/StateFlow inicial: las reglas declarativas de `StateFlow` / `StateFlow-SharedFlow` quedan enlazadas a `heuristics.android.flow.livedata-state-exposure.ast`, que detecta `LiveData` / `MutableLiveData` en presentation como estado observable legacy. No se declara todavía cobertura completa de `Flow`, `collectAsState`, `stateIn`, Room observable queries ni SharedFlow events.
 
 Snapshot PUMUKI-INC-061 (2026-05-12):
 - Cerrado con release publicada `pumuki@6.3.175`.

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1267,8 +1267,17 @@ test('detects Android heuristics in production path and skips tests', () => {
         ['Thread.sleep(10)', 'GlobalScope.launch { }', 'runBlocking { }'].join('\n')
       ),
       fileContentFact(
+        'apps/android/app/src/main/java/com/acme/presentation/FeatureViewModel.kt',
+        ['private val mutableState = MutableLiveData<FeatureUiState>()'].join('\n')
+      ),
+      fileContentFact(
         'apps/android/app/src/test/java/com/acme/FeatureTest.kt',
-        ['Thread.sleep(10)', 'GlobalScope.launch { }', 'runBlocking { }'].join('\n')
+        [
+          'Thread.sleep(10)',
+          'GlobalScope.launch { }',
+          'runBlocking { }',
+          'private val mutableState = MutableLiveData<FeatureUiState>()',
+        ].join('\n')
       ),
     ],
     detectedPlatforms: {
@@ -1278,6 +1287,7 @@ test('detects Android heuristics in production path and skips tests', () => {
 
   const findings = evaluateRules(astHeuristicsRuleSet, extracted);
   assert.deepEqual(toRuleIds(findings), [
+    'heuristics.android.flow.livedata-state-exposure.ast',
     'heuristics.android.globalscope.ast',
     'heuristics.android.run-blocking.ast',
     'heuristics.android.thread-sleep.ast',

--- a/core/facts/detectors/text/android.test.ts
+++ b/core/facts/detectors/text/android.test.ts
@@ -7,6 +7,7 @@ import {
   findKotlinOpenClosedWhenMatch,
   findKotlinPresentationSrpMatch,
   hasKotlinGlobalScopeUsage,
+  hasKotlinLiveDataStateExposureUsage,
   hasKotlinRunBlockingUsage,
   hasKotlinThreadSleepCall,
 } from './android';
@@ -89,6 +90,28 @@ fun main() {
 `;
   assert.equal(hasKotlinRunBlockingUsage(commentedSource), false);
   assert.equal(hasKotlinRunBlockingUsage(partialSource), false);
+});
+
+test('hasKotlinLiveDataStateExposureUsage detecta LiveData y MutableLiveData como estado observable legacy', () => {
+  const source = `
+class OrdersViewModel : ViewModel() {
+  private val mutableState = MutableLiveData<OrdersUiState>()
+  val state: LiveData<OrdersUiState> = mutableState
+}
+`;
+  assert.equal(hasKotlinLiveDataStateExposureUsage(source), true);
+});
+
+test('hasKotlinLiveDataStateExposureUsage ignora imports, comentarios y strings', () => {
+  const source = `
+import androidx.lifecycle.LiveData
+// val state = MutableLiveData<OrdersUiState>()
+val sample = "LiveData<OrdersUiState>"
+class OrdersViewModel : ViewModel() {
+  val state: StateFlow<OrdersUiState> = MutableStateFlow(OrdersUiState())
+}
+`;
+  assert.equal(hasKotlinLiveDataStateExposureUsage(source), false);
 });
 
 test('findKotlinPresentationSrpMatch devuelve payload semantico para SRP-Android en presentation', () => {

--- a/core/facts/detectors/text/android.ts
+++ b/core/facts/detectors/text/android.ts
@@ -292,6 +292,13 @@ export const hasKotlinRunBlockingUsage = (source: string): boolean => {
   });
 };
 
+export const hasKotlinLiveDataStateExposureUsage = (source: string): boolean => {
+  return collectKotlinRegexLines(
+    source,
+    /\b(?:MutableLiveData|LiveData)\s*(?:<|\(|\.)/
+  ).length > 0;
+};
+
 export const findKotlinPresentationSrpMatch = (
   source: string
 ): KotlinPresentationSrpMatch | undefined => {

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -637,6 +637,7 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinThreadSleepCall, ruleId: 'heuristics.android.thread-sleep.ast', code: 'HEURISTICS_ANDROID_THREAD_SLEEP_AST', message: 'AST heuristic detected Thread.sleep usage in production Kotlin code.' },
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinGlobalScopeUsage, ruleId: 'heuristics.android.globalscope.ast', code: 'HEURISTICS_ANDROID_GLOBAL_SCOPE_AST', message: 'AST heuristic detected GlobalScope coroutine usage in production Kotlin code.' },
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinRunBlockingUsage, ruleId: 'heuristics.android.run-blocking.ast', code: 'HEURISTICS_ANDROID_RUN_BLOCKING_AST', message: 'AST heuristic detected runBlocking usage in production Kotlin code.' },
+  { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinLiveDataStateExposureUsage, ruleId: 'heuristics.android.flow.livedata-state-exposure.ast', code: 'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST', message: 'AST heuristic detected LiveData state exposure in Android presentation code where StateFlow or SharedFlow should be preferred.' },
 ];
 
 const extractWorkflowHeuristicFacts = (

--- a/core/rules/presets/heuristics/android.test.ts
+++ b/core/rules/presets/heuristics/android.test.ts
@@ -3,13 +3,14 @@ import test from 'node:test';
 import { androidRules } from './android';
 
 test('androidRules define reglas heurísticas locked para plataforma android', () => {
-  assert.equal(androidRules.length, 8);
+  assert.equal(androidRules.length, 9);
 
   const ids = androidRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
     'heuristics.android.thread-sleep.ast',
     'heuristics.android.globalscope.ast',
     'heuristics.android.run-blocking.ast',
+    'heuristics.android.flow.livedata-state-exposure.ast',
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',
     'heuristics.android.solid.dip.concrete-framework-dependency.ast',
@@ -39,6 +40,10 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
   assert.equal(
     byId.get('heuristics.android.run-blocking.ast')?.then.code,
     'HEURISTICS_ANDROID_RUN_BLOCKING_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.flow.livedata-state-exposure.ast')?.then.code,
+    'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST'
   );
   assert.equal(
     byId.get('heuristics.android.solid.srp.presentation-mixed-responsibilities.ast')?.then.code,

--- a/core/rules/presets/heuristics/android.ts
+++ b/core/rules/presets/heuristics/android.ts
@@ -56,6 +56,26 @@ export const androidRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.android.flow.livedata-state-exposure.ast',
+    description:
+      'Detects LiveData state exposure in Android presentation code where StateFlow or SharedFlow should be preferred.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.flow.livedata-state-exposure.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected LiveData state exposure in Android presentation code.',
+      code: 'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST',
+    },
+  },
+  {
     id: 'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     description:
       'Detects Android presentation types mixing session, networking, persistence and navigation responsibilities.',

--- a/docs/codex-skills/android-enterprise-rules.md
+++ b/docs/codex-skills/android-enterprise-rules.md
@@ -127,6 +127,11 @@ app/
 ✅ El baseline inicial de coroutines es parcial: cubre APIs bloqueantes o scopes no estructurados, pero no declara todavía cobertura completa de `Flow`, `viewModelScope`, `supervisorScope`, dispatchers ni cancelación cooperativa.
 ✅ Si se amplía esta cobertura, cada nueva regla debe aterrizar como detector AST/textual semántico con test dirigido antes de declararse cubierta en el registry.
 
+### Enforcement AST inicial de Flow/StateFlow Android
+✅ Las reglas de `StateFlow` / `StateFlow-SharedFlow` deben mapear a señales ejecutables de estado observable legacy, empezando por exposición de `LiveData` / `MutableLiveData` en presentation.
+✅ Este baseline no obliga a que todo ViewModel use Flow; solo detecta una alternativa legacy concreta cuando aparece en código de presentación Android.
+✅ `Flow`, `collectAsState`, `stateIn`, Room observable queries y SharedFlow events quedan fuera hasta que tengan detectores propios y regresiones dirigidas.
+
 ### Dependency Injection (Hilt):
 ✅ **Hilt** - DI framework (NO manual factories)
 ✅ **@HiltAndroidApp** - Application class

--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -98,6 +98,12 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
       'heuristics.android.run-blocking.ast',
     ]
   );
+  assert.deepEqual(
+    resolveMappedHeuristicRuleIds(
+      'skills.android.guideline.android.stateflow-sharedflow-para-exponer-estado-del-viewmodel'
+    ),
+    ['heuristics.android.flow.livedata-state-exposure.ast']
+  );
   assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-solid-violations'), [
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -220,6 +220,18 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
       'heuristics.android.run-blocking.ast',
     ]
   ),
+  'skills.android.guideline.android.stateflow-estado-mutable-observable': heuristicDetector(
+    'android.flow.state-exposure',
+    ['heuristics.android.flow.livedata-state-exposure.ast']
+  ),
+  'skills.android.guideline.android.stateflow-hot-stream-siempre-tiene-valor-para-estado': heuristicDetector(
+    'android.flow.state-exposure',
+    ['heuristics.android.flow.livedata-state-exposure.ast']
+  ),
+  'skills.android.guideline.android.stateflow-sharedflow-para-exponer-estado-del-viewmodel': heuristicDetector(
+    'android.flow.state-exposure',
+    ['heuristics.android.flow.livedata-state-exposure.ast']
+  ),
   'skills.android.no-solid-violations': heuristicDetector('android.solid', [
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',


### PR DESCRIPTION
## Trazabilidad
- escenario: PARITY-ANDROID-001 / Flow-StateFlow baseline inicial
- tests: skills:lock:check, typecheck, android + registry + extractor focused tests
- evidencia: FRESH, typecheck OK, 52/52 pass, git diff --check limpio
- task: PARITY-ANDROID-001

## Alcance
- Añade detector heurístico para LiveData/MutableLiveData en presentation Android.
- Mapea reglas declarativas StateFlow/StateFlow-SharedFlow a la señal ejecutable.
- Mantiene fuera Flow completo, collectAsState, stateIn, Room observable queries y SharedFlow events hasta slices posteriores.