### PR TITLE
chore(release): 6.3.195

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.194",
+  "version": "6.3.195",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.194",
+      "version": "6.3.195",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.194",
+  "version": "6.3.195",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Resumen
- Publica pumuki 6.3.195 con detección iOS brownfield-aware de secretos en UserDefaults/AppStorage.

## Evidencia
- npm run -s skills:lock:check -> FRESH
- npm run -s typecheck -> OK
- npx tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts -> 77/77 pass
- npm pack --dry-run --silent -> OK
- git diff --check -> OK