### PR TITLE
feat(android): detect JUnit4 test usage

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -1146,3 +1146,6 @@ Esta sección es backlog estratégico futuro. No sustituye ni mueve la `🚧` ac
 
 
 Último avance operativo: `[✅] - PARITY-ANDROID-001 / DataStore - reemplazo de SharedPreferences` amplía el baseline Android de persistencia con detector AST/textual real para uso legacy de `SharedPreferences` en Kotlin production, enlazado en extractor, preset, registry y markdown. La tarea principal sigue activa para continuar con el baseline Android restante. Evidencia local: `npm run -s skills:lock:check` -> `FRESH`; `npm run -s typecheck` -> OK; suite dirigida `68/68 pass`; `git diff --check` limpio; PR #927 mergeada; release PR #928 mergeada; `pumuki@6.3.188` publicada y verificada como `latest`; RuralGo repineado a `6.3.188` en `bugfix/ruralgo-tracking-build-stability` con commit `5696501c9`, `version.runtime=consumerInstalled=lifecycleInstalled=6.3.188` y `PRE_WRITE.strict=true`.
+
+
+Último avance operativo: `[🚧] - PARITY-ANDROID-001 / JUnit5 - Framework de testing preferido sobre JUnit4` amplía el baseline Android de testing con detector AST/textual real para usos JUnit4 en tests Kotlin Android, enlazado en extractor, preset, registry y markdown. La tarea principal sigue activa para continuar con el baseline Android restante. Evidencia local pendiente de gates, release y repin RuralGo.

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -1316,6 +1316,20 @@ test('detects Android heuristics in production path and skips tests', () => {
           'private val mutableState = MutableLiveData<FeatureUiState>()',
         ].join('\n')
       ),
+      fileContentFact(
+        'apps/android/app/src/test/java/com/acme/LegacyJUnit4Test.kt',
+        [
+          'import org.junit.Test',
+          'import org.junit.Assert',
+          '',
+          'class LegacyJUnit4Test {',
+          '  @Test',
+          '  fun verifiesLegacyAssertion() {',
+          '    Assert.assertEquals(1, 1)',
+          '  }',
+          '}',
+        ].join('\n')
+      ),
     ],
     detectedPlatforms: {
       android: { detected: true },
@@ -1337,6 +1351,7 @@ test('detects Android heuristics in production path and skips tests', () => {
     'heuristics.android.persistence.shared-preferences-usage.ast',
     'heuristics.android.run-blocking.ast',
     'heuristics.android.security.local-properties-tracked.ast',
+    'heuristics.android.testing.junit4-usage.ast',
     'heuristics.android.thread-sleep.ast',
   ]);
 });

--- a/core/facts/detectors/text/android.test.ts
+++ b/core/facts/detectors/text/android.test.ts
@@ -10,6 +10,7 @@ import {
   hasKotlinDispatcherMainBoundaryLeakUsage,
   hasKotlinGlobalScopeUsage,
   hasKotlinHardcodedBackgroundDispatcherUsage,
+  hasKotlinJUnit4Usage,
   hasKotlinLiveDataStateExposureUsage,
   hasKotlinLifecycleScopeUsage,
   hasKotlinSharedPreferencesUsage,
@@ -273,6 +274,45 @@ class PreferencesStore {
 }
 `;
   assert.equal(hasKotlinSharedPreferencesUsage(source), false);
+});
+
+test('hasKotlinJUnit4Usage detecta imports y anotaciones JUnit4 en tests Kotlin Android', () => {
+  const importSource = `
+import org.junit.Test
+import org.junit.Assert
+
+class OrdersViewModelTest {
+  @Test
+  fun loadsOrders() {
+    Assert.assertEquals(1, 1)
+  }
+}
+`;
+  const runnerSource = `
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OrdersInstrumentedTest
+`;
+
+  assert.equal(hasKotlinJUnit4Usage(importSource), true);
+  assert.equal(hasKotlinJUnit4Usage(runnerSource), true);
+});
+
+test('hasKotlinJUnit4Usage ignora JUnit5, comentarios y strings', () => {
+  const source = `
+import org.junit.jupiter.api.Test
+// import org.junit.Test
+val sample = "Assert.assertEquals(1, 1)"
+
+class OrdersViewModelTest {
+  @Test
+  fun loadsOrders() {
+    assertEquals(1, 1)
+  }
+}
+`;
+  assert.equal(hasKotlinJUnit4Usage(source), false);
 });
 
 test('hasKotlinSupervisorScopeUsage detecta supervisorScope con parentesis y llaves', () => {

--- a/core/facts/detectors/text/android.ts
+++ b/core/facts/detectors/text/android.ts
@@ -271,6 +271,17 @@ export const hasKotlinSharedPreferencesUsage = (source: string): boolean => {
   return collectKotlinRegexLines(source, /\b(?:SharedPreferences|PreferenceManager\s*\.|getSharedPreferences\s*\()/).length > 0;
 };
 
+export const hasKotlinJUnit4Usage = (source: string): boolean => {
+  return source.split(/\r?\n/).some((line) => {
+    const sanitized = stripKotlinLineForSemanticScan(line);
+    return (
+      /\bimport\s+org\.junit\.(?:Test|Before|After|BeforeClass|AfterClass|Assert|Rule|ClassRule|runner\.RunWith|rules\.)\b/.test(sanitized) ||
+      /@(?:RunWith|Rule|ClassRule)\b/.test(sanitized) ||
+      /\bAssert\s*\./.test(sanitized)
+    );
+  });
+};
+
 export const hasKotlinSupervisorScopeUsage = (source: string): boolean => {
   return collectKotlinRegexLines(source, /\bsupervisorScope\s*(?:<[^>\n]+>\s*)?(?:\(|\{)/).length > 0;
 };

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -161,6 +161,10 @@ const isKotlinTestPath = (path: string): boolean => {
   );
 };
 
+const isAndroidKotlinTestPath = (path: string): boolean => {
+  return isAndroidKotlinPath(path) && isKotlinTestPath(path);
+};
+
 const isExcludedProjectScanPath = (path: string): boolean => {
   const normalized = path.replace(/\\/g, '/').toLowerCase();
   return (
@@ -654,6 +658,7 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinRunBlockingUsage, ruleId: 'heuristics.android.run-blocking.ast', code: 'HEURISTICS_ANDROID_RUN_BLOCKING_AST', message: 'AST heuristic detected runBlocking usage in production Kotlin code.' },
   { platform: 'android', pathCheck: isAndroidLocalPropertiesPath, excludePaths: [], detect: detectsTrackedFilePresence, ruleId: 'heuristics.android.security.local-properties-tracked.ast', code: 'HEURISTICS_ANDROID_SECURITY_LOCAL_PROPERTIES_TRACKED_AST', message: 'AST heuristic detected tracked Android local.properties file.' },
   { platform: 'android', pathCheck: isAndroidKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinSharedPreferencesUsage, ruleId: 'heuristics.android.persistence.shared-preferences-usage.ast', code: 'HEURISTICS_ANDROID_PERSISTENCE_SHARED_PREFERENCES_USAGE_AST', message: 'AST heuristic detected SharedPreferences usage in Android production Kotlin code.' },
+  { platform: 'android', pathCheck: isAndroidKotlinTestPath, excludePaths: [], detect: TextAndroid.hasKotlinJUnit4Usage, ruleId: 'heuristics.android.testing.junit4-usage.ast', code: 'HEURISTICS_ANDROID_TESTING_JUNIT4_USAGE_AST', message: 'AST heuristic detected JUnit4 usage in Android Kotlin tests where JUnit5 is preferred.' },
   { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinLiveDataStateExposureUsage, ruleId: 'heuristics.android.flow.livedata-state-exposure.ast', code: 'HEURISTICS_ANDROID_FLOW_LIVEDATA_STATE_EXPOSURE_AST', message: 'AST heuristic detected LiveData state exposure in Android presentation code where StateFlow or SharedFlow should be preferred.' },
   { platform: 'android', pathCheck: isAndroidPresentationPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinManualCoroutineScopeInViewModelUsage, ruleId: 'heuristics.android.coroutines.manual-scope-in-viewmodel.ast', code: 'HEURISTICS_ANDROID_COROUTINES_MANUAL_SCOPE_IN_VIEWMODEL_AST', message: 'AST heuristic detected manual CoroutineScope inside an Android ViewModel where viewModelScope should be preferred.' },
   { platform: 'android', pathCheck: isAndroidNonPresentationKotlinPath, excludePaths: [isKotlinTestPath], detect: TextAndroid.hasKotlinDispatcherMainBoundaryLeakUsage, ruleId: 'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast', code: 'HEURISTICS_ANDROID_COROUTINES_DISPATCHERS_MAIN_BOUNDARY_LEAK_AST', message: 'AST heuristic detected Dispatchers.Main outside Android presentation code.' },

--- a/core/rules/presets/heuristics/android.test.ts
+++ b/core/rules/presets/heuristics/android.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { androidRules } from './android';
 
 test('androidRules define reglas heurísticas locked para plataforma android', () => {
-  assert.equal(androidRules.length, 18);
+  assert.equal(androidRules.length, 19);
 
   const ids = androidRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -13,6 +13,7 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
     'heuristics.android.flow.livedata-state-exposure.ast',
     'heuristics.android.security.local-properties-tracked.ast',
     'heuristics.android.persistence.shared-preferences-usage.ast',
+    'heuristics.android.testing.junit4-usage.ast',
     'heuristics.android.coroutines.manual-scope-in-viewmodel.ast',
     'heuristics.android.coroutines.dispatchers-main-boundary-leak.ast',
     'heuristics.android.coroutines.hardcoded-background-dispatcher.ast',
@@ -61,6 +62,10 @@ test('androidRules define reglas heurísticas locked para plataforma android', (
   assert.equal(
     byId.get('heuristics.android.persistence.shared-preferences-usage.ast')?.then.code,
     'HEURISTICS_ANDROID_PERSISTENCE_SHARED_PREFERENCES_USAGE_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.android.testing.junit4-usage.ast')?.then.code,
+    'HEURISTICS_ANDROID_TESTING_JUNIT4_USAGE_AST'
   );
   assert.equal(
     byId.get('heuristics.android.coroutines.manual-scope-in-viewmodel.ast')?.then.code,

--- a/core/rules/presets/heuristics/android.ts
+++ b/core/rules/presets/heuristics/android.ts
@@ -116,6 +116,26 @@ export const androidRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.android.testing.junit4-usage.ast',
+    description:
+      'Detects JUnit4 usage in Android Kotlin tests where JUnit5 is preferred.',
+    severity: 'WARN',
+    platform: 'android',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.android.testing.junit4-usage.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message:
+        'AST heuristic detected JUnit4 usage in Android Kotlin tests.',
+      code: 'HEURISTICS_ANDROID_TESTING_JUNIT4_USAGE_AST',
+    },
+  },
+  {
     id: 'heuristics.android.coroutines.manual-scope-in-viewmodel.ast',
     description:
       'Detects manual CoroutineScope construction inside Android ViewModel classes where viewModelScope should be preferred.',

--- a/docs/codex-skills/android-enterprise-rules.md
+++ b/docs/codex-skills/android-enterprise-rules.md
@@ -146,6 +146,11 @@ app/
 ✅ Este baseline no obliga a que todo ViewModel use Flow; solo detecta una alternativa legacy concreta cuando aparece en código de presentación Android.
 ✅ `Flow`, `collectAsState`, `stateIn`, Room observable queries y SharedFlow events quedan fuera hasta que tengan detectores propios y regresiones dirigidas.
 
+### Enforcement AST inicial de testing Android
+✅ `skills.android.guideline.android.junit5-framework-de-testing-preferido-sobre-junit4` debe mapear a señal ejecutable de uso JUnit4 en tests Kotlin Android.
+✅ Este baseline detecta imports/anotaciones JUnit4 (`org.junit.Test`, `org.junit.Assert`, `@RunWith`, reglas JUnit4) bajo `apps/android/**/test/**` y `apps/android/**/androidTest/**`.
+✅ JUnit5/Jupiter queda preservado como caso limpio; migración completa de runner, Gradle y APIs de assertions queda fuera hasta tener detectores propios.
+
 ### Dependency Injection (Hilt):
 ✅ **Hilt** - DI framework (NO manual factories)
 ✅ **@HiltAndroidApp** - Application class

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -255,6 +255,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     'android.persistence.shared-preferences',
     ['heuristics.android.persistence.shared-preferences-usage.ast']
   ),
+  'skills.android.guideline.android.junit5-framework-de-testing-preferido-sobre-junit4': heuristicDetector(
+    'android.testing.junit4-usage',
+    ['heuristics.android.testing.junit4-usage.ast']
+  ),
   'skills.android.guideline.android.stateflow-estado-mutable-observable': heuristicDetector(
     'android.flow.state-exposure',
     ['heuristics.android.flow.livedata-state-exposure.ast']

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "compilerVersion": "1.0.0",
-  "generatedAt": "2026-05-12T21:13:45.516Z",
+  "generatedAt": "2026-05-12T21:22:02.797Z",
   "bundles": [
     {
       "name": "android-guidelines",


### PR DESCRIPTION
## Summary
- Adds Android Kotlin test heuristic for JUnit4 usage where JUnit5 is preferred
- Maps the Android enterprise testing skill to the new executable heuristic
- Updates Android heuristic rules, tests, vendored skill docs, and reset tracking

## Validation
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test core/facts/detectors/text/android.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/android.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts
- git diff --check