### PR TITLE
feat(ios): detect localizable strings

### DIFF
--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -476,6 +476,7 @@ test('detects iOS heuristics and skips bridge callback rule', () => {
       ),
       fileContentFact('apps/ios/Podfile', 'pod "LegacyDependency"'),
       fileContentFact('apps/ios/Cartfile', 'github "Legacy/Dependency"'),
+      fileContentFact('apps/ios/App/es.lproj/Localizable.strings', '"title" = "Catalog";'),
       fileContentFact(
         'apps/ios/App/Info.plist',
         [
@@ -516,6 +517,7 @@ test('detects iOS heuristics and skips bridge callback rule', () => {
     'heuristics.ios.json.jsonserialization.ast',
     'heuristics.ios.legacy-onchange.ast',
     'heuristics.ios.legacy-swiftui-observable-wrapper.ast',
+    'heuristics.ios.localization.localizable-strings.ast',
     'heuristics.ios.logging.adhoc-print.ast',
     'heuristics.ios.logging.sensitive-data.ast',
     'heuristics.ios.navigation-view.ast',

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -97,6 +97,11 @@ const isIOSInfoPlistPath = (path: string): boolean => {
   return normalized.startsWith('apps/ios/') && normalized.endsWith('/Info.plist');
 };
 
+const isIOSLocalizableStringsPath = (path: string): boolean => {
+  const normalized = path.replace(/\\/g, '/');
+  return normalized.startsWith('apps/ios/') && normalized.endsWith('/Localizable.strings');
+};
+
 const isIOSApplicationOrPresentationPath = (path: string): boolean => {
   return (
     isIOSSwiftPath(path) &&
@@ -648,6 +653,7 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftSensitiveUserDefaultsStorageUsage, ruleId: 'heuristics.ios.security.userdefaults-sensitive-data.ast', code: 'HEURISTICS_IOS_SECURITY_USERDEFAULTS_SENSITIVE_DATA_AST', message: 'AST heuristic detected sensitive data stored in UserDefaults/AppStorage; native Keychain remains the preferred baseline for secrets.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftInsecureTransportUsage, ruleId: 'heuristics.ios.security.insecure-transport.ast', code: 'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST', message: 'AST heuristic detected insecure HTTP transport in iOS production code; HTTPS and ATS remain the preferred baseline.' },
   { platform: 'ios', pathCheck: isIOSInfoPlistPath, excludePaths: [], detect: TextIOS.hasSwiftInsecureTransportUsage, ruleId: 'heuristics.ios.security.insecure-transport.ast', code: 'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST', message: 'AST heuristic detected permissive App Transport Security configuration; HTTPS and ATS remain the preferred baseline.' },
+  { platform: 'ios', pathCheck: isIOSLocalizableStringsPath, excludePaths: [], detect: detectsTrackedFilePresence, ruleId: 'heuristics.ios.localization.localizable-strings.ast', code: 'HEURISTICS_IOS_LOCALIZATION_LOCALIZABLE_STRINGS_AST', message: 'AST heuristic detected Localizable.strings usage; String Catalogs (.xcstrings) remain the preferred baseline for new localization work.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftUncheckedSendableUsage, ruleId: 'heuristics.ios.unchecked-sendable.ast', code: 'HEURISTICS_IOS_UNCHECKED_SENDABLE_AST', message: 'AST heuristic detected @unchecked Sendable usage.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftPreconcurrencyUsage, ruleId: 'heuristics.ios.preconcurrency.ast', code: 'HEURISTICS_IOS_PRECONCURRENCY_AST', message: 'AST heuristic detected @preconcurrency usage.' },
   { platform: 'ios', pathCheck: isIOSSwiftPath, excludePaths: [isSwiftTestPath], detect: TextIOS.hasSwiftNonisolatedUnsafeUsage, ruleId: 'heuristics.ios.nonisolated-unsafe.ast', code: 'HEURISTICS_IOS_NONISOLATED_UNSAFE_AST', message: 'AST heuristic detected nonisolated(unsafe) usage.' },

--- a/core/rules/presets/heuristics/ios.test.ts
+++ b/core/rules/presets/heuristics/ios.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { iosRules } from './ios';
 
 test('iosRules define reglas heurísticas locked para plataforma ios', () => {
-  assert.equal(iosRules.length, 51);
+  assert.equal(iosRules.length, 52);
 
   const ids = iosRules.map((rule) => rule.id);
   assert.deepEqual(ids, [
@@ -25,6 +25,7 @@ test('iosRules define reglas heurísticas locked para plataforma ios', () => {
     'heuristics.ios.dependencies.carthage.ast',
     'heuristics.ios.security.userdefaults-sensitive-data.ast',
     'heuristics.ios.security.insecure-transport.ast',
+    'heuristics.ios.localization.localizable-strings.ast',
     'heuristics.ios.unchecked-sendable.ast',
     'heuristics.ios.preconcurrency.ast',
     'heuristics.ios.nonisolated-unsafe.ast',
@@ -100,6 +101,10 @@ test('iosRules define reglas heurísticas locked para plataforma ios', () => {
   assert.equal(
     byId.get('heuristics.ios.security.insecure-transport.ast')?.then.code,
     'HEURISTICS_IOS_SECURITY_INSECURE_TRANSPORT_AST'
+  );
+  assert.equal(
+    byId.get('heuristics.ios.localization.localizable-strings.ast')?.then.code,
+    'HEURISTICS_IOS_LOCALIZATION_LOCALIZABLE_STRINGS_AST'
   );
   assert.equal(
     byId.get('heuristics.ios.preconcurrency.ast')?.then.code,

--- a/core/rules/presets/heuristics/ios.ts
+++ b/core/rules/presets/heuristics/ios.ts
@@ -326,6 +326,24 @@ export const iosRules: RuleSet = [
     },
   },
   {
+    id: 'heuristics.ios.localization.localizable-strings.ast',
+    description: 'Detects legacy Localizable.strings files where String Catalogs are the preferred iOS baseline.',
+    severity: 'WARN',
+    platform: 'ios',
+    locked: true,
+    when: {
+      kind: 'Heuristic',
+      where: {
+        ruleId: 'heuristics.ios.localization.localizable-strings.ast',
+      },
+    },
+    then: {
+      kind: 'Finding',
+      message: 'AST heuristic detected Localizable.strings usage; String Catalogs (.xcstrings) remain the preferred baseline for new localization work.',
+      code: 'HEURISTICS_IOS_LOCALIZATION_LOCALIZABLE_STRINGS_AST',
+    },
+  },
+  {
     id: 'heuristics.ios.unchecked-sendable.ast',
     description: 'Detects @unchecked Sendable usage in iOS production code.',
     severity: 'WARN',


### PR DESCRIPTION
## Summary
- Add an iOS localization heuristic for legacy Localizable.strings files.
- Keep String Catalogs as the preferred baseline while preserving brownfield WARN semantics.

## Evidence
- npm run -s typecheck
- npx tsx --test core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts
- git diff --check