### PR TITLE
feat(ios): detect insecure transport

### DIFF
--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -476,6 +476,18 @@ test('detects iOS heuristics and skips bridge callback rule', () => {
       ),
       fileContentFact('apps/ios/Podfile', 'pod "LegacyDependency"'),
       fileContentFact('apps/ios/Cartfile', 'github "Legacy/Dependency"'),
+      fileContentFact(
+        'apps/ios/App/Info.plist',
+        [
+          '<dict>',
+          '  <key>NSAppTransportSecurity</key>',
+          '  <dict>',
+          '    <key>NSAllowsArbitraryLoads</key>',
+          '    <true/>',
+          '  </dict>',
+          '</dict>',
+        ].join('\n')
+      ),
     ],
     detectedPlatforms: {
       ios: { detected: true },
@@ -515,6 +527,7 @@ test('detects iOS heuristics and skips bridge callback rule', () => {
     'heuristics.ios.passed-value-state-wrapper.ast',
     'heuristics.ios.preconcurrency.ast',
     'heuristics.ios.scrollview-shows-indicators.ast',
+    'heuristics.ios.security.insecure-transport.ast',
     'heuristics.ios.security.userdefaults-sensitive-data.ast',
     'heuristics.ios.sheet-is-presented.ast',
     'heuristics.ios.string-format.ast',

--- a/core/facts/detectors/text/ios.test.ts
+++ b/core/facts/detectors/text/ios.test.ts
@@ -45,6 +45,7 @@ import {
   hasSwiftScrollViewShowsIndicatorsUsage,
   hasSwiftSensitiveLoggingUsage,
   hasSwiftSensitiveUserDefaultsStorageUsage,
+  hasSwiftInsecureTransportUsage,
   hasSwiftJSONSerializationUsage,
   hasSwiftStringFormatUsage,
   hasSwiftTabItemUsage,
@@ -238,6 +239,33 @@ let text = "UserDefaults.standard.set(accessToken, forKey: \\"accessToken\\")"
 
   assert.equal(hasSwiftSensitiveUserDefaultsStorageUsage(source), true);
   assert.equal(hasSwiftSensitiveUserDefaultsStorageUsage(ignored), false);
+});
+
+test('detector iOS de seguridad detecta transporte inseguro HTTP y ATS permisivo', () => {
+  const source = `
+final class CatalogClient {
+  func load() {
+    _ = URL(string: "http://example.com/catalog.json")
+  }
+}
+`;
+  const plist = `
+<dict>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
+</dict>
+`;
+  const ignored = `
+// _ = URL(string: "http://example.com/catalog.json")
+let text = "https://example.com/catalog.json"
+`;
+
+  assert.equal(hasSwiftInsecureTransportUsage(source), true);
+  assert.equal(hasSwiftInsecureTransportUsage(plist), true);
+  assert.equal(hasSwiftInsecureTransportUsage(ignored), false);
 });
 
 test('hasSwiftUncheckedSendableUsage detecta @unchecked Sendable', () => {

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -492,6 +492,25 @@ export const hasSwiftSensitiveUserDefaultsStorageUsage = (source: string): boole
   });
 };
 
+export const hasSwiftInsecureTransportUsage = (source: string): boolean => {
+  const withoutBlockComments = source.replace(/\/\*[\s\S]*?\*\//g, '\n');
+  const hasHttpUrlLiteral = withoutBlockComments.split(/\r?\n/).some((line) => {
+    if (/^\s*\/\//.test(line)) {
+      return false;
+    }
+    return /["']http:\/\/[^"']*["']/.test(line);
+  });
+
+  if (hasHttpUrlLiteral) {
+    return true;
+  }
+
+  return (
+    /<key>\s*NSAllowsArbitraryLoads\s*<\/key>\s*<true\s*\/>/i.test(source) ||
+    /\bNSAllowsArbitraryLoads\b\s*=\s*(?:true|YES|1)\b/i.test(source)
+  );
+};
+
 export const hasSwiftUncheckedSendableUsage = (source: string): boolean => {
   return scanCodeLikeSource(source, ({ source: swiftSource, index, current }) => {
     if (current !== '@' || !swiftSource.startsWith('@unchecked', index)) {

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -92,6 +92,11 @@ const isIOSCartfilePath = (path: string): boolean => {
   );
 };
 
+const isIOSInfoPlistPath = (path: string): boolean => {
+  const normalized = path.replace(/\\/g, '/');
+  return normalized.startsWith('apps/ios/') && normalized.endsWith('/Info.plist');
+};
+
 const isIOSApplicationOrPresentationPath = (path: string): boolean => {
   return (
     isIOSSwiftPath(path) &&
@@ -641,6 +646,8 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftAlamofireUsage, ruleId: 'heuristics.ios.networking.alamofire.ast', code: 'HEURISTICS_IOS_NETWORKING_ALAMOFIRE_AST', message: 'AST heuristic detected Alamofire usage in iOS production code; URLSession remains the preferred baseline for new code.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftJSONSerializationUsage, ruleId: 'heuristics.ios.json.jsonserialization.ast', code: 'HEURISTICS_IOS_JSON_JSONSERIALIZATION_AST', message: 'AST heuristic detected JSONSerialization usage in iOS production code; Codable remains the preferred baseline for new code.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftSensitiveUserDefaultsStorageUsage, ruleId: 'heuristics.ios.security.userdefaults-sensitive-data.ast', code: 'HEURISTICS_IOS_SECURITY_USERDEFAULTS_SENSITIVE_DATA_AST', message: 'AST heuristic detected sensitive data stored in UserDefaults/AppStorage; native Keychain remains the preferred baseline for secrets.' },
+  { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftInsecureTransportUsage, ruleId: 'heuristics.ios.security.insecure-transport.ast', code: 'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST', message: 'AST heuristic detected insecure HTTP transport in iOS production code; HTTPS and ATS remain the preferred baseline.' },
+  { platform: 'ios', pathCheck: isIOSInfoPlistPath, excludePaths: [], detect: TextIOS.hasSwiftInsecureTransportUsage, ruleId: 'heuristics.ios.security.insecure-transport.ast', code: 'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST', message: 'AST heuristic detected permissive App Transport Security configuration; HTTPS and ATS remain the preferred baseline.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftUncheckedSendableUsage, ruleId: 'heuristics.ios.unchecked-sendable.ast', code: 'HEURISTICS_IOS_UNCHECKED_SENDABLE_AST', message: 'AST heuristic detected @unchecked Sendable usage.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftPreconcurrencyUsage, ruleId: 'heuristics.ios.preconcurrency.ast', code: 'HEURISTICS_IOS_PRECONCURRENCY_AST', message: 'AST heuristic detected @preconcurrency usage.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftNonisolatedUnsafeUsage, ruleId: 'heuristics.ios.nonisolated-unsafe.ast', code: 'HEURISTICS_IOS_NONISOLATED_UNSAFE_AST', message: 'AST heuristic detected nonisolated(unsafe) usage.' },

--- a/core/rules/presets/heuristics/ios.test.ts
+++ b/core/rules/presets/heuristics/ios.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { iosRules } from './ios';
 
 test('iosRules define reglas heurísticas locked para plataforma ios', () => {
-  assert.equal(iosRules.length, 50);
+  assert.equal(iosRules.length, 51);
 
   const ids = iosRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -24,6 +24,7 @@ test('iosRules define reglas heurísticas locked para plataforma ios', () => {
     'heuristics.ios.dependencies.cocoapods.ast',
     'heuristics.ios.dependencies.carthage.ast',
     'heuristics.ios.security.userdefaults-sensitive-data.ast',
+    'heuristics.ios.security.insecure-transport.ast',
     'heuristics.ios.unchecked-sendable.ast',
     'heuristics.ios.preconcurrency.ast',
     'heuristics.ios.nonisolated-unsafe.ast',
@@ -95,6 +96,10 @@ test('iosRules define reglas heurísticas locked para plataforma ios', () => {
   assert.equal(
     byId.get('heuristics.ios.security.userdefaults-sensitive-data.ast')?.then.code,
     'HEURISTICS_IOS_SECURITY_USERDEFAULTS_SENSITIVE_DATA_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.ios.security.insecure-transport.ast')?.then.code,
+    'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST'
   );
   assert.equal(
     byId.get('heuristics.ios.preconcurrency.ast')?.then.code,

--- a/core/rules/presets/heuristics/ios.ts
+++ b/core/rules/presets/heuristics/ios.ts
@@ -308,6 +308,24 @@ export const iosRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.ios.security.insecure-transport.ast',
+    description: 'Detects insecure HTTP transport or permissive ATS configuration in iOS projects.',
+    severity: 'WARN',
+    platform: 'ios',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.ios.security.insecure-transport.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message: 'AST heuristic detected insecure iOS transport configuration; HTTPS and ATS remain the preferred baseline.',
+      code: 'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST',
+    },
+  },
+  {
     id: 'heuristics.ios.unchecked-sendable.ast',
     description: 'Detects @unchecked Sendable usage in iOS production code.',
     severity: 'WARN',


### PR DESCRIPTION
## Summary
- Add iOS ATS/HTTPS heuristic for insecure HTTP URLs and permissive NSAllowsArbitraryLoads.
- Keep the rule WARN/brownfield-aware.

## Evidence
- npm run -s typecheck
- npx tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts
- git diff --check