### PR TITLE
feat(ios): map swiftdata persistence skill

### DIFF
--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -933,13 +933,18 @@ git checkout -b refactor/s1-governance-console
 |-----------|-----------------|
 | Este plan | `[🚧] - PARITY-IOS-001` / Continuación iOS - reglas pendientes de baseline Swift/iOS. |
 
-- Estado: 🚧 PARITY-IOS-001 / Continuación iOS - reglas pendientes de baseline Swift/iOS.
+- Estado: 🚧 PARITY-IOS-001 / SwiftData layer-leak AUTO mapping desde `core-data-expert`.
 
 Snapshot PARITY-IOS-SWIFTDATA-001 (2026-05-12):
 - Reapertura limpia: PR #890 queda descartado como ruta de merge directa porque estaba basado en `bugfix/pumuki-inc130-ios-helper-critical-quality-final2` y no en `main`, arrastrando historia antigua.
 - Implementación objetivo: rehacer la slice en `feature/parity-ios-swiftdata-clean` desde `origin/main`, aplicando solo el patch SwiftData/Core Data.
 - Alcance explícito: no se declara cobertura total de SwiftData; esta slice cierra la frontera de capas enterprise para APIs de persistencia SwiftData y mantiene intactas las reglas brownfield Core Data existentes.
 - Cierre: PR #899 mergeado en `main`, release `pumuki@6.3.176` publicada y RuralGo repineado a `6.3.176` con `status` sin drift y policy válida en `PRE_WRITE`, `PRE_COMMIT`, `PRE_PUSH` y `CI`.
+
+Snapshot PARITY-IOS-SWIFTDATA-002 (2026-05-13):
+- Diagnóstico: `skills.ios.no-swiftdata-layer-leak` ya tenía detector, extractor, preset y registry, pero las frases reales de `core-data-expert` sobre `ModelContext`, `ModelContainer`, `@Query`, `@Model` y modelos SwiftData seguían compilando como `DECLARATIVE`.
+- Implementación: el normalizador de markdown de skills convierte esas frases a `skills.ios.no-swiftdata-layer-leak`, conservando severidad `WARN`, alcance brownfield y binding `heuristics.ios.swiftdata.layer-leak.ast`.
+- Evidencia local: `node --import tsx scripts/compile-skills-lock.ts`; `npm run -s skills:lock:check` -> `FRESH`; `npm run -s typecheck` -> OK; suite dirigida `91/91 pass`; `git diff --check` limpio.
 
 Snapshot PARITY-ANDROID-001 (2026-05-12):
 - Diagnóstico: el extractor ya emitía heurísticas semánticas SOLID Android para SRP/OCP/DIP/ISP/LSP, pero `androidRules` solo exponía reglas básicas (`Thread.sleep`, `GlobalScope`, `runBlocking`) y `skills.android.no-solid-violations` no estaba enlazada al registry.

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -128,6 +128,7 @@ test('normaliza reglas Core Data a ids canonicos del slice phase8', () => {
     sourcePath: 'docs/codex-skills/core-data-expert.md',
     sourceContent: [
       '- ✅ Keep Core Data orchestration inside infrastructure or repository layers instead of presentation code.',
+      '- ✅ Keep SwiftData orchestration (`ModelContext`, `ModelContainer`, `@Query`, `@Model`) inside infrastructure or repository layers instead of application or presentation code.',
       '- ❌ Leaking context-scoped managed objects into SwiftUI state or view models.',
     ].join('\n'),
   });
@@ -136,6 +137,7 @@ test('normaliza reglas Core Data a ids canonicos del slice phase8', () => {
   assert.deepEqual(ids, [
     'skills.ios.no-core-data-layer-leak',
     'skills.ios.no-nsmanagedobject-state-leak',
+    'skills.ios.no-swiftdata-layer-leak',
   ]);
 });
 

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -404,6 +404,15 @@ const normalizeKnownRuleTarget = (
       return 'skills.ios.no-nsmanagedobject-async-boundary';
     }
     if (
+      includes('keep swiftdata orchestration') ||
+      includes('swiftdata contexts containers queries or persistence models') ||
+      includes('modelcontext') ||
+      includes('modelcontainer') ||
+      includes('query model')
+    ) {
+      return 'skills.ios.no-swiftdata-layer-leak';
+    }
+    if (
       includes('core data orchestration inside infrastructure') ||
       includes('instead of presentation code') ||
       includes('core data apis in application or presentation code') ||

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "compilerVersion": "1.0.0",
-  "generatedAt": "2026-05-12T21:28:07.507Z",
+  "generatedAt": "2026-05-13T11:03:09.894Z",
   "bundles": [
     {
       "name": "android-guidelines",
@@ -5644,20 +5644,8 @@
       "name": "ios-core-data-guidelines",
       "version": "1.0.0",
       "source": "file:vendor/skills/core-data-expert/SKILL.md",
-      "hash": "d91f2cad6499310a4299b39593d47f40a507299a0562c21bc64aad9b5d27c66f",
+      "hash": "be63caab019ec200e0248cc670f431b27d4fa8023c3267d0577785e50ba14db4",
       "rules": [
-        {
-          "id": "skills.ios.guideline.ios-core-data.keep-swiftdata-orchestration-modelcontext-modelcontainer-query-model-i",
-          "description": "Keep SwiftData orchestration (ModelContext, ModelContainer, @Query, @Model) inside infrastructure or repository layers instead of application or presentation code in enterprise Clean Architecture.",
-          "severity": "WARN",
-          "platform": "ios",
-          "sourceSkill": "ios-core-data-guidelines",
-          "sourcePath": "vendor/skills/core-data-expert/SKILL.md",
-          "confidence": "MEDIUM",
-          "locked": true,
-          "evaluationMode": "DECLARATIVE",
-          "origin": "core"
-        },
         {
           "id": "skills.ios.guideline.ios-core-data.make-context-ownership-explicit-and-keep-merge-boundaries-controlled",
           "description": "Make context ownership explicit and keep merge boundaries controlled.",
@@ -5702,18 +5690,6 @@
           "sourceSkill": "ios-core-data-guidelines",
           "sourcePath": "vendor/skills/core-data-expert/SKILL.md",
           "confidence": "MEDIUM",
-          "locked": true,
-          "evaluationMode": "DECLARATIVE",
-          "origin": "core"
-        },
-        {
-          "id": "skills.ios.guideline.ios-core-data.using-swiftdata-contexts-containers-queries-or-persistence-models-dire",
-          "description": "Using SwiftData contexts, containers, queries, or persistence models directly in application or presentation code when the repo requires Clean Architecture boundaries.",
-          "severity": "ERROR",
-          "platform": "ios",
-          "sourceSkill": "ios-core-data-guidelines",
-          "sourcePath": "vendor/skills/core-data-expert/SKILL.md",
-          "confidence": "HIGH",
           "locked": true,
           "evaluationMode": "DECLARATIVE",
           "origin": "core"
@@ -5767,6 +5743,18 @@
           "locked": true,
           "sourceSkill": "ios-core-data-guidelines",
           "sourcePath": "vendor/skills/core-data-expert/SKILL.md",
+          "evaluationMode": "AUTO",
+          "origin": "core"
+        },
+        {
+          "id": "skills.ios.no-swiftdata-layer-leak",
+          "description": "Keep SwiftData orchestration (ModelContext, ModelContainer, @Query, @Model) inside infrastructure or repository layers instead of application or presentation code in enterprise Clean Architecture.",
+          "severity": "WARN",
+          "platform": "ios",
+          "sourceSkill": "ios-core-data-guidelines",
+          "sourcePath": "vendor/skills/core-data-expert/SKILL.md",
+          "confidence": "MEDIUM",
+          "locked": true,
           "evaluationMode": "AUTO",
           "origin": "core"
         }


### PR DESCRIPTION
## Summary
- Map SwiftData persistence guidance from core-data-expert to skills.ios.no-swiftdata-layer-leak.
- Regenerate skills.lock so SwiftData layer leak is AUTO instead of DECLARATIVE.
- Record the PARITY-IOS-SWIFTDATA-002 evidence in the reset plan.

## Evidence
- node --import tsx scripts/compile-skills-lock.ts
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts
- npm run -s validation:tracking-single-active
- git diff --check