### PR TITLE
chore(release): 6.3.192

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.191",
+  "version": "6.3.192",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.191",
+      "version": "6.3.192",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.191",
+  "version": "6.3.192",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bumps pumuki to 6.3.192 for the RuralGo PRE_PUSH parity regression fix

## Evidence
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test integrations/config/__tests__/skillsRuleSet.test.ts integrations/lifecycle/__tests__/audit.test.ts integrations/git/__tests__/runPlatformGate.test.ts
- git diff --check
- npm pack --dry-run --silent