### PR TITLE
chore(release): 6.3.196

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.195",
+  "version": "6.3.196",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.195",
+      "version": "6.3.196",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.195",
+  "version": "6.3.196",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump Pumuki to 6.3.196 for the SwiftData persistence skill mapping release.

## Evidence
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test integrations/config/__tests__/skillsMarkdownRules.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts
- npm pack --dry-run --silent
- git diff --check