### PR TITLE
feat(ios): add ast nodes for xctest waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.3.253] - 2026-05-14
+
+### Added
+- **iOS AST node evidence for XCTest waits:** `skills.ios.no-wait-for-expectations` now emits actionable line and node metadata for `wait(for:)`, `self.wait(for:)`, `waitForExpectations(timeout:)` and `XCTWaiter.wait(for:)`, while ignoring strings and comments.
+
 All notable changes to `pumuki` are documented here.
 
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/PUMUKI-RESET-MASTER-PLAN.md
+++ b/PUMUKI-RESET-MASTER-PLAN.md
@@ -7,7 +7,8 @@ Este documento es la **única fuente viva** de seguimiento interno del monorepo 
 ## Registro reciente de incidencias externas
 
 - [✅] - `R_GO` / `PUMUKI-INC-143` / SDD session refresh stale active task (`pumuki@6.3.252`): cerrado en PR #982 y publicado como `pumuki@6.3.252`; RuralGo repineado confirma que `pumuki sdd session --refresh --ttl-minutes=90` ya no conserva `rgo-1900-22` y bloquea de forma accionable cuando el tracking activo (`rgo-1900-26`) no tiene `openspec/changes/rgo-1900-26`.
-- [🚧] - `PARITY-IOS-001` / `skills.ios.no-wait-for-expectations` / detector AST real para waits XCTest: continuar la paridad iOS prioritaria con detección por nodos, sin reglas paraguas ni declarativas usadas como enforcement runtime.
+- [✅] - `PARITY-IOS-001` / `skills.ios.no-wait-for-expectations` / detector AST real para waits XCTest (`pumuki@6.3.253`): el finding enlaza llamadas `wait(for:)`, `self.wait(for:)`, `waitForExpectations(timeout:)` y `XCTWaiter.wait(for:)` con líneas, nodo primario, nodo de reemplazo y `expected_fix` hacia `await fulfillment(of:timeout:)`.
+- [🚧] - `PARITY-IOS-001` / `skills.ios.no-legacy-expectation-description` / detector AST real para expectation(description:) legacy: continuar la paridad Swift Testing con nodos accionables y sin enforcement declarativo.
 - [✅] - `R_GO` / `PUMUKI-INC-142` / zero-violation + AST-actionable findings contract (`pumuki@6.3.250`): RuralGo reporta que `pumuki@6.3.248` deja `findings_count>0`, `blocking_findings_count=0` y `gate_exit_code=0` en `PRE_COMMIT`, contradiciendo el contrato de que toda regla runtime activa bloquea. Corrección aplicada: los matches scoped de `skills.*`/`heuristics.*` sin línea, rango o nodo semántico dejan de emitirse como findings advisory; cualquier finding runtime emitido fuerza bloqueo aunque el runner devuelva exit 0. Tras publicar `pumuki@6.3.249`, el repin de RuralGo detecta un gap residual: `governance.skills.cross-platform-critical.incomplete` bloquea sobre `.ai_evidence.json` sin línea ni nodo AST. Corrección adicional: los gaps sintéticos de cobertura cross-platform dejan de emitirse como findings runtime y quedan fuera del panel de violaciones PRE_WRITE; la cobertura sigue como metadato diagnóstico. Validación: tests específicos de gate/panel/audit -> OK; `npm run -s typecheck` -> OK; `validation:package-smoke` -> OK; `npx jest --runInBand --testMatch "**/__tests__/**/*.spec.ts" --runInBand` -> OK; `npm publish` -> `+ pumuki@6.3.250`; `npm view pumuki@6.3.250 version` -> `6.3.250`; `npm view pumuki dist-tags --json` -> `latest=6.3.250`; RuralGo repineado a `6.3.250`: `npx pumuki audit --stage=PRE_COMMIT --json` -> `gate_exit_code=0`, `findings_count=0`, `blocking_findings_count=0`; `npx pumuki-pre-commit --quiet` -> `0`.
 
 ---
@@ -937,9 +938,9 @@ git checkout -b refactor/s1-governance-console
 
 | Documento | Tarea 🚧 actual |
 |-----------|-----------------|
-| Este plan | `[✅] - PUMUKI-INC-143` cerrado; `[🚧] - PARITY-IOS-001 / skills.ios.no-wait-for-expectations` reactivado como siguiente detector AST iOS. |
+| Este plan | `[✅] - PUMUKI-INC-143` cerrado; `[✅] - PARITY-IOS-001 / skills.ios.no-wait-for-expectations` preparado para `pumuki@6.3.253`; `[🚧] - PARITY-IOS-001 / skills.ios.no-legacy-expectation-description` queda como siguiente detector Swift Testing. |
 
-- Estado: ✅ PUMUKI-INC-143 cerrado en `pumuki@6.3.252`; sin bugs externos abiertos conocidos tras el repin RuralGo. Task activa interna reanudada: 🚧 `PARITY-IOS-001` / `skills.ios.no-wait-for-expectations`.
+- Estado: ✅ PUMUKI-INC-143 cerrado en `pumuki@6.3.252`; sin bugs externos abiertos conocidos tras el repin RuralGo. Task iOS actual: ✅ `skills.ios.no-wait-for-expectations` preparado para `pumuki@6.3.253`; siguiente 🚧 `skills.ios.no-legacy-expectation-description`.
 
 Snapshot PUMUKI-INC-143 (2026-05-14):
 - Fuente externa: `R_GO/docs/technical/08-validation/refactor/pumuki-integration-feedback.md`, sección `PUMUKI-INC-143`.

--- a/core/facts/__tests__/extractHeuristicFacts.test.ts
+++ b/core/facts/__tests__/extractHeuristicFacts.test.ts
@@ -669,6 +669,23 @@ test('detects iOS Swift Testing and Core Data boundary heuristics in scoped file
     findings.some((finding) => finding.ruleId === 'heuristics.ios.testing.wait-for-expectations.ast'),
     true
   );
+  const waitFinding = findings.find(
+    (finding) => finding.ruleId === 'heuristics.ios.testing.wait-for-expectations.ast'
+  );
+  assert.deepEqual(waitFinding?.lines, [9]);
+  assert.deepEqual(waitFinding?.primary_node, {
+    kind: 'call',
+    name: 'legacy XCTest wait call',
+    lines: [9],
+  });
+  assert.deepEqual(waitFinding?.related_nodes, [
+    {
+      kind: 'call',
+      name: 'replacement: await fulfillment(of:timeout:)',
+      lines: [9],
+    },
+  ]);
+  assert.match(waitFinding?.expected_fix ?? '', /await fulfillment/);
   assert.equal(
     findings.some((finding) => finding.ruleId === 'heuristics.ios.testing.legacy-expectation-description.ast'),
     true

--- a/core/facts/detectors/text/ios.test.ts
+++ b/core/facts/detectors/text/ios.test.ts
@@ -6,6 +6,7 @@ import {
   findSwiftOpenClosedSwitchMatch,
   findSwiftConcreteDependencyDipMatch,
   findSwiftPresentationSrpMatch,
+  collectSwiftWaitForExpectationsLines,
   hasSwiftAnyViewUsage,
   hasSwiftAsyncWithoutAwaitUsage,
   hasSwiftCallbackStyleSignature,
@@ -1721,14 +1722,20 @@ test('hasSwiftWaitForExpectationsUsage detecta waits legacy y excluye await fulf
 let expectation = expectation(description: "Done")
 wait(for: [expectation], timeout: 1)
 waitForExpectations(timeout: 1)
+self.wait(for: [expectation], timeout: 1)
+XCTWaiter.wait(for: [expectation], timeout: 1)
 `;
   const modernWait = `
 let expectation = expectation(description: "Done")
 await fulfillment(of: [expectation], timeout: 1)
+let sample = "waitForExpectations(timeout: 1)"
+// wait(for: [expectation], timeout: 1)
 `;
 
   assert.equal(hasSwiftWaitForExpectationsUsage(legacyWait), true);
   assert.equal(hasSwiftWaitForExpectationsUsage(modernWait), false);
+  assert.deepEqual(collectSwiftWaitForExpectationsLines(legacyWait), [3, 4, 5, 6]);
+  assert.deepEqual(collectSwiftWaitForExpectationsLines(modernWait), []);
 });
 
 test('hasSwiftLegacyExpectationDescriptionUsage detecta expectation(description:) sin flujo moderno', () => {

--- a/core/facts/detectors/text/ios.ts
+++ b/core/facts/detectors/text/ios.ts
@@ -1362,11 +1362,16 @@ const hasSwiftConfirmationUsage = (source: string): boolean => {
   return hasSwiftSanitizedRegexMatch(source, /\bawait\s+confirmation\b/);
 };
 
+export const collectSwiftWaitForExpectationsLines = (source: string): readonly number[] => {
+  return sortedUniqueLines([
+    ...collectSwiftRegexLines(source, /\b(?:self\s*\.\s*)?wait\s*\(\s*for\s*:/),
+    ...collectSwiftRegexLines(source, /\bwaitForExpectations\s*\(/),
+    ...collectSwiftRegexLines(source, /\bXCTWaiter\s*\.\s*wait\s*\(\s*for\s*:/),
+  ]);
+};
+
 export const hasSwiftWaitForExpectationsUsage = (source: string): boolean => {
-  return hasSwiftSanitizedRegexMatch(
-    source,
-    /\bwait\s*\(\s*for\s*:|\bwaitForExpectations\s*\(/
-  );
+  return collectSwiftWaitForExpectationsLines(source).length > 0;
 };
 
 export const hasSwiftLegacyExpectationDescriptionUsage = (source: string): boolean => {

--- a/core/facts/extractHeuristicFacts.ts
+++ b/core/facts/extractHeuristicFacts.ts
@@ -627,6 +627,12 @@ type TextDetectorRegistryEntry = {
   readonly pathCheck: (path: string) => boolean;
   readonly excludePaths: ReadonlyArray<(path: string) => boolean>;
   readonly detect: (content: string) => boolean;
+  readonly locateLines?: (content: string) => readonly number[];
+  readonly primaryNode?: (lines: readonly number[]) => HeuristicFact['primary_node'];
+  readonly relatedNodes?: (lines: readonly number[]) => HeuristicFact['related_nodes'];
+  readonly why?: string;
+  readonly impact?: string;
+  readonly expected_fix?: string;
   readonly ruleId: string;
   readonly code: string;
   readonly message: string;
@@ -714,7 +720,7 @@ const textDetectorRegistry: ReadonlyArray<TextDetectorRegistryEntry> = [
   { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftModernizableXCTestSuiteUsage, ruleId: 'heuristics.ios.testing.xctest-suite-modernizable.ast', code: 'HEURISTICS_IOS_TESTING_XCTEST_SUITE_MODERNIZABLE_AST', message: 'AST heuristic detected XCTestCase/test... suite that may be modernizable to Swift Testing with import Testing and @Test.' },
   { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftXCTestAssertionUsage, ruleId: 'heuristics.ios.testing.xctassert.ast', code: 'HEURISTICS_IOS_TESTING_XCTASSERT_AST', message: 'AST heuristic detected XCTest assertion usage where #expect may be preferred.' },
   { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftXCTUnwrapUsage, ruleId: 'heuristics.ios.testing.xctunwrap.ast', code: 'HEURISTICS_IOS_TESTING_XCTUNWRAP_AST', message: 'AST heuristic detected XCTUnwrap usage where #require may be preferred.' },
-  { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftWaitForExpectationsUsage, ruleId: 'heuristics.ios.testing.wait-for-expectations.ast', code: 'HEURISTICS_IOS_TESTING_WAIT_FOR_EXPECTATIONS_AST', message: 'AST heuristic detected wait(for:)/waitForExpectations usage where await fulfillment(of:) may be preferred.' },
+  { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftWaitForExpectationsUsage, locateLines: TextIOS.collectSwiftWaitForExpectationsLines, primaryNode: (lines) => ({ kind: 'call', name: 'legacy XCTest wait call', lines }), relatedNodes: (lines) => [{ kind: 'call', name: 'replacement: await fulfillment(of:timeout:)', lines }], why: 'Legacy XCTest wait APIs block the current test thread and hide async intent that Swift concurrency can express directly.', impact: 'Async tests become less deterministic, harder to cancel and easier to keep tied to XCTest-only migration paths.', expected_fix: 'Replace wait(for:timeout:), self.wait(for:timeout:) or waitForExpectations(timeout:) with await fulfillment(of:timeout:) when the test target supports async XCTest migration.', ruleId: 'heuristics.ios.testing.wait-for-expectations.ast', code: 'HEURISTICS_IOS_TESTING_WAIT_FOR_EXPECTATIONS_AST', message: 'AST heuristic detected wait(for:)/waitForExpectations usage where await fulfillment(of:) may be preferred.' },
   { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftLegacyExpectationDescriptionUsage, ruleId: 'heuristics.ios.testing.legacy-expectation-description.ast', code: 'HEURISTICS_IOS_TESTING_LEGACY_EXPECTATION_DESCRIPTION_AST', message: 'AST heuristic detected expectation(description:) usage without modern fulfillment/confirmation flow.' },
   { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftMixedTestingFrameworksUsage, ruleId: 'heuristics.ios.testing.mixed-frameworks.ast', code: 'HEURISTICS_IOS_TESTING_MIXED_FRAMEWORKS_AST', message: 'AST heuristic detected XCTestCase and Swift Testing markers mixed in the same test file without explicit compatibility reason.' },
   { platform: 'ios', pathCheck: isIOSSwiftTestPath, excludePaths: [], detect: TextIOS.hasSwiftQuickNimbleUsage, ruleId: 'heuristics.ios.testing.quick-nimble.ast', code: 'HEURISTICS_IOS_TESTING_QUICK_NIMBLE_AST', message: 'AST heuristic detected Quick/Nimble usage where native Swift Testing remains the preferred baseline.' },
@@ -812,12 +818,19 @@ export const extractHeuristicFacts = (
         (entry.excludePaths ?? []).every((exclude) => !exclude(fileFact.path)) &&
         entry.detect(fileFact.content)
       ) {
+        const lines = entry.locateLines?.(fileFact.content);
         heuristicFacts.push(
           createHeuristicFact({
             ruleId: entry.ruleId,
             code: entry.code,
             message: entry.message,
             filePath: fileFact.path,
+            lines,
+            primary_node: lines && lines.length > 0 ? entry.primaryNode?.(lines) : undefined,
+            related_nodes: lines && lines.length > 0 ? entry.relatedNodes?.(lines) : undefined,
+            why: entry.why,
+            impact: entry.impact,
+            expected_fix: entry.expected_fix,
           })
         );
       }

--- a/docs/operations/RELEASE_NOTES.md
+++ b/docs/operations/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ This file keeps only the operational highlights and rollout notes that matter wh
 
 ## 2026-04 (CLI stability and macOS notifications)
 
+### 2026-05-14 (v6.3.253)
+
+- **Paridad AST iOS testing:** `skills.ios.no-wait-for-expectations` queda respaldada por evidencia accionable de llamada Swift, con líneas, nodo primario y remediación hacia `await fulfillment(of:timeout:)`.
+- **Rollout recomendado:** publicar `pumuki@6.3.253` y continuar con `skills.ios.no-legacy-expectation-description` si no entra bug externo nuevo.
+
 ### 2026-05-14 (v6.3.252)
 
 - **Parser de tracking estricto:** el refresh SDD ya no interpreta bullets operativos (`Siguiente`, `next`, `delegable`) como IDs de task activa.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumuki",
-  "version": "6.3.252",
+  "version": "6.3.253",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumuki",
-      "version": "6.3.252",
+      "version": "6.3.253",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumuki",
-  "version": "6.3.252",
+  "version": "6.3.253",
   "description": "Enterprise-grade AST Intelligence System with multi-platform support (iOS, Android, Backend, Frontend) and Feature-First + DDD + Clean Architecture enforcement. Includes dynamic violations API for intelligent querying.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Escenario
PARITY-IOS-001 / skills.ios.no-wait-for-expectations necesitaba evidencia AST accionable para llamadas legacy de espera XCTest.

## Cambios
- Añade localización de líneas para wait(for:), self.wait(for:), waitForExpectations(timeout:) y XCTWaiter.wait(for:).
- Enriquece hechos heurísticos con primary_node, related_nodes, why, impact y expected_fix.
- Actualiza tests, release notes, changelog, tracking y versión npm a 6.3.253.

## Validación
- npx --yes tsx@4.21.0 --test core/facts/detectors/text/ios.test.ts core/facts/__tests__/extractHeuristicFacts.test.ts core/rules/presets/heuristics/ios.test.ts integrations/config/__tests__/skillsDetectorRegistry.test.ts integrations/config/__tests__/iosAvdleeParity.test.ts
- npm run -s typecheck
- npm run -s skills:lock:check
- git diff --check
- npm pack --dry-run --silent
- PUMUKI_SYSTEM_NOTIFICATIONS=0 PUMUKI_NOTIFICATIONS=0 npm run -s validation:package-smoke
- npm test -- --runInBand
- npm publish
- npm view pumuki@6.3.253 version
- npm view pumuki dist-tags --json