### PR TITLE
feat(ios): map localization skill

### DIFF
--- a/integrations/config/__tests__/skillsDetectorRegistry.test.ts
+++ b/integrations/config/__tests__/skillsDetectorRegistry.test.ts
@@ -126,6 +126,16 @@ test('resuelve detectores heuristics para reglas canonicales backend/frontend/io
     ['heuristics.ios.security.insecure-transport.ast']
   );
   assert.deepEqual(
+    resolveMappedHeuristicRuleIds(
+      'skills.ios.guideline.ios.localizable-strings-deprecado-usar-string-catalogs'
+    ),
+    ['heuristics.ios.localization.localizable-strings.ast']
+  );
+  assert.deepEqual(
+    resolveMappedHeuristicRuleIds('skills.ios.guideline.ios.string-catalogs-xcstrings'),
+    ['heuristics.ios.localization.localizable-strings.ast']
+  );
+  assert.deepEqual(
     resolveMappedHeuristicRuleIds('skills.ios.no-legacy-expectation-description'),
     ['heuristics.ios.testing.legacy-expectation-description.ast']
   );

--- a/integrations/config/__tests__/skillsMarkdownRules.test.ts
+++ b/integrations/config/__tests__/skillsMarkdownRules.test.ts
@@ -153,6 +153,18 @@ test('normaliza regla iOS ATS a detector canonico de transporte seguro', () => {
   ]);
 });
 
+test('normaliza regla iOS Localizable.strings a detector canonico de String Catalogs', () => {
+  const rules = extractCompiledRulesFromSkillMarkdown({
+    sourceSkill: 'ios-guidelines',
+    sourcePath: 'docs/codex-skills/ios-enterprise-rules.md',
+    sourceContent: '- ✅ **Localizable.strings** - Deprecado, usar String Catalogs',
+  });
+
+  assert.deepEqual(rules.map((rule) => rule.id), [
+    'skills.ios.guideline.ios.localizable-strings-deprecado-usar-string-catalogs',
+  ]);
+});
+
 test('normaliza reglas Swift Concurrency a ids canonicos del slice phase9', () => {
   const rules = extractCompiledRulesFromSkillMarkdown({
     sourceSkill: 'ios-concurrency-guidelines',

--- a/integrations/config/skillsDetectorRegistry.ts
+++ b/integrations/config/skillsDetectorRegistry.ts
@@ -91,6 +91,18 @@ const registryByRuleId: Record<string, SkillsDetectorBinding> = {
     'ios.security.insecure-transport',
     ['heuristics.ios.security.insecure-transport.ast']
   ),
+  'skills.ios.guideline.ios.localizable-strings-deprecado-usar-string-catalogs': heuristicDetector(
+    'ios.localization.localizable-strings',
+    ['heuristics.ios.localization.localizable-strings.ast']
+  ),
+  'skills.ios.guideline.ios.string-catalogs-xcstrings': heuristicDetector(
+    'ios.localization.localizable-strings',
+    ['heuristics.ios.localization.localizable-strings.ast']
+  ),
+  'skills.ios.guideline.ios.string-catalogs-xcstrings-sistema-moderno-de-localizacio-n-xcode-15': heuristicDetector(
+    'ios.localization.localizable-strings',
+    ['heuristics.ios.localization.localizable-strings.ast']
+  ),
   'skills.ios.no-unchecked-sendable': heuristicDetector('ios.unchecked-sendable', [
     'heuristics.ios.unchecked-sendable.ast',
   ]),

--- a/integrations/config/skillsMarkdownRules.ts
+++ b/integrations/config/skillsMarkdownRules.ts
@@ -389,6 +389,13 @@ const normalizeKnownRuleTarget = (
       return 'skills.ios.guideline.ios.app-transport-security-ats-https-por-defecto';
     }
     if (
+      includes('localizable strings') ||
+      includes('string catalogs') ||
+      includes('xcstrings')
+    ) {
+      return 'skills.ios.guideline.ios.localizable-strings-deprecado-usar-string-catalogs';
+    }
+    if (
       includes('mixing legacy xctest style') ||
       includes('mixed xctest and swift testing') ||
       includes('mixed testing frameworks')

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "compilerVersion": "1.0.0",
-  "generatedAt": "2026-05-13T11:13:04.662Z",
+  "generatedAt": "2026-05-13T11:18:53.521Z",
   "bundles": [
     {
       "name": "android-guidelines",
@@ -5764,7 +5764,7 @@
       "name": "ios-guidelines",
       "version": "1.0.0",
       "source": "file:vendor/skills/ios-enterprise-rules/SKILL.md",
-      "hash": "d4504cef8996fd4877a6c89183ee891e33be0164628ec64d0e1d564db60f9a7a",
+      "hash": "30c5afdca8ca553960a3063adf318d314f3d60489bf88465b670e82e6e157d51",
       "rules": [
         {
           "id": "skills.ios.guideline.ios.accessibility-identifiers-para-localizar-elementos",
@@ -5937,18 +5937,6 @@
         {
           "id": "skills.ios.guideline.ios.auto-layout-nslayoutconstraint",
           "description": "Auto Layout - NSLayoutConstraint",
-          "severity": "WARN",
-          "platform": "ios",
-          "sourceSkill": "ios-guidelines",
-          "sourcePath": "vendor/skills/ios-enterprise-rules/SKILL.md",
-          "confidence": "MEDIUM",
-          "locked": true,
-          "evaluationMode": "DECLARATIVE",
-          "origin": "core"
-        },
-        {
-          "id": "skills.ios.guideline.ios.automatic-plural-handling-en-string-catalogs",
-          "description": "Automatic plural handling - En String Catalogs",
           "severity": "WARN",
           "platform": "ios",
           "sourceSkill": "ios-guidelines",
@@ -6933,14 +6921,14 @@
         },
         {
           "id": "skills.ios.guideline.ios.localizable-strings-deprecado-usar-string-catalogs",
-          "description": "Localizable.strings - Deprecado, usar String Catalogs",
-          "severity": "ERROR",
+          "description": "String Catalogs (.xcstrings)",
+          "severity": "WARN",
           "platform": "ios",
           "sourceSkill": "ios-guidelines",
           "sourcePath": "vendor/skills/ios-enterprise-rules/SKILL.md",
-          "confidence": "HIGH",
+          "confidence": "MEDIUM",
           "locked": true,
-          "evaluationMode": "DECLARATIVE",
+          "evaluationMode": "AUTO",
           "origin": "core"
         },
         {
@@ -7882,30 +7870,6 @@
         {
           "id": "skills.ios.guideline.ios.strict-concurrency-checking-activar-en-complete",
           "description": "Strict Concurrency Checking - Activar en Complete",
-          "severity": "WARN",
-          "platform": "ios",
-          "sourceSkill": "ios-guidelines",
-          "sourcePath": "vendor/skills/ios-enterprise-rules/SKILL.md",
-          "confidence": "MEDIUM",
-          "locked": true,
-          "evaluationMode": "DECLARATIVE",
-          "origin": "core"
-        },
-        {
-          "id": "skills.ios.guideline.ios.string-catalogs-xcstrings",
-          "description": "String Catalogs (.xcstrings)",
-          "severity": "WARN",
-          "platform": "ios",
-          "sourceSkill": "ios-guidelines",
-          "sourcePath": "vendor/skills/ios-enterprise-rules/SKILL.md",
-          "confidence": "MEDIUM",
-          "locked": true,
-          "evaluationMode": "DECLARATIVE",
-          "origin": "core"
-        },
-        {
-          "id": "skills.ios.guideline.ios.string-catalogs-xcstrings-sistema-moderno-de-localizacio-n-xcode-15",
-          "description": "String Catalogs (.xcstrings) - Sistema moderno de localización (Xcode 15+)",
           "severity": "WARN",
           "platform": "ios",
           "sourceSkill": "ios-guidelines",


### PR DESCRIPTION
## Summary
- Map Localizable.strings/String Catalogs guidance to the iOS localization heuristic.
- Regenerate skills.lock so the localization baseline is AUTO.

## Evidence
- node --import tsx scripts/compile-skills-lock.ts
- npm run -s skills:lock:check
- npm run -s typecheck
- npx tsx --test integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/skillsMarkdownRules.test.ts
- git diff --check