### PR TITLE
feat(ios): map ats security skill

### DIFF
--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -120,6 +120,12 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
     ['heuristics.ios.security.userdefaults-sensitive-data.ast']
   );
   assert.deepEqual(
+    resolveMappedHeuristicRuleIds(
+      'skills.ios.guideline.ios.app-transport-security-ats-https-por-defecto'
+    ),
+    ['heuristics.ios.security.insecure-transport.ast']
+  );
+  assert.deepEqual(
     resolveMappedHeuristicRuleIds('skills.ios.no-legacy-expectation-description'),
     ['heuristics.ios.testing.legacy-expectation-description.ast']
   );

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -141,6 +141,18 @@ test('normaliza reglas Core Data a ids canonicos del slice phase8', () => {
   ]);
 });
 
+test('normaliza regla iOS ATS a detector canonico de transporte seguro', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'ios-guidelines',
+    sourcePath: 'docs/codex-skills/ios-enterprise-rules.md',
+    sourceContent: '- ✅ **App Transport Security (ATS)** - HTTPS por defecto',
+  });
+
+  assert.deepEqual(rules.map((rule) => rule.id), [
+    'skills.ios.guideline.ios.app-transport-security-ats-https-por-defecto',
+  ]);
+});
+
 test('normaliza reglas Swift Concurrency a ids canonicos del slice phase9', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'ios-concurrency-guidelines',

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -87,6 +87,10 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     'ios.security.userdefaults-sensitive-data',
     ['heuristics.ios.security.userdefaults-sensitive-data.ast']
   ),
+  'skills.ios.guideline.ios.app-transport-security-ats-https-por-defecto': heuristicDetector(
+    'ios.security.insecure-transport',
+    ['heuristics.ios.security.insecure-transport.ast']
+  ),
   'skills.ios.no-unchecked-sendable': heuristicDetector('ios.unchecked-sendable', [
     'heuristics.ios.unchecked-sendable.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -382,6 +382,13 @@ const normalizeKnownRuleTarget = (
       return 'skills.ios.no-legacy-expectation-description';
     }
     if (
+      includes('app transport security') ||
+      includes('ats https') ||
+      includes('https por defecto')
+    ) {
+      return 'skills.ios.guideline.ios.app-transport-security-ats-https-por-defecto';
+    }
+    if (
       includes('mixing legacy xctest style') ||
       includes('mixed xctest and swift testing') ||
       includes('mixed testing frameworks')

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "compilerVersion": "1.0.0",
-  "generatedAt": "2026-05-13T11:03:09.894Z",
+  "generatedAt": "2026-05-13T11:13:04.662Z",
   "bundles": [
     {
       "name": "android-guidelines",
@@ -5764,7 +5764,7 @@
       "name": "ios-guidelines",
       "version": "1.0.0",
       "source": "file:vendor/skills/ios-enterprise-rules/SKILL.md",
-      "hash": "cadb9547991b6309ad35b1e503c6fafda8b655823e51b52023b037bac267c129",
+      "hash": "d4504cef8996fd4877a6c89183ee891e33be0164628ec64d0e1d564db60f9a7a",
       "rules": [
         {
           "id": "skills.ios.guideline.ios.accessibility-identifiers-para-localizar-elementos",
@@ -5871,7 +5871,7 @@
           "sourcePath": "vendor/skills/ios-enterprise-rules/SKILL.md",
           "confidence": "MEDIUM",
           "locked": true,
-          "evaluationMode": "DECLARATIVE",
+          "evaluationMode": "AUTO",
           "origin": "core"
         },
         {


### PR DESCRIPTION
## Summary
- Map App Transport Security guidance to the iOS insecure transport heuristic.
- Regenerate skills.lock so ATS/HTTPS is AUTO instead of DECLARATIVE.

## Evidence
- node --import tsx scripts/compile-skills-lock.ts
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/skillsMarkdownRules.test.ts
- git diff --check