### PR TITLE
chore(release): 6.3.194

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.193",
+  "version": "6.3.194",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.193",
+      "version": "6.3.194",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.193",
+  "version": "6.3.194",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Resumen
- Publica pumuki 6.3.194 con detección iOS brownfield-aware de CocoaPods/Carthage.

## Evidencia
- npm run -s skills:lock:check -> FRESH
- npm run -s typecheck -> OK
- npx tsx --test core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts -> 38/38 pass
- npm pack --dry-run --silent -> OK
- git diff --check -> OK