### PR TITLE
chore(release): 6.3.199

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.198",
+  "version": "6.3.199",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.198",
+      "version": "6.3.199",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.198",
+  "version": "6.3.199",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Release 6.3.199 con detector iOS brownfield-aware de strings UI hardcodeadas.\n\nValidación:\n- npm run -s skills:lock:check\n- npm run -s typecheck\n- npx tsx --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/skillsMarkdownRules.test.ts\n- npm pack --dry-run --silent\n- git diff --check