### PR TITLE
feat(android): detect tracked local.properties

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1140,3 +1140,6 @@ Esta sección es backlog estratégico futuro. No sustituye ni mueve la `🚧` ac
 
 
 Último avance operativo: `[✅] - PARITY-ANDROID-001 / lifecycleScope - Scope de Activity/Fragment` amplía el baseline Android de coroutines con detector AST real para fugas de `lifecycleScope` en `domain` o `application`, enlazado en extractor, preset, registry y markdown. La tarea principal sigue activa para continuar con el baseline Android restante. Evidencia local: `npm run -s skills:lock:check` -> `FRESH`; `npm run -s typecheck` -> OK; suite dirigida `66/66 pass`; `git diff --check` limpio; PR #921 mergeada; release PR #922 mergeada; `pumuki@6.3.186` publicada y verificada como `latest`; RuralGo repineado a `6.3.186` en `bugfix/ruralgo-tracking-build-stability` con commit `8d36ecfbf`, `version.runtime=consumerInstalled=lifecycleInstalled=6.3.186` y `PRE_WRITE.strict=true`.
+
+
+Último avance operativo: `[✅] - PARITY-ANDROID-001 / local.properties - API keys no subir a git` amplía el baseline Android con detector AST/path real para `local.properties` versionado bajo `apps/android/`, enlazado en extractor, preset, registry y markdown. La tarea principal sigue activa para continuar con el baseline Android restante. Evidencia local: `npm run -s skills:lock:check` -> `FRESH`; `npm run -s typecheck` -> OK; suite dirigida `38/38 pass`; `git diff --check` limpio.

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1267,6 +1267,10 @@ test('detects Android heuristics in production path and skips tests', () => {
         ['Thread.sleep(10)', 'GlobalScope.launch { }', 'runBlocking { }'].join('\n')
       ),
       fileContentFact(
+        'apps/android/local.properties',
+        ['sdk.dir=/Users/demo/Library/Android/sdk'].join('\n')
+      ),
+      fileContentFact(
         'apps/android/app/src/main/java/com/acme/presentation/FeatureViewModel.kt',
         [
           'class FeatureViewModel : ViewModel() {',
@@ -1327,6 +1331,7 @@ test('detects Android heuristics in production path and skips tests', () => {
     'heuristics.android.flow.livedata-state-exposure.ast',
     'heuristics.android.globalscope.ast',
     'heuristics.android.run-blocking.ast',
+    'heuristics.android.security.local-properties-tracked.ast',
     'heuristics.android.thread-sleep.ast',
   ]);
 });

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -91,6 +91,13 @@ const isAndroidKotlinPath = (path: string): boolean => {
   return (path.endsWith('.kt') || path.endsWith('.kts')) && path.startsWith('apps/android/');
 };
 
+const isAndroidLocalPropertiesPath = (path: string): boolean => {
+  const normalized = path.replace(/\\/g, '/').toLowerCase();
+  return normalized.startsWith('apps/android/') && normalized.endsWith('/local.properties');
+};
+
+const detectsTrackedFilePresence = (_source: string): boolean => true;
+
 const isAndroidPresentationPath = (path: string): boolean => {
   return isAndroidKotlinPath(path) && path.includes('/presentation/');
 };
@@ -645,6 +652,7 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinThreadSleepCall, ruleId: 'heuristics.android.thread-sleep.ast', code: 'HEURISTICS_ANDROID_THREAD_SLEEP_AST', message: 'AST heuristic detected Thread.sleep usage in production Kotlin code.' },
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinGlobalScopeUsage, ruleId: 'heuristics.android.globalscope.ast', code: 'HEURISTICS_ANDROID_GLOBAL_SCOPE_AST', message: 'AST heuristic detected GlobalScope coroutine usage in production Kotlin code.' },
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinRunBlockingUsage, ruleId: 'heuristics.android.run-blocking.ast', code: 'HEURISTICS_ANDROID_RUN_BLOCKING_AST', message: 'AST heuristic detected runBlocking usage in production Kotlin code.' },
+  { platform: 'android', pathCheck: isAndroidLocalPropertiesPath, excludePaths: [], detect: detectsTrackedFilePresence, ruleId: 'heuristics.android.security.local-properties-tracked.ast', code: 'HEURISTICS_ANDROID_SECURITY_LOCAL_PROPERTIES_TRACKED_AST', message: 'AST heuristic detected tracked Android local.properties file.' },
   { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinLiveDataStateExposureUsage, ruleId: 'heuristics.android.flow.livedata-state-exposure.ast', code: 'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST', message: 'AST heuristic detected LiveData state exposure in Android presentation code where StateFlow or SharedFlow should be preferred.' },
   { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinManualCoroutineScopeInViewModelUsage, ruleId: 'heuristics.android.coroutines.manual-scope-in-viewmodel.ast', code: 'HEURISTICS_ANDROID_COROUTINES_MANUAL_SCOPE_IN_VIEWMODEL_AST', message: 'AST heuristic detected manual CoroutineScope inside an Android ViewModel where viewModelScope should be preferred.' },
   { platform: 'android', pathCheck: isAndroidNonPresentationKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinDispatcherMainBoundaryLeakUsage, ruleId: 'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast', code: 'HEURISTICS_ANDROID_COROUTINES_DISPATCHERS_MAIN_BOUNDARY_LEAK_AST', message: 'AST heuristic detected Dispatchers.Main outside Android presentation code.' },

--- a/core/rules/presets/heuristics/android.test.ts
+++ b/core/rules/presets/heuristics/android.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { androidRules } from './android';
 
 test('androidRules define reglas heurísticas locked para plataforma android', () => {
-  assert.equal(androidRules.length, 16);
+  assert.equal(androidRules.length, 17);
 
   const ids = androidRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -11,6 +11,7 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
     'heuristics.android.globalscope.ast',
     'heuristics.android.run-blocking.ast',
     'heuristics.android.flow.livedata-state-exposure.ast',
+    'heuristics.android.security.local-properties-tracked.ast',
     'heuristics.android.coroutines.manual-scope-in-viewmodel.ast',
     'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast',
     'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
@@ -51,6 +52,10 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
   assert.equal(
     byId.get('heuristics.android.flow.livedata-state-exposure.ast')?.then.code,
     'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.security.local-properties-tracked.ast')?.then.code,
+    'HEURISTICS_ANDROID_SECURITY_LOCAL_PROPERTIES_TRACKED_AST'
   );
   assert.equal(
     byId.get('heuristics.android.coroutines.manual-scope-in-viewmodel.ast')?.then.code,

--- a/core/rules/presets/heuristics/android.ts
+++ b/core/rules/presets/heuristics/android.ts
@@ -76,6 +76,26 @@ export const androidRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.android.security.local-properties-tracked.ast',
+    description:
+      'Detects tracked Android local.properties files that may expose machine-local SDK paths or secrets.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.security.local-properties-tracked.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected tracked Android local.properties file.',
+      code: 'HEURISTICS_ANDROID_SECURITY_LOCAL_PROPERTIES_TRACKED_AST',
+    },
+  },
+  {
     id: 'heuristics.android.coroutines.manual-scope-in-viewmodel.ast',
     description:
       'Detects manual CoroutineScope construction inside Android ViewModel classes where viewModelScope should be preferred.',

--- a/docs/codex-skills/android-enterprise-rules.md
+++ b/docs/codex-skills/android-enterprise-rules.md
@@ -133,6 +133,10 @@ app/
 ✅ El baseline inicial de coroutines es parcial: cubre APIs bloqueantes, scopes no estructurados, scopes manuales en `ViewModel`, filtraciones de `Dispatchers.Main`, hardcode de dispatchers de background en dominio/aplicación, `withContext`, fuga de `lifecycleScope`, `supervisorScope` y `try/catch` en coroutines, pero no declara todavía cobertura completa de `Flow`, dispatchers ni cancelación cooperativa.
 ✅ Si se amplía esta cobertura, cada nueva regla debe aterrizar como detector AST/textual semántico con test dirigido antes de declararse cubierta en el registry.
 
+### Enforcement AST inicial de seguridad Android
+✅ `skills.android.guideline.android.local-properties-api-keys-no-subir-a-git` debe mapear a señal ejecutable de `local.properties` versionado bajo `apps/android/`.
+✅ Este baseline no imprime ni analiza valores secretos; solo reporta la presencia del archivo versionado y exige retirarlo del control de versiones.
+
 ### Enforcement AST inicial de Flow/StateFlow Android
 ✅ Las reglas de `StateFlow` / `StateFlow-SharedFlow` deben mapear a señales ejecutables de estado observable legacy, empezando por exposición de `LiveData` / `MutableLiveData` en presentation.
 ✅ Este baseline no obliga a que todo ViewModel use Flow; solo detecta una alternativa legacy concreta cuando aparece en código de presentación Android.

--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -143,6 +143,12 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
     ),
     ['heuristics.android.coroutines.try-catch.ast']
   );
+  assert.deepEqual(
+    resolveMappedHeuristicRuleIds(
+      'skills.android.guideline.android.local-properties-api-keys-no-subir-a-git'
+    ),
+    ['heuristics.android.security.local-properties-tracked.ast']
+  );
   assert.deepEqual(resolveMappedHeuristicRuleIds('skills.android.no-solid-violations'), [
     'heuristics.android.solid.srp.presentation-mixed-responsibilities.ast',
     'heuristics.android.solid.ocp.discriminator-branching.ast',

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -247,6 +247,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     'android.coroutines.try-catch',
     ['heuristics.android.coroutines.try-catch.ast']
   ),
+  'skills.android.guideline.android.local-properties-api-keys-no-subir-a-git': heuristicDetector(
+    'android.security.local-properties',
+    ['heuristics.android.security.local-properties-tracked.ast']
+  ),
   'skills.android.guideline.android.stateflow-estado-mutable-observable': heuristicDetector(
     'android.flow.state-exposure',
     ['heuristics.android.flow.livedata-state-exposure.ast']

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "compilerVersion": "1.0.0",
-  "generatedAt": "2026-05-12T21:00:49.435Z",
+  "generatedAt": "2026-05-12T21:06:58.727Z",
   "bundles": [
     {
       "name": "android-guidelines",


### PR DESCRIPTION
## Summary
- add Android path heuristic for tracked apps/android/**/local.properties
- map local-properties-api-keys-no-subir-a-git to executable coverage
- update Android parity tracking and regression coverage

## Validation
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test core/rules/presets/heuristics/android.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts
- git diff --check