### PR TITLE
feat(android): detect hardcoded background dispatchers

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1128,3 +1128,5 @@ Esta sección es backlog estratégico futuro. No sustituye ni mueve la `🚧` ac
 2. Definir para cada plataforma su pack mínimo de reglas hard, anti-patterns y criterios de arquitectura y test comparables a iOS.
 3. Respaldar cada skill nueva o ampliada con fuentes oficiales y, cuando aporte valor, con uno o más repos de referencia mantenidos.
 4. Integrar esa paridad en compiler templates, detector registry y documentación operativa sin degradar la línea base agnóstica del producto.
+
+Último avance operativo: `[✅] - PARITY-ANDROID-001 / Dispatchers - hardcode background en dominio/aplicación` amplía la sub-slice Android de dispatchers con detector AST real para `Dispatchers.IO` y `Dispatchers.Default` hardcodeados en `domain` o `application`, enlazado en extractor, preset, registry y markdown. La tarea principal sigue activa para continuar con el baseline Android restante. Evidencia local pendiente en rama `feature/parity-android-dispatcher-injection-baseline`.

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1280,6 +1280,10 @@ test('detects Android heuristics in production path and skips tests', () => {
         ['suspend fun execute() = withContext(Dispatchers.Main) { }'].join('\n')
       ),
       fileContentFact(
+        'apps/android/app/src/main/java/com/acme/domain/BuildCatalogIndexUseCase.kt',
+        ['suspend fun execute() = withContext(Dispatchers.Default) { }'].join('\n')
+      ),
+      fileContentFact(
         'apps/android/app/src/test/java/com/acme/FeatureTest.kt',
         [
           'Thread.sleep(10)',
@@ -1297,6 +1301,7 @@ test('detects Android heuristics in production path and skips tests', () => {
   const findings = evaluateRules(astHeuristicsRuleSet, extracted);
   assert.deepEqual(toRuleIds(findings), [
     'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast',
+    'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
     'heuristics.android.coroutines.manual-scope-in-viewmodel.ast',
     'heuristics.android.flow.livedata-state-exposure.ast',
     'heuristics.android.globalscope.ast',

--- a/core/facts/detectors/text/android.test.ts
+++ b/core/facts/detectors/text/android.test.ts
@@ -8,6 +8,7 @@ import {
   findKotlinPresentationSrpMatch,
   hasKotlinDispatcherMainBoundaryLeakUsage,
   hasKotlinGlobalScopeUsage,
+  hasKotlinHardcodedBackgroundDispatcherUsage,
   hasKotlinLiveDataStateExposureUsage,
   hasKotlinManualCoroutineScopeInViewModelUsage,
   hasKotlinRunBlockingUsage,
@@ -161,6 +162,33 @@ class SyncOrdersUseCase {
 }
 `;
   assert.equal(hasKotlinDispatcherMainBoundaryLeakUsage(source), false);
+});
+
+test('hasKotlinHardcodedBackgroundDispatcherUsage detecta Dispatchers.IO y Dispatchers.Default', () => {
+  const ioSource = `
+class SyncOrdersUseCase {
+  suspend fun execute() = withContext(Dispatchers.IO) { }
+}
+`;
+  const defaultSource = `
+class BuildCatalogIndexUseCase {
+  suspend fun execute() = withContext(Dispatchers.Default) { }
+}
+`;
+  assert.equal(hasKotlinHardcodedBackgroundDispatcherUsage(ioSource), true);
+  assert.equal(hasKotlinHardcodedBackgroundDispatcherUsage(defaultSource), true);
+});
+
+test('hasKotlinHardcodedBackgroundDispatcherUsage ignora imports, comentarios, strings y Main', () => {
+  const source = `
+import kotlinx.coroutines.Dispatchers
+// withContext(Dispatchers.IO) { }
+val sample = "Dispatchers.Default"
+class SyncOrdersUseCase {
+  suspend fun execute() = withContext(Dispatchers.Main) { }
+}
+`;
+  assert.equal(hasKotlinHardcodedBackgroundDispatcherUsage(source), false);
 });
 
 test('findKotlinPresentationSrpMatch devuelve payload semantico para SRP-Android en presentation', () => {

--- a/core/facts/detectors/text/android.ts
+++ b/core/facts/detectors/text/android.ts
@@ -255,6 +255,10 @@ const parseKotlinTypeDeclarations = (source: string): readonly KotlinTypeDeclara
   return declarations;
 };
 
+export const hasKotlinHardcodedBackgroundDispatcherUsage = (source: string): boolean => {
+  return collectKotlinRegexLines(source, /\bDispatchers\s*\.\s*(?:IO|Default)\b/).length > 0;
+};
+
 export const hasKotlinThreadSleepCall = (source: string): boolean => {
   return scanCodeLikeSource(source, ({ source: kotlinSource, index, current }) => {
     if (current !== 'T') {

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -99,6 +99,10 @@ const isAndroidApplicationOrPresentationPath = (path: string): boolean => {
   return isAndroidKotlinPath(path) && (path.includes('/application/') || path.includes('/presentation/'));
 };
 
+const isAndroidDomainOrApplicationPath = (path: string): boolean => {
+  return isAndroidKotlinPath(path) && (path.includes('/domain/') || path.includes('/application/'));
+};
+
 const isAndroidNonPresentationKotlinPath = (path: string): boolean => {
   return isAndroidKotlinPath(path) && !path.includes('/presentation/');
 };
@@ -644,6 +648,7 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinLiveDataStateExposureUsage, ruleId: 'heuristics.android.flow.livedata-state-exposure.ast', code: 'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST', message: 'AST heuristic detected LiveData state exposure in Android presentation code where StateFlow or SharedFlow should be preferred.' },
   { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinManualCoroutineScopeInViewModelUsage, ruleId: 'heuristics.android.coroutines.manual-scope-in-viewmodel.ast', code: 'HEURISTICS_ANDROID_COROUTINES_MANUAL_SCOPE_IN_VIEWMODEL_AST', message: 'AST heuristic detected manual CoroutineScope inside an Android ViewModel where viewModelScope should be preferred.' },
   { platform: 'android', pathCheck: isAndroidNonPresentationKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinDispatcherMainBoundaryLeakUsage, ruleId: 'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast', code: 'HEURISTICS_ANDROID_COROUTINES_DISPATCHERS_MAIN_BOUNDARY_LEAK_AST', message: 'AST heuristic detected Dispatchers.Main outside Android presentation code.' },
+  { platform: 'android', pathCheck: isAndroidDomainOrApplicationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinHardcodedBackgroundDispatcherUsage, ruleId: 'heuristics.android.coroutines.hardcoded-background-dispatcher.ast', code: 'HEURISTICS_ANDROID_COROUTINES_HARDCODED_BACKGROUND_DISPATCHER_AST', message: 'AST heuristic detected hard-coded Dispatchers.IO or Dispatchers.Default in Android domain/application code.' },
 ];
 
 const extractWorkflowHeuristicFacts = (

--- a/core/rules/presets/heuristics/android.test.ts
+++ b/core/rules/presets/heuristics/android.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { androidRules } from './android';
 
 test('androidRules define reglas heurísticas locked para plataforma android', () => {
-  assert.equal(androidRules.length, 11);
+  assert.equal(androidRules.length, 12);
 
   const ids = androidRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -13,6 +13,7 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
     'heuristics.android.flow.livedata-state-exposure.ast',
     'heuristics.android.coroutines.manual-scope-in-viewmodel.ast',
     'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast',
+    'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',
     'heuristics.android.solid.dip.concrete-framework-dependency.ast',
@@ -54,6 +55,10 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
   assert.equal(
     byId.get('heuristics.android.coroutines.dispatchers-main-boundary-leak.ast')?.then.code,
     'HEURISTICS_ANDROID_COROUTINES_DISPATCHERS_MAIN_BOUNDARY_LEAK_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.coroutines.hardcoded-background-dispatcher.ast')?.then.code,
+    'HEURISTICS_ANDROID_COROUTINES_HARDCODED_BACKGROUND_DISPATCHER_AST'
   );
   assert.equal(
     byId.get('heuristics.android.solid.srp.presentation-mixed-responsibilities.ast')?.then.code,

--- a/core/rules/presets/heuristics/android.ts
+++ b/core/rules/presets/heuristics/android.ts
@@ -116,6 +116,26 @@ export const androidRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
+    description:
+      'Detects hard-coded Dispatchers.IO or Dispatchers.Default usage in Android domain/application code.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected hard-coded background dispatcher in Android domain/application code.',
+      code: 'HEURISTICS_ANDROID_COROUTINES_HARDCODED_BACKGROUND_DISPATCHER_AST',
+    },
+  },
+  {
     id: 'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     description:
       'Detects Android presentation types mixing session, networking, persistence and navigation responsibilities.',

--- a/docs/codex-skills/android-enterprise-rules.md
+++ b/docs/codex-skills/android-enterprise-rules.md
@@ -125,8 +125,8 @@ app/
 ### Enforcement AST inicial de coroutines Android
 ✅ `skills.android.guideline.android.coroutines-async-await-no-callbacks` debe mapear a señales ejecutables existentes de uso inseguro de coroutines, empezando por `GlobalScope` y `runBlocking`.
 ✅ `skills.android.guideline.android.viewmodelscope-scope-de-viewmodel-cancelado-automa-ticamente` debe mapear a señales ejecutables de scopes manuales dentro de `ViewModel`, empezando por `CoroutineScope(...)` construido en presentation.
-✅ `skills.android.guideline.android.dispatchers-main-ui-io-network-disk-default-cpu` debe mapear a señales ejecutables de dispatcher UI filtrado fuera de presentation, empezando por `Dispatchers.Main` en application/data.
-✅ El baseline inicial de coroutines es parcial: cubre APIs bloqueantes, scopes no estructurados, scopes manuales en `ViewModel` y filtraciones de `Dispatchers.Main`, pero no declara todavía cobertura completa de `Flow`, `supervisorScope`, dispatchers ni cancelación cooperativa.
+✅ `skills.android.guideline.android.dispatchers-main-ui-io-network-disk-default-cpu` debe mapear a señales ejecutables de dispatchers mal ubicados: `Dispatchers.Main` fuera de `presentation` y `Dispatchers.IO` / `Dispatchers.Default` hardcodeados en `domain` o `application` en lugar de entrar por frontera inyectable.
+✅ El baseline inicial de coroutines es parcial: cubre APIs bloqueantes, scopes no estructurados, scopes manuales en `ViewModel`, filtraciones de `Dispatchers.Main` y hardcode de dispatchers de background en dominio/aplicación, pero no declara todavía cobertura completa de `Flow`, `supervisorScope`, dispatchers ni cancelación cooperativa.
 ✅ Si se amplía esta cobertura, cada nueva regla debe aterrizar como detector AST/textual semántico con test dirigido antes de declararse cubierta en el registry.
 
 ### Enforcement AST inicial de Flow/StateFlow Android

--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -114,7 +114,10 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
     resolveMappedHeuristicRuleIds(
       'skills.android.guideline.android.dispatchers-main-ui-io-network-disk-default-cpu'
     ),
-    ['heuristics.android.coroutines.dispatchers-main-boundary-leak.ast']
+    [
+      'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast',
+      'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
+    ]
   );
   assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-solid-violations'), [
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -226,7 +226,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
   ),
   'skills.android.guideline.android.dispatchers-main-ui-io-network-disk-default-cpu': heuristicDetector(
     'android.coroutines.dispatchers',
-    ['heuristics.android.coroutines.dispatchers-main-boundary-leak.ast']
+    [
+      'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast',
+      'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
+    ]
   ),
   'skills.android.guideline.android.stateflow-estado-mutable-observable': heuristicDetector(
     'android.flow.state-exposure',

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "compilerVersion": "1.0.0",
-  "generatedAt": "2026-05-12T19:46:23.268Z",
+  "generatedAt": "2026-05-12T20:34:49.636Z",
   "bundles": [
     {
       "name": "android-guidelines",


### PR DESCRIPTION
## Summary
- Add Android heuristic for hard-coded Dispatchers.IO/Default in domain/application code.
- Map the dispatcher skill to both Main boundary leak and background dispatcher hardcode signals.
- Update Android parity tracking and skill documentation.

## Validation
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test core/rules/presets/heuristics/android.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts core/facts/detectors/text/android.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts
- git diff --check